### PR TITLE
Feature / TEC-3758 event details

### DIFF
--- a/src/Tribe/Customizer/Single_Event.php
+++ b/src/Tribe/Customizer/Single_Event.php
@@ -37,6 +37,7 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 		if ( $customizer->has_option( $this->ID, 'details_bg_color' ) ) {
 			$template .= '
 				.single-tribe_events .tribe-events-event-meta {
+					background-color: <%= single_event.details_bg_color %>;
 					color: <%= single_event.details_text_color %>;
 				}
 			';

--- a/src/Tribe/Customizer/Single_Event.php
+++ b/src/Tribe/Customizer/Single_Event.php
@@ -37,7 +37,6 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 		if ( $customizer->has_option( $this->ID, 'details_bg_color' ) ) {
 			$template .= '
 				.single-tribe_events .tribe-events-event-meta {
-					background-color: <%= single_event.details_bg_color %>;
 					color: <%= single_event.details_text_color %>;
 				}
 			';

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -152,6 +152,12 @@
 	& ~ div:not(.tribe-events-event-meta) {
 		border-top: 1px solid var(--color-border-secondary);
 	}
+	
+	/* We don't want the Customizer's overrides applied here */
+	.single-tribe_events .tribe-events-single & {
+		color: var(--color-text-primary);
+		background-color: transparent;
+	}
 }
 
 /* Details column */

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -91,6 +91,11 @@
 		border-right-width: 0;
 		font-family: var(--font-family-base);
 		
+		@media (--viewport-medium) {
+			border-top: 1px solid var(--color-border-secondary);
+			border-bottom: 1px solid var(--color-border-secondary);
+		}
+		
 		a {
 			color: var(--color-accent-primary);
 		}
@@ -101,6 +106,10 @@
 			.tribe-events-venue-map {
 				border: 0;
 				border-radius: 0;
+			}
+			
+			@media (--viewport-medium) {
+				border-top: 1px solid var(--color-border-secondary);
 			}
 		}
 		

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -82,4 +82,11 @@
 			@mixin desktop-heading-6;
 		}
 	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		background-color: transparent;
+		border-left-width: 0;
+		border-right-width: 0;
+	}
 }

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -100,17 +100,9 @@
 			color: var(--color-accent-primary);
 		}
 		
-		&.secondary {
-			border-top: 0;
-			
-			.tribe-events-venue-map {
-				border: 0;
-				border-radius: 0;
-			}
-			
-			@media (--viewport-medium) {
-				border-top: 1px solid var(--color-border-secondary);
-			}
+		.tribe-events-venue-map {
+			border: 0;
+			border-radius: 0;
 		}
 		
 		.tribe-events-meta-group {
@@ -131,6 +123,14 @@
 		.tribe-events-address {
 			font-style: normal;
 			line-height: 26px;
+		}
+		
+		&.secondary {
+			border-top: 0;
+			
+			@media (--viewport-medium) {
+				border-top: 1px solid var(--color-border-secondary);
+			}
 		}
 	}
 }

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -75,11 +75,9 @@
 	}
 	
 	/* Details block */
