### PR TITLE
Fixes a rouge closing li under certain conditions

### DIFF
--- a/views/list/nav.php
+++ b/views/list/nav.php
@@ -26,12 +26,13 @@ if ( !defined('ABSPATH') ) { die('-1'); } ?>
 	<?php elseif ( tribe_is_upcoming() ) : ?>
 		<?php if( get_previous_posts_link() ) : ?>
 			<li class="tribe-events-nav-previous tribe-events-nav-left">
-			<a href="<?php echo tribe_get_upcoming_link() ?>" rel="prev"><?php _e( '<span>&laquo;</span> Previous Events', 'tribe-events-calendar' ) ?></a>
+				<a href="<?php echo tribe_get_upcoming_link() ?>" rel="prev"><?php _e( '<span>&laquo;</span> Previous Events', 'tribe-events-calendar' ) ?></a>
+			</li><!-- .tribe-events-nav-previous -->
 		<?php elseif ( tribe_has_past_events() ) : ?>
 			<li class="tribe-events-nav-previous tribe-events-nav-left tribe-events-past">
-			<a href="<?php echo tribe_get_past_link() ?>" rel="prev"><?php _e( '<span>&laquo;</span> Previous Events', 'tribe-events-calendar' ) ?></a>
+				<a href="<?php echo tribe_get_past_link() ?>" rel="prev"><?php _e( '<span>&laquo;</span> Previous Events', 'tribe-events-calendar' ) ?></a>
+			</li><!-- .tribe-events-nav-previous -->
 		<?php endif; ?>
-		</li><!-- .tribe-events-nav-previous -->
 	<?php endif; ?>
 
 	<!-- Right Navigation -->
@@ -39,11 +40,12 @@ if ( !defined('ABSPATH') ) { die('-1'); } ?>
 		<?php if( get_query_var( 'paged' ) > 1 ) : ?>
 			<li class="tribe-events-nav-previous tribe-events-nav-right tribe-events-past">
 				<a href="<?php echo tribe_get_past_link() ?>" rel="next"><?php _e( 'Next Events <span>&raquo;</span>', 'tribe-events-calendar' ) ?></a>
+			</li><!-- .tribe-events-nav-previous -->
 		<?php elseif( !get_previous_posts_link() ) : ?>
 			<li class="tribe-events-nav-previous tribe-events-nav-right">
 				<a href="<?php echo tribe_get_upcoming_link() ?>" rel="next"><?php _e( 'Next Events <span>&raquo;</span>', 'tribe-events-calendar' ) ?></a>
+			</li><!-- .tribe-events-nav-previous -->
 		<?php endif; ?>
-		</li><!-- .tribe-events-nav-previous -->
 	<?php elseif ( tribe_is_upcoming() ) : ?>
 		<li class="tribe-events-nav-next tribe-events-nav-right">
 		<?php if( get_next_posts_link() ) : ?> 


### PR DESCRIPTION
This pull fixes a rouge closing LI in the list nav when the query is upcoming but there is no previous post link and no past events.
