### PR TITLE
Feature / TEC-3755 disable v1 styles

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -466,8 +466,6 @@ class Assets extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-override-style', '__return_false' );
 
 		add_filter( 'tribe_events_assets_should_enqueue_frontend', '__return_false' );
-		
-		add_filter( 'tribe_events_stylesheet_url', '__return_false' );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -449,9 +449,9 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 */
 	public function disable_v1() {
 		// Dont disable V1 on Single Event page
-		if ( tribe( Template_Bootstrap::class )->is_single_event() ) {
-			return;
-		}
+		// if ( tribe( Template_Bootstrap::class )->is_single_event() ) {
+		// 	return;
+		// }
 
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-script', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_tribe-events-bar', '__return_false' );
@@ -466,6 +466,8 @@ class Assets extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-override-style', '__return_false' );
 
 		add_filter( 'tribe_events_assets_should_enqueue_frontend', '__return_false' );
+		
+		add_filter( 'tribe_events_stylesheet_url', '__return_false' );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -414,32 +414,35 @@ class Assets extends \tad_DI52_ServiceProvider {
 			);
 		}
 		
-		// @todo: need logic to handle this as calling tribe( Template_Bootstrap::class )->is_single_event() doesn't work
-		if ( tribe_events_views_v2_is_enabled() ) {
-			tribe_asset(
-				$plugin,
-				'tribe-events-v2-single-skeleton',
-				'tribe-events-single-skeleton.css',
-				[],
-				'wp_enqueue_scripts',
-				[
-					'priority' => 15,
-				]
-			);
-
-			tribe_asset(
-				$plugin,
-				'tribe-events-v2-single-skeleton-full',
-				'tribe-events-single-full.css',
-				[
-					'tribe-events-v2-single-skeleton',
+		tribe_asset(
+			$plugin,
+			'tribe-events-v2-single-skeleton',
+			'tribe-events-single-skeleton.css',
+			[],
+			'wp_enqueue_scripts',
+			[
+				'priority' => 15,
+				'conditionals' => [
+					[ $this, 'should_enqueue_single_event_styles' ],
 				],
-				'wp_enqueue_scripts',
-				[
-					'priority' => 15,
-				]
-			);
-		}
+			]
+		);
+
+		tribe_asset(
+			$plugin,
+			'tribe-events-v2-single-skeleton-full',
+			'tribe-events-single-full.css',
+			[
+				'tribe-events-v2-single-skeleton',
+			],
+			'wp_enqueue_scripts',
+			[
+				'priority' => 15,
+				'conditionals' => [
+					[ $this, 'should_enqueue_single_event_styles' ],
+				],
+			]
+		);
 	}
 
 	/**
@@ -533,5 +536,26 @@ class Assets extends \tad_DI52_ServiceProvider {
 		 * @param bool $is_skeleton_style
 		 */
 		return apply_filters( 'tribe_events_views_v2_assets_should_enqueue_full_styles', $should_enqueue );