-	#tribe-events-content .tribe-events-event-meta {
-		background-color: transparent;
-		border-left-width: 0;
-		border-right-width: 0;
-		font-family: var(--font-family-base);
+	.tribe-events-event-meta {
+		@mixin body;
+		font-size: var(--font-size-2);
 		
 		@media (--viewport-medium) {
 			border-top: 1px solid var(--color-border-secondary);
@@ -90,22 +88,6 @@
 			color: var(--color-accent-primary);
 		}
 		
-		.tribe-events-venue-map {
-			border: 0;
-			border-radius: 0;
-		}
-		
-		.tribe-events-meta-group {
-		
-			.tribe-events-single-section-title {
-				@mixin heading;
-				@mixin heading-8;
-				color: var(--color-text-primary-light);
-				font-weight: var(--font-weight-regular);
-				text-transform: uppercase;
-			}
-		}
-		
 		dt {
 			line-height: var(--line-height-3);
 		}
@@ -114,13 +96,23 @@
 			font-style: normal;
 			line-height: 26px;
 		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
 		
-		&.secondary {
-			border-top: 0;
-			
-			@media (--viewport-medium) {
-				border-top: 1px solid var(--color-border-secondary);
-			}
+		.tribe-events-single-section-title {
+			@mixin heading;
+			@mixin heading-8;
+			color: var(--color-text-primary-light);
+			font-weight: var(--font-weight-regular);
+			text-transform: uppercase;
 		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		border: 0;
+		border-radius: 0;
 	}
 }

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -79,10 +79,42 @@
 		@mixin body;
 		font-size: var(--font-size-2);
 		
-		@media (--viewport-medium) {
-			border-top: 1px solid var(--color-border-secondary);
-			border-bottom: 1px solid var(--color-border-secondary);
+		a {
+			color: var(--color-accent-primary);
 		}
+		
+		dt {
+			line-height: var(--line-height-3);
+		}
+		
+		.tribe-events-address {
+			font-style: normal;
+			line-height: 26px;
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		
+		.tribe-events-single-section-title {
+			@mixin heading;
+			@mixin heading-8;
+			color: var(--color-text-primary-light);
+			font-weight: var(--font-weight-regular);
+			text-transform: uppercase;
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		border: 0;
+		border-radius: 0;
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		@mixin body;
+		font-size: var(--font-size-2);
 		
 		a {
 			color: var(--color-accent-primary);
@@ -95,6 +127,11 @@
 		.tribe-events-address {
 			font-style: normal;
 			line-height: 26px;
+		}
+		
+		&:not(.secondary):before,
+		& ~ div:not(.tribe-events-event-meta) {
+			border-top: 1px solid var(--color-border-secondary);
 		}
 	}
 	

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -6,6 +6,7 @@
  */
 
 .single-tribe_events-v2 {
+	-webkit-font-smoothing: antialiased;
 	
 	/* Back navigation block */
 	.tribe-events-back a {
@@ -84,9 +85,43 @@
 	}
 	
 	/* Details block */
-	.tribe-events-event-meta {
+	#tribe-events-content .tribe-events-event-meta {
 		background-color: transparent;
 		border-left-width: 0;
 		border-right-width: 0;
+		font-family: var(--font-family-base);
+		
+		a {
+			color: var(--color-accent-primary);
+		}
+		
+		&.secondary {
+			border-top: 0;
+			
+			.tribe-events-venue-map {
+				border: 0;
+				border-radius: 0;
+			}
+		}
+		
+		.tribe-events-meta-group {
+		
+			.tribe-events-single-section-title {
+				@mixin heading;
+				@mixin heading-8;
+				color: var(--color-text-primary-light);
+				font-weight: var(--font-weight-regular);
+				text-transform: uppercase;
+			}
+		}
+		
+		dt {
+			line-height: var(--line-height-3);
+		}
+		
+		.tribe-events-address {
+			font-style: normal;
+			line-height: 26px;
+		}
 	}
 }

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -102,10 +102,44 @@
 		}
 	}
 	
-		/* Details block */
-	.tribe-events-event-meta {
+	/* Details block */
+	#tribe-events-content .tribe-events-event-meta {
 		display: flex;
+		flex-wrap: wrap;
 		margin: var(--spacer-5) 0 var(--spacer-7);
 		padding: var(--spacer-5) 0;
+		
+		&.secondary {
+			padding-top: 0;
+			
+			.tribe-events-meta-group {
+				margin-right: 0;
+			}
+			
+			.tribe-events-venue-map {
+				margin: 0 0 var(--spacer-5) 0;
+				order: -1;
+				padding: 0;
+				width: 100%;
+			}
+		}
+		
+		.tribe-events-meta-group {
+			flex: 1 0 140px;
+			margin-right: var(--spacer-5);
+			padding: 0;
+			
+			&:last-child {
+				margin-right: 0;
+			}
+		
+			.tribe-events-single-section-title {
+				margin-bottom: var(--spacer-1);
+			}
+		}
+		
+		dt, dd {
+			margin-bottom: var(--spacer-0);
+		}
 	}
 }

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -101,4 +101,11 @@
 			margin: 0 var(--spacer-1);
 		}
 	}
+	
+		/* Details block */
+	.tribe-events-event-meta {
+		display: flex;
+		margin: var(--spacer-5) 0 var(--spacer-7);
+		padding: var(--spacer-5) 0;
+	}
 }

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -11,6 +11,15 @@
 		max-width: 1048px;
 	}
 	
