### PR TITLE
fix(Repositories/Event) make sure event UTC dates are correctly set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = git://github.com/kartik-v/php-date-formatter
 [submodule "common"]
 	path = common
-	url = git@github.com:moderntribe/tribe-common.git
+	url = git@github.com:the-events-calendar/tribe-common.git
 [submodule "src/resources/postcss/utilities"]
 	path = src/resources/postcss/utilities
-	url = git@github.com:moderntribe/tribe-common-styles.git
+	url = git@github.com:the-events-calendar/tribe-common-styles.git

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1116,7 +1116,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 
 			$timezone         = Tribe__Timezones::build_timezone_object( $input_timezone );
 			$timezone_changed = $input_timezone !== $current_event_timezone_string;
-			$utc              = $this->normal_timezone;
+			$utc              = Timezones::build_timezone_object('UTC');
 			$dates_changed    = [];
 
 			/**
@@ -1135,7 +1135,7 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 						$postarr[ 'meta_input' ][ "_Event{$check}Date" ] = $meta_value;
 					}
 
-					$date = new DateTime( $meta_value, $timezone );
+					$date = Dates::build_date_object($meta_value,$timezone);
 
 					$postarr['meta_input']["_Event{$check}Date"] = $date->format( $datetime_format );
 


### PR DESCRIPTION
This PR fixes an issue where the Event ORM would set the UTC dates incorrectly depending on the site timezone settings.

Artifacts: see tests.