+	}
+	
+	/**
+	 * Verifies if we are on V2 and on Event Single in order to enqueue the override styles for Single Event
+	 *
+	 * @since TBD
+	 * 
+	 * @return boolean
+	 */
+	public function should_enqueue_single_event_styles() {
+		// Bail if not V2
+		if ( ! tribe_events_views_v2_is_enabled() ) {
+			return false;
+		}
+		
+		// Bail if not Single Event
+		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
+			return false;
+		}
+		
+		return true;
 	}
 }

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -546,12 +546,12 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return boolean
 	 */
 	public function should_enqueue_single_event_styles() {
-		// Bail if not V2
+		// Bail if not V2.
 		if ( ! tribe_events_views_v2_is_enabled() ) {
 			return false;
 		}
 		
-		// Bail if not Single Event
+		// Bail if not Single Event.
 		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
 			return false;
 		}

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -453,11 +453,6 @@ class Assets extends \tad_DI52_ServiceProvider {
 	 * @return void
 	 */
 	public function disable_v1() {
-		// Dont disable V1 on Single Event page
-		// if ( tribe( Template_Bootstrap::class )->is_single_event() ) {
-		// 	return;
-		// }
-
 		add_filter( 'tribe_asset_enqueue_tribe-events-calendar-script', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_tribe-events-bar', '__return_false' );
 		add_filter( 'tribe_asset_enqueue_the-events-calendar', '__return_false' );

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -6,10 +6,19 @@
  */
 
 .single-tribe_events-v2 {
+	-webkit-font-smoothing: antialiased;
+	
+	.tribe-events-before-html,
+	.tribe-events-after-html {
+		p {
+			line-height: 1.7;
+		}
+	}
 	
 	/* Back navigation block */
 	.tribe-events-back a {
 		font-family: var(--font-family-base);
+		font-weight: var(--font-weight-bold);
 	}
 	
 	/* Event title */
@@ -23,21 +32,12 @@
 		}
 	}
 	
-	/* Header metadata wrapper  */
-	.tribe-events-schedule {
-		background-color: transparent;
-		border: 0;
-	}
-	
 	/* Datetime block */
 	.tribe-events-schedule h2 { /* NOTE: this is best done by adding tribe-common-h8 to the html */
-		@mixin heading;
-		@mixin mobile-heading-6;
+		@mixin body;
+		font-size: var(--font-size-3);
 		font-weight: var(--font-weight-regular);
-
-		@media (--viewport-medium) {
-			@mixin desktop-heading-6;
-		}
+		line-height: var(--line-height-3);
 	}
 	
 	/* Recurring info block */
@@ -49,15 +49,6 @@
 		
 		@media (--viewport-medium) {
 			@mixin heading-7;
-		}
-		
-		.event-is-recurring {
-			
-			&,
-			&:hover,
-			&:focus {
-				color: var(--color-text-primary);
-			}
 		}
 		
 		a {

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -7,13 +7,36 @@
 
 .single-tribe_events-v2 {
 	
+	/* Hide a bunch of elements (from v1 styles) */
+	.single-featured-image-header,
+	#tribe-events-header,
+	.tribe-events-divider,
+	.recurring-info-tooltip {
+		display: none;
+	}
+	
 	#tribe-events-pg-template {
+		margin: 0 auto;
 		max-width: 1048px;
+		padding: var(--spacer-8) var(--spacer-4) var(--spacer-4);
+	}
+	
+	.tribe-events-before-html,
+	.tribe-events-after-html {
+		p {
+			margin: 0 0 10px;
+		}
 	}
 	
 	/* Back navigation block */
 	.tribe-events-back {
 		margin-bottom: var(--spacer-7);
+	}
+	
+	/* Event title */
+	.tribe-events-single-event-title { /* NOTE: this is best done by adding tribe-common-h1 to the html */
+		margin: 0;
+		padding: 0;
 	}
 	
 	/* Header metadata wrapper  */
@@ -22,7 +45,6 @@
 		display: flex;
 		flex-wrap: wrap;
 		margin: var(--spacer-1) 0 var(--spacer-4);
-		padding: 0;
 		
 		@media (--viewport-medium) {
 			align-items: baseline;
@@ -49,6 +71,7 @@
 		margin-right: var(--spacer-1);
 		order: 2;
 		padding: 0 var(--spacer-1);
+		position: relative;
 		
 		@media (--viewport-medium) {
 			margin-left: var(--spacer-1);
@@ -69,10 +92,6 @@
 				left: 16px;
 			}
 		}
-		
-		.tribe-events-divider {
-			display: none;
-		}
 	
 		.event-is-recurring {
 			letter-spacing: -9999px; /* To hide the "Recurring Event" label on mobile */
@@ -80,7 +99,6 @@
 			visibility: hidden;
 			
 			@media (--viewport-medium) {
-				height: auto;
 				letter-spacing: normal;
 				visibility: visible;
 			}

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -11,7 +11,9 @@
 	.single-featured-image-header,
 	#tribe-events-header,
 	.tribe-events-divider,
-	.recurring-info-tooltip {
+	.recurring-info-tooltip,
+	.tribe-events-ajax-loading
+	 {
 		display: none;
 	}
 	

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -10,8 +10,7 @@
 #tribe-events-header,
 .tribe-events-divider,
 .recurring-info-tooltip,
-.tribe-events-ajax-loading
-	{
+.tribe-events-ajax-loading {
 	display: none;
 }
 
@@ -23,6 +22,7 @@
 
 .tribe-events-before-html,
 .tribe-events-after-html {
+
 	p {
 		margin: 0 0 10px;
 	}


### PR DESCRIPTION
**Description:** This disabled the enqueueing of v1 styles to provide a clean slate for styling the whole Event Single view

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3755

**Screenshots:** see https://github.com/the-events-calendar/the-events-calendar/pull/3429 and others