+	.tribe-events-single > .tribe_events {
+		display: flex;
+		flex-wrap: wrap;
+		
+		& > div {
+			width: 100%;
+		}
+	}
+	
 	/* Back navigation block */
 	.tribe-events-back {
 		margin-bottom: var(--spacer-7);
@@ -109,11 +118,33 @@
 		margin: var(--spacer-5) 0 var(--spacer-7);
 		padding: var(--spacer-5) 0;
 		
+		@media (--viewport-medium) {
+			padding: var(--spacer-2) 0;
+		}
+		
+		&.primary {
+			@media (--viewport-medium) {
+				flex: 1 0 60%;
+				width: auto;
+			}
+		}
+		
 		&.secondary {
 			padding-top: 0;
 			
+			@media (--viewport-medium) {
+				flex: none;
+				padding-top: var(--spacer-2);
+				width: auto;
+			}
+			
 			.tribe-events-meta-group {
 				margin-right: 0;
+				
+				@media (--viewport-medium) {
+					margin-right: var(--spacer-5);
+					width: 168px;
+				}
 			}
 			
 			.tribe-events-venue-map {
@@ -121,6 +152,18 @@
 				order: -1;
 				padding: 0;
 				width: 100%;
+				
+				@media (--viewport-medium) {
+					margin-top: var(--spacer-4);
+					order: 1;
+					width: 211px;
+				}
+				
+				&, & > div {
+					@media (--viewport-medium) {
+						height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+					}
+				}
 			}
 		}
 		
@@ -128,6 +171,10 @@
 			flex: 1 0 140px;
 			margin-right: var(--spacer-5);
 			padding: 0;
+			
+			@media (--viewport-medium) {
+				flex: 0 0 168px;
+			}
 			
 			&:last-child {
 				margin-right: 0;

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -253,9 +253,10 @@
 		width: 211px;
 	}
 	
-	&, & > div {
+	/* Make sure the gmap div has this specific height on desktop */
+	& > div {
 		@media (--viewport-medium) {
-			height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+			max-height: 211px;
 		}
 	}
 }

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -33,8 +33,11 @@
 	.tribe-events-single > .tribe_events {
 		display: flex;
 		flex-wrap: wrap;
+		overflow: hidden;
+		position: relative;
 		
-		& > div:not(.primary, .secondary) {
+		& > *:not(.primary, .secondary) {
+			order: 1;
 			width: 100%;
 		}
 	}
@@ -151,6 +154,91 @@
 			
 			@media (--viewport-medium) {
 				width: auto;
+			}
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		flex: 1 0 140px;
+		margin-right: var(--spacer-5);
+		
+		@media (--viewport-medium) {
+			padding: var(--spacer-7) 0 var(--spacer-3);
+			width: 168px;
+		}
+	
+		.tribe-events-single-section-title {
+			margin-bottom: var(--spacer-1);
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		margin: 0 0 var(--spacer-3) 0;
+		order: -1;
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			margin-top: var(--spacer-7);
+			order: 1;
+			width: 211px;
+		}
+		
+		&, & > div {
+			@media (--viewport-medium) {
+				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+			}
+		}
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		display: flex;
+		flex-wrap: wrap;
+		margin: var(--spacer-5) 0 var(--spacer-7);
+		
+		@media (--viewport-medium) {
+			margin-bottom: var(--spacer-3);
+		}
+		
+		dt, dd {
+			margin: 0 0 var(--spacer-0) 0;
+		}
+		
+		.tribe-events-address {
+			margin: 0;
+		}
+
+		&.primary,
+		&.secondary {
+			order: 2;
+			width: 100%;
+			
+			@media (--viewport-medium) {
+				width: auto;
+			}
+		}
+		
+		&.primary {
+			padding-top: var(--spacer-5);
+			position: relative;
+			
+			@media (--viewport-medium) {
+				padding-top: 0;
+				position: static;
+			}
+		}
+		
+		&:not(.secondary):before {
+			content: '';
+			position: absolute;
+			left: 0;
+			right: 0;
+			top: 0;
+			
+			@media (--viewport-medium) {
+				top: auto;
 			}
 		}
 	}

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -137,6 +137,25 @@
 			margin-bottom: var(--spacer-0);
 		}
 		
+		.tribe-events-venue-map {
+			margin: 0 0 var(--spacer-5) 0;
+			order: -1;
+			padding: 0;
+			width: 100%;
+			
+			@media (--viewport-medium) {
+				margin-top: var(--spacer-7);
+				order: 1;
+				width: 211px;
+			}
+			
+			&, & > div {
+				@media (--viewport-medium) {
+					height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+				}
+			}
+		}
+		
 		&.primary {
 			@media (--viewport-medium) {
 				flex: 0 0 auto;
@@ -157,25 +176,6 @@
 				
 				@media (--viewport-medium) {
 					margin-right: var(--spacer-5);
-				}
-			}
-			
-			.tribe-events-venue-map {
-				margin: 0 0 var(--spacer-5) 0;
-				order: -1;
-				padding: 0;
-				width: 100%;
-				
-				@media (--viewport-medium) {
-					margin-top: var(--spacer-7);
-					order: 1;
-					width: 211px;
-				}
-				
-				&, & > div {
-					@media (--viewport-medium) {
-						height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
-					}
 				}
 			}
 		}

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -34,7 +34,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		
-		& > div {
+		& > div:not(.primary, .secondary) {
 			width: 100%;
 		}
 	}
@@ -132,71 +132,59 @@
 	}
 	
 	/* Details block */
