### PR TITLE
deactivate submenu item 'Help' if tab 'help' is deactivated/hidden

### DIFF
--- a/lib/the-events-calendar.class.php
+++ b/lib/the-events-calendar.class.php
@@ -3933,6 +3933,8 @@ if ( !class_exists( 'TribeEvents' ) ) {
 			if ( !defined( 'TRIBE_DISABLE_TOOLBAR_ITEMS' ) || !TRIBE_DISABLE_TOOLBAR_ITEMS ) {
 				global $wp_admin_bar;
 
+				$hideSettingsTabs = TribeEvents::instance()->getNetworkOption( 'hideSettingsTabs', array( ) );
+
 				$wp_admin_bar->add_menu( array(
 					'id' => 'tribe-events',
 					'title' => __( 'Events', 'tribe-events-calendar' ),
@@ -4002,7 +4004,7 @@ if ( !class_exists( 'TribeEvents' ) ) {
 					) );
 				}
 
-				if ( current_user_can( 'manage_options' ) ) {
+				if ( current_user_can( 'manage_options' ) && ! in_array( 'help', $hideSettingsTabs ) ) {
 					$wp_admin_bar->add_menu( array(
 						'id' => 'tribe-events-help',
 						'title' => __( 'Help', 'tribe-events-calendar' ),


### PR DESCRIPTION
When you deactivate/hide the 'Help' tab the submenu item should be removed also.
