### PR TITLE
properly enqueue manager script as last script to be enqueued

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -191,7 +191,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 			[
 				'priority'     => 20,
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
-				'groups'       => [ static::$group_key, static::$widget_group_key ],
+				'groups'       => [ static::$group_key ],
 			]
 		);
 

--- a/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
+++ b/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
@@ -51,6 +51,7 @@ abstract class Widget_Abstract extends \Tribe\Widget\Widget_Abstract {
 
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'filter_widget_template_vars' ], 20, 2 );
 		add_filter( "tribe_events_views_v2_view{$this->view_slug}_template_vars", [ $this, 'filter_widget_template_vars' ], 20, 2 );
+		// Dequeue and enqueue manager JS to ensure it is the last JS file to be added.
 		add_action( 'tribe_events_views_v2_widget_after_enqueue_assets', [ $this, 'action_enqueue_manager' ], 10, 3 );
 	}
 

--- a/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
+++ b/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
@@ -51,6 +51,7 @@ abstract class Widget_Abstract extends \Tribe\Widget\Widget_Abstract {
 
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'filter_widget_template_vars' ], 20, 2 );
 		add_filter( "tribe_events_views_v2_view{$this->view_slug}_template_vars", [ $this, 'filter_widget_template_vars' ], 20, 2 );
+		add_action( 'tribe_events_views_v2_widget_after_enqueue_assets', [ $this, 'action_enqueue_manager' ], 10, 3 );
 	}
 
 	/**
@@ -186,6 +187,24 @@ abstract class Widget_Abstract extends \Tribe\Widget\Widget_Abstract {
 	public function enqueue_assets( $context, $view ) {
 		// Ensure we also have all the other things from Tribe\Events\Views\V2\Assets we need.
 		tribe_asset_enqueue_group( Assets::$widget_group_key );
+	}
+
+	/**
+	 * Dequeues and enqueues the manager JS.
+	 *
+	 * @since TBD
+	 *
+	 * @param boolean         $should_enqueue Whether assets are enqueued or not.
+	 * @param \Tribe__Context $context        Context we are using to build the view.
+	 * @param View_Interface  $view           Which view we are using the template on.
+	 */
+	public function action_enqueue_manager( $should_enqueue, $context, $view ) {
+		if ( ! $should_enqueue ) {
+			return;
+		}
+
+		wp_dequeue_script( 'tribe-events-views-v2-manager' );
+		tribe_asset_enqueue( 'tribe-events-views-v2-manager' );
 	}
 
 	/**


### PR DESCRIPTION
**Ticket:** [ECP-690]

This fixes an issue with the countdown widget JS not loading properly, but loading after the manager. This enqueues the manager as the last JS asset to allow all the other JS files to work properly.

**Artifact:**

![image](https://user-images.githubusercontent.com/16699941/105363449-00203700-5c37-11eb-80bd-90fc06147b80.png)
