### PR TITLE
Ensure product-taskmaster is present before using it

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "waiting_strings": false
   },
   "scripts": {
-    "preinstall": "node node_modules/product-taskmaster/scripts/syncPackageJSON.js",
+    "preinstall": "if [ -d node_modules/product-taskmaster ]; then node node_modules/product-taskmaster/scripts/syncPackageJSON.js; fi",
     "analyze": "webpack-bundle-analyzer -m static stats.json",
     "bootstrap": "./scripts/linkDependencies",
     "build:webpack": "cross-env NODE_ENV=production webpack -p --progress",


### PR DESCRIPTION
This was a bug found during packaging from a fresh install

Related: https://github.com/moderntribe/events-pro/pull/1042