### PR TITLE
Fetch prev_url from containerData

### DIFF
--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -288,13 +288,16 @@ tribe.events.views.manager = {};
 	 */
 	obj.onLinkClick = function( event ) {
 		var $container = obj.getContainer( this );
+
 		$container.trigger( 'beforeOnLinkClick.tribeEvents', event );
 
 		event.preventDefault();
 
+		var containerData = obj.getContainerData( $container );
+
 		var $link = $( this );
 		var url = $link.attr( 'href' );
-		var currentUrl = window.location.href;
+		var currentUrl = containerData.prev_url;
 		var nonce = $link.data( 'view-rest-nonce' );
 		var shouldManageUrl = obj.shouldManageUrl( $container );
 		var shortcodeId = $container.data( 'view-shortcode' );

--- a/tests/wpunit/Tribe/Events/Importer/File_Importer_Events_ReimportBehaviourTest.php
+++ b/tests/wpunit/Tribe/Events/Importer/File_Importer_Events_ReimportBehaviourTest.php
@@ -2,7 +2,14 @@
 
 namespace tests\functional\Tribe\Events\Importer;
 
-require_once 'functions.php';
+function get_image_url( $extension = 'jpg' ) {
+	return plugins_url( 'tests/_data/csv-import-test-files/featured-image/images/featured-image.' . $extension, codecept_root_dir( 'the-events-calendar.php' ) );
+}
+
+function get_image_path( $extension = 'jpg' ) {
+	return codecept_data_dir( 'csv-import-test-files/featured-image/images/featured-image.' . $extension );
+}
+
 require_once 'File_Importer_EventsTest.php';
 
 use Tribe\Events\Importer\File_Importer_EventsTest;

--- a/tests/wpunit/Tribe/Events/Importer/File_Importer_Events_ReimportBehaviourTest.php
+++ b/tests/wpunit/Tribe/Events/Importer/File_Importer_Events_ReimportBehaviourTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\functional\Tribe\Events\Importer;
 
+require_once 'functions.php';
 require_once 'File_Importer_EventsTest.php';
 
 use Tribe\Events\Importer\File_Importer_EventsTest;
@@ -87,7 +88,7 @@ class File_Importer_Events_ReimportBehaviourTest extends File_Importer_EventsTes
 	 * it should not remove featured image when re-importing same event from file
 	 */
 	public function it_should_not_remove_featured_image_when_re_importing_same_event_from_file() {
-		$image_url     = plugins_url( '_data/csv-import-test-files/featured-image/images/featured-image.jpg', codecept_data_dir() );
+		$image_url     = get_image_path();
 		$attachment_id = $this->factory()->attachment->create_upload_object( $image_url );
 		$this->featured_image_uploader->upload_and_get_attachment_id()->willReturn( $attachment_id );
 
@@ -125,7 +126,7 @@ class File_Importer_Events_ReimportBehaviourTest extends File_Importer_EventsTes
 	 * @dataProvider single_secondary_field
 	 */
 	public function it_should_not_modify_the_featured_image_when_re_importing_file_with_empty_secondary_fields( $field ) {
-		$image_url     = plugins_url( '_data/csv-import-test-files/featured-image/images/featured-image.jpg', codecept_data_dir() );
+		$image_url     = get_image_path();
 		$attachment_id = $this->factory()->attachment->create_upload_object( $image_url );
 		$this->featured_image_uploader->upload_and_get_attachment_id()->willReturn( $attachment_id );
 
@@ -174,7 +175,7 @@ class File_Importer_Events_ReimportBehaviourTest extends File_Importer_EventsTes
 	 * @dataProvider modified_secondary_fields
 	 */
 	public function it_should_not_modify_the_featured_image_when_re_importing_file_with_modified_secondary_fields( $field, $modified_value ) {
-		$image_url     = plugins_url( '_data/csv-import-test-files/featured-image/images/featured-image.jpg', codecept_data_dir() );
+		$image_url     = get_image_path();
 		$attachment_id = $this->factory()->attachment->create_upload_object( $image_url );
 		$this->featured_image_uploader->upload_and_get_attachment_id()->willReturn( $attachment_id );
 

--- a/tests/wpunit/Tribe/Events/Importer/File_Importer_Organizers_FeaturedImageTest.php
+++ b/tests/wpunit/Tribe/Events/Importer/File_Importer_Organizers_FeaturedImageTest.php
@@ -24,7 +24,7 @@ class File_Importer_Organizers_FeaturedImageTest extends File_Importer_Organizer
 	 * it should import and attach featured image if featured image is ok
 	 */
 	public function it_should_import_and_attach_featured_image_if_featured_image_is_ok() {
-		$image_url     = get_image_url();
+		$image_url     = get_image_path();
 		$attachment_id = $this->factory()->attachment->create_upload_object( $image_url );
 		$this->featured_image_uploader->upload_and_get_attachment_id()->willReturn( $attachment_id );
 

--- a/tests/wpunit/Tribe/Events/Importer/File_Importer_Venues_FeaturedImageTest.php
+++ b/tests/wpunit/Tribe/Events/Importer/File_Importer_Venues_FeaturedImageTest.php
@@ -24,7 +24,7 @@ class File_Importer_Venues_FeaturedImageTest extends File_Importer_VenuesTest {
 	 * it should import and attach featured image if featured image is ok
 	 */
 	public function it_should_import_and_attach_featured_image_if_featured_image_is_ok() {
-		$image_url     = get_image_url();
+		$image_url     = get_image_path();
 		$attachment_id = $this->factory()->attachment->create_upload_object( $image_url );
 		$this->featured_image_uploader->upload_and_get_attachment_id()->willReturn( $attachment_id );
 		$this->field_map[] = 'venue_thumbnail';


### PR DESCRIPTION
The `prev_url` was using `window.location.href`, which _only_ works for the main event page. Updating the `prev_url` to use the `containerData` will always contain the appropriate value whether you are on the main event page or shortcodes.