-	#tribe-events-content .tribe-events-event-meta {
+	.tribe-events-event-meta {
 		display: flex;
 		flex-wrap: wrap;
 		margin: var(--spacer-5) 0 var(--spacer-7);
-		padding: 0;
-		
-		.tribe-events-meta-group {
-			flex: 1 0 140px;
-			margin-right: var(--spacer-5);
-			padding: var(--spacer-5) 0;
-			
-			@media (--viewport-medium) {
-				padding: var(--spacer-2) 0;
-				width: 168px;
-			}
-		
-			.tribe-events-single-section-title {
-				margin-bottom: var(--spacer-1);
-			}
-		}
 		
 		dt, dd {
-			margin-bottom: var(--spacer-0);
+			margin: 0 0 var(--spacer-0) 0;
 		}
 		
-		.tribe-events-venue-map {
-			margin: 0 0 var(--spacer-5) 0;
-			order: -1;
-			padding: 0;
+		.tribe-events-address {
+			margin: 0;
+		}
+
+		&.primary,
+		&.secondary {
 			width: 100%;
 			
 			@media (--viewport-medium) {
-				margin-top: var(--spacer-7);
-				order: 1;
-				width: 211px;
-			}
-			
-			&, & > div {
-				@media (--viewport-medium) {
-					height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
-				}
-			}
-		}
-		
-		&.primary {
-			@media (--viewport-medium) {
-				flex: 0 0 auto;
 				width: auto;
 			}
 		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		flex: 1 0 140px;
+		margin-right: var(--spacer-5);
 		
-		&.secondary {
-			padding-top: 0;
-			
+		@media (--viewport-medium) {
+			padding: var(--spacer-7) 0 var(--spacer-3);
+			width: 168px;
+		}
+	
+		.tribe-events-single-section-title {
+			margin-bottom: var(--spacer-1);
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		margin: 0 0 var(--spacer-3) 0;
+		order: -1;
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			margin-top: var(--spacer-7);
+			order: 1;
+			width: 211px;
+		}
+		
+		&, & > div {
 			@media (--viewport-medium) {
-				flex: none;
-				width: auto;
-			}
-			
-			.tribe-events-meta-group {
-				margin-right: 0;
-				
-				@media (--viewport-medium) {
-					margin-right: var(--spacer-5);
-				}
+				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
 			}
 		}
 	}

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -116,15 +116,30 @@
 		display: flex;
 		flex-wrap: wrap;
 		margin: var(--spacer-5) 0 var(--spacer-7);
-		padding: var(--spacer-5) 0;
+		padding: 0;
 		
-		@media (--viewport-medium) {
-			padding: var(--spacer-2) 0;
+		.tribe-events-meta-group {
+			flex: 1 0 140px;
+			margin-right: var(--spacer-5);
+			padding: var(--spacer-5) 0;
+			
+			@media (--viewport-medium) {
+				padding: var(--spacer-2) 0;
+				width: 168px;
+			}
+		
+			.tribe-events-single-section-title {
+				margin-bottom: var(--spacer-1);
+			}
+		}
+		
+		dt, dd {
+			margin-bottom: var(--spacer-0);
 		}
 		
 		&.primary {
 			@media (--viewport-medium) {
-				flex: 1 0 60%;
+				flex: 0 0 auto;
 				width: auto;
 			}
 		}
@@ -134,7 +149,6 @@
 			
 			@media (--viewport-medium) {
 				flex: none;
-				padding-top: var(--spacer-2);
 				width: auto;
 			}
 			
@@ -143,7 +157,6 @@
 				
 				@media (--viewport-medium) {
 					margin-right: var(--spacer-5);
-					width: 168px;
 				}
 			}
 			
@@ -154,7 +167,7 @@
 				width: 100%;
 				
 				@media (--viewport-medium) {
-					margin-top: var(--spacer-4);
+					margin-top: var(--spacer-7);
 					order: 1;
 					width: 211px;
 				}
@@ -165,28 +178,6 @@
 					}
 				}
 			}
-		}
-		
-		.tribe-events-meta-group {
-			flex: 1 0 140px;
-			margin-right: var(--spacer-5);
-			padding: 0;
-			
-			@media (--viewport-medium) {
-				flex: 0 0 168px;
-			}
-			
-			&:last-child {
-				margin-right: 0;
-			}
-		
-			.tribe-events-single-section-title {
-				margin-bottom: var(--spacer-1);
-			}
-		}
-		
-		dt, dd {
-			margin-bottom: var(--spacer-0);
 		}
 	}
 }


### PR DESCRIPTION
**Description:** Updates the Event Single details block styles for V2. It also removes the Customizer background color override for the block.

**Note:** Related on https://github.com/the-events-calendar/the-events-calendar/pull/3442 for some layout updates

**Tickets:**
- https://theeventscalendar.atlassian.net/browse/TEC-3758
- https://theeventscalendar.atlassian.net/browse/TEC-3761
- https://theeventscalendar.atlassian.net/browse/TEC-3767

**Screencast:**

https://d.pr/i/7gmLNe