### PR TITLE
disable admin_bar elements in the network admin 

### DIFF
--- a/lib/the-events-calendar.class.php
+++ b/lib/the-events-calendar.class.php
@@ -3826,7 +3826,7 @@ if ( !class_exists( 'TribeEvents' ) ) {
 		 * @return null
 		 */
 		public function addToolbarItems() {
-			if ( !defined( 'TRIBE_DISABLE_TOOLBAR_ITEMS' ) || !TRIBE_DISABLE_TOOLBAR_ITEMS ) {
+			if ( ( !defined( 'TRIBE_DISABLE_TOOLBAR_ITEMS' ) || !TRIBE_DISABLE_TOOLBAR_ITEMS ) && !is_network_admin() ) {
 				global $wp_admin_bar;
 
 				$wp_admin_bar->add_menu( array(


### PR DESCRIPTION
since it makes no sense to control site ID:1 content from the nework admin interface
