### PR TITLE
Feature / event single related events updates

### DIFF
--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -40,12 +40,21 @@
 	}
 	
 	/* Recurring info block */
-	.tribe-events-schedule .recurringinfo { /* NOTE: this is best done by adding tribe-common-h7 to the html */
+	.tribe-events-schedule .recurringinfo,
+	.tribe-related-event-info .recurringinfo { /* NOTE: this is best done by adding tribe-common-h7 to the html */
 		@mixin heading;
 		@mixin heading-8;
 		background-color: var(--color-background-secondary);
 		border-radius: 40px;
 		
+		a {
+			color: var(--color-accent-primary);
+			font-weight: var(--font-weight-regular);
+			line-height: 20px;
+		}
+	}
+	
+	.tribe-events-schedule .recurringinfo {
 		@media (--viewport-medium) {
 			@mixin heading-7;
 		}
@@ -60,10 +69,6 @@
 		}
 		
 		a {
-			color: var(--color-accent-primary);
-			font-weight: var(--font-weight-regular);
-			line-height: 20px;
-			
 			@media (--viewport-medium) {
 				line-height: var(--line-height-3);
 			}
@@ -79,6 +84,155 @@
 		
 		@media (--viewport-medium) {
 			@mixin desktop-heading-6;
+		}
+	}
+	
+	/* Description Block */
+	.tribe-events-content {
+		@mixin body;
+		
+		h2, h3, h4, h5, h6 {
+			@mixin heading;
+			letter-spacing: normal;
+			text-transform: none;
+		}
+		
+		h2 {
+			@mixin mobile-heading-3;
+		}
+		
+		p, ul, ol {
+			font-size: var(--font-size-3);
+			line-height: var(--line-height-3);
+			
+			@media (--viewport-medium) {
+				font-size: var(--font-size-4);
+				line-height: var(--line-height-2);
+			}
+		}
+		
+		ul, ol {
+			list-style-position: inside;
+		}
+		
+		a {
+			@mixin anchor-thin;
+		}
+	}
+	
+	/* Cal export links block */
+	.tribe-events-cal-links {
+		@mixin body;
+		
+		.tribe-events-gcal,
+		.tribe-events-ical {
+			background: svg-inline(cal-export) 0 / 24px no-repeat;
+			color: var(--color-accent-primary);
+			font-size: var(--font-size-2);
+			font-weight: var(--font-weight-regular);
+			line-height: var(--line-height-3);
+		}
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		@mixin body;
+		font-size: var(--font-size-2);
+		
+		a {
+			color: var(--color-accent-primary);
+		}
+		
+		dt {
+			line-height: var(--line-height-3);
+		}
+		
+		.tribe-events-address {
+			font-style: normal;
+			line-height: 26px;
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		
+		.tribe-events-single-section-title {
+			@mixin heading;
+			@mixin heading-8;
+			color: var(--color-text-primary-light);
+			font-weight: var(--font-weight-regular);
+			text-transform: uppercase;
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		border: 0;
+		border-radius: 0;
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		@mixin body;
+		font-size: var(--font-size-2);
+		
+		a {
+			color: var(--color-accent-primary);
+		}
+		
+		dt {
+			line-height: var(--line-height-3);
+		}
+		
+		.tribe-events-address {
+			font-style: normal;
+			line-height: 26px;
+		}
+		
+		&:not(.secondary):before,
+		& ~ div:not(.tribe-events-event-meta) {
+			border-top: 1px solid var(--color-border-secondary);
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		
+		.tribe-events-single-section-title {
+			@mixin heading;
+			@mixin heading-8;
+			color: var(--color-text-primary-light);
+			font-weight: var(--font-weight-regular);
+			text-transform: uppercase;
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		border: 0;
+		border-radius: 0;
+	}
+	
+	/* Related Events block */
+	.tribe-events-related-events-title {
+		@mixin heading;
+		@mixin mobile-heading-3;
+		border-top: 1px solid var(--color-border-secondary);
+
+		@media (--viewport-medium) {
+			@mixin desktop-heading-3;
+		}
+	}
+	
+	ul.tribe-related-events {
+		
+		li {
+			@mixin body;
+
+			.tribe-related-events-title {
+				@mixin heading;
+				@mixin heading-7;
+			}
 		}
 	}
 }

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -206,7 +206,7 @@
 	}
 }
 
-ul.tribe-related-events {
+.tribe-events-single ul.tribe-related-events {
 	
 	li {
 		@mixin body;

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -98,153 +98,153 @@
 	@media (--viewport-medium) {
 		@mixin desktop-heading-6;
 	}
+}
+
+/* Description Block */
+.tribe-events-content {
+	@mixin body;
 	
-	/* Description Block */
-	.tribe-events-content {
-		@mixin body;
-		
-		h2, h3, h4, h5, h6 {
-			@mixin heading;
-			letter-spacing: normal;
-			text-transform: none;
-		}
-		
-		h2 {
-			@mixin mobile-heading-3;
-		}
-		
-		p, ul, ol {
-			font-size: var(--font-size-3);
-			line-height: var(--line-height-3);
-			
-			@media (--viewport-medium) {
-				font-size: var(--font-size-4);
-				line-height: var(--line-height-2);
-			}
-		}
-		
-		ul, ol {
-			list-style-position: inside;
-		}
-		
-		a {
-			@mixin anchor-thin;
-		}
-	}
-	
-	/* Cal export links block */
-	.tribe-events-cal-links {
-		@mixin body;
-		
-		.tribe-events-gcal,
-		.tribe-events-ical {
-			background: svg-inline(cal-export) 0 / 24px no-repeat;
-			color: var(--color-accent-primary);
-			font-size: var(--font-size-2);
-			font-weight: var(--font-weight-regular);
-			line-height: var(--line-height-3);
-		}
-	}
-	
-	/* Details block */
-	.tribe-events-event-meta {
-		@mixin body;
-		font-size: var(--font-size-2);
-		
-		a {
-			color: var(--color-accent-primary);
-		}
-		
-		dt {
-			line-height: var(--line-height-3);
-		}
-		
-		.tribe-events-address {
-			font-style: normal;
-			line-height: 26px;
-		}
-	}
-	
-	/* Details column */
-	.tribe-events-meta-group {
-		
-		.tribe-events-single-section-title {
-			@mixin heading;
-			@mixin heading-8;
-			color: var(--color-text-primary-light);
-			font-weight: var(--font-weight-regular);
-			text-transform: uppercase;
-		}
-	}
-	
-	/* Venue block */
-	.tribe-events-venue-map {
-		border: 0;
-		border-radius: 0;
-	}
-	
-	/* Details block */
-	.tribe-events-event-meta {
-		@mixin body;
-		font-size: var(--font-size-2);
-		
-		a {
-			color: var(--color-accent-primary);
-		}
-		
-		dt {
-			line-height: var(--line-height-3);
-		}
-		
-		.tribe-events-address {
-			font-style: normal;
-			line-height: 26px;
-		}
-		
-		&:not(.secondary):before,
-		& ~ div:not(.tribe-events-event-meta) {
-			border-top: 1px solid var(--color-border-secondary);
-		}
-	}
-	
-	/* Details column */
-	.tribe-events-meta-group {
-		
-		.tribe-events-single-section-title {
-			@mixin heading;
-			@mixin heading-8;
-			color: var(--color-text-primary-light);
-			font-weight: var(--font-weight-regular);
-			text-transform: uppercase;
-		}
-	}
-	
-	/* Venue block */
-	.tribe-events-venue-map {
-		border: 0;
-		border-radius: 0;
-	}
-	
-	/* Related Events block */
-	.tribe-events-related-events-title {
+	h2, h3, h4, h5, h6 {
 		@mixin heading;
+		letter-spacing: normal;
+		text-transform: none;
+	}
+	
+	h2 {
 		@mixin mobile-heading-3;
-		border-top: 1px solid var(--color-border-secondary);
-
+	}
+	
+	p, ul, ol {
+		font-size: var(--font-size-3);
+		line-height: var(--line-height-3);
+		
 		@media (--viewport-medium) {
-			@mixin desktop-heading-3;
+			font-size: var(--font-size-4);
+			line-height: var(--line-height-2);
 		}
 	}
 	
-	ul.tribe-related-events {
-		
-		li {
-			@mixin body;
+	ul, ol {
+		list-style-position: inside;
+	}
+	
+	a {
+		@mixin anchor-thin;
+	}
+}
 
-			.tribe-related-events-title {
-				@mixin heading;
-				@mixin heading-7;
-			}
+/* Cal export links block */
+.tribe-events-cal-links {
+	@mixin body;
+	
+	.tribe-events-gcal,
+	.tribe-events-ical {
+		background: svg-inline(cal-export) 0 / 24px no-repeat;
+		color: var(--color-accent-primary);
+		font-size: var(--font-size-2);
+		font-weight: var(--font-weight-regular);
+		line-height: var(--line-height-3);
+	}
+}
+
+/* Details block */
+.tribe-events-event-meta {
+	@mixin body;
+	font-size: var(--font-size-2);
+	
+	a {
+		color: var(--color-accent-primary);
+	}
+	
+	dt {
+		line-height: var(--line-height-3);
+	}
+	
+	.tribe-events-address {
+		font-style: normal;
+		line-height: 26px;
+	}
+}
+
+/* Details column */
+.tribe-events-meta-group {
+	
+	.tribe-events-single-section-title {
+		@mixin heading;
+		@mixin heading-8;
+		color: var(--color-text-primary-light);
+		font-weight: var(--font-weight-regular);
+		text-transform: uppercase;
+	}
+}
+
+/* Venue block */
+.tribe-events-venue-map {
+	border: 0;
+	border-radius: 0;
+}
+
+/* Details block */
+.tribe-events-event-meta {
+	@mixin body;
+	font-size: var(--font-size-2);
+	
+	a {
+		color: var(--color-accent-primary);
+	}
+	
+	dt {
+		line-height: var(--line-height-3);
+	}
+	
+	.tribe-events-address {
+		font-style: normal;
+		line-height: 26px;
+	}
+	
+	&:not(.secondary):before,
+	& ~ div:not(.tribe-events-event-meta) {
+		border-top: 1px solid var(--color-border-secondary);
+	}
+}
+
+/* Details column */
+.tribe-events-meta-group {
+	
+	.tribe-events-single-section-title {
+		@mixin heading;
+		@mixin heading-8;
+		color: var(--color-text-primary-light);
+		font-weight: var(--font-weight-regular);
+		text-transform: uppercase;
+	}
+}
+
+/* Venue block */
+.tribe-events-venue-map {
+	border: 0;
+	border-radius: 0;
+}
+
+/* Related Events block */
+.tribe-events-related-events-title {
+	@mixin heading;
+	@mixin mobile-heading-3;
+	border-top: 1px solid var(--color-border-secondary);
+
+	@media (--viewport-medium) {
+		@mixin desktop-heading-3;
+	}
+}
+
+ul.tribe-related-events {
+	
+	li {
+		@mixin body;
+
+		.tribe-related-events-title {
+			@mixin heading;
+			@mixin heading-7;
 		}
 	}
 }

--- a/src/resources/postcss/views/full/_single-event.pcss
+++ b/src/resources/postcss/views/full/_single-event.pcss
@@ -57,9 +57,14 @@
 	background-color: var(--color-background-secondary);
 	border-radius: 40px;
 	
+	.event-is-recurring {
+		letter-spacing: -9999px; /* To hide the "Recurring Event" label on mobile */
+	}
+	
 	a {
 		color: var(--color-accent-primary);
 		font-weight: var(--font-weight-regular);
+		letter-spacing: normal;
 		line-height: 20px;
 	}
 }
@@ -75,15 +80,9 @@
 		@mixin heading-7;
 	}
 	
-	.tribe-events-schedule .recurringinfo {
+	.event-is-recurring {
 		@media (--viewport-medium) {
-			@mixin heading-7;
-		}
-		
-		a {
-			@media (--viewport-medium) {
-				line-height: var(--line-height-3);
-			}
+			letter-spacing: normal;
 		}
 	}
 }

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -300,6 +300,7 @@
 .tribe-events-single ul.tribe-related-events {
 	display: flex;
 	flex-direction: column;
+	margin-bottom: 0;
 	
 	@media (--viewport-medium) {
 		flex-direction: row;

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -297,7 +297,7 @@
 	width: 100%;
 }
 
-ul.tribe-related-events {
+.tribe-events-single ul.tribe-related-events {
 	display: flex;
 	flex-direction: column;
 	
@@ -321,6 +321,23 @@ ul.tribe-related-events {
 		.tribe-related-events-thumbnail {
 			margin-bottom: var(--spacer-3);
 			width: 100%;
+			
+			/* Display featured images in a specific aspect ratio */
+			@media (--viewport-medium) {
+				a {
+					display: block;
+					overflow: hidden;
+					position: relative;
+					padding-top: 75%; /* 4:3 aspect ratio */
+				}
+				
+				img {
+					height: 100%;
+					object-fit: cover;
+					position: absolute;
+					top: 0;
+				}
+			}
 		}
 		
 		.tribe-related-event-info {

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -319,23 +319,6 @@
 		.tribe-related-events-thumbnail {
 			margin-bottom: var(--spacer-3);
 			width: 100%;
-			
-			/* Display featured images in a specific aspect ratio */
-			@media (--viewport-medium) {
-				a {
-					display: block;
-					overflow: hidden;
-					position: relative;
-					padding-top: 75%; /* 4:3 aspect ratio */
-				}
-				
-				img {
-					height: 100%;
-					object-fit: cover;
-					position: absolute;
-					top: 0;
-				}
-			}
 		}
 		
 		.tribe-related-event-info {

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -106,14 +106,12 @@
 	}
 	
 	.event-is-recurring {
-		letter-spacing: -9999px; /* To hide the "Recurring Event" label on mobile */
 		padding-left: var(--spacer-4);
 		visibility: hidden;
 	}
 	
 	a {
 		visibility: visible;
-		letter-spacing: normal;
 	}
 }
 
@@ -136,7 +134,6 @@
 	
 	.event-is-recurring {
 		@media (--viewport-medium) {
-			letter-spacing: normal;
 			visibility: visible;
 		}
 	}

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -165,242 +165,243 @@
 			margin-bottom: var(--spacer-7);
 		}
 	}
+}
 	
-	/* Description Block */
-	.tribe-events-content {
-		
-		h2 {
-			margin-bottom: var(--spacer-1);
-			
-			@media (--viewport-medium) {
-				margin-bottom: var(--spacer-2);
-			}
-		}
-	}
+/* Description Block */
+.tribe-events-content {
 	
-	/* Cal export links block */
-	.tribe-events-cal-links {
-		margin-bottom: var(--spacer-7);
+	h2 {
+		margin-bottom: var(--spacer-1);
 		
 		@media (--viewport-medium) {
-			margin-bottom: var(--spacer-8);
-		}
-		
-		.tribe-events-gcal {
-			margin-right: var(--spacer-5);
-			
-			@media (--viewport-medium) {
-				margin-right: var(--spacer-8);
-			}
-		}
-		
-		.tribe-events-gcal,
-		.tribe-events-ical {
-			padding-left: var(--spacer-7);
-		}
-	}
-	
-	/* Details block */
-	.tribe-events-event-meta {
-		display: flex;
-		flex-wrap: wrap;
-		margin: var(--spacer-5) 0 var(--spacer-7);
-		
-		dt, dd {
-			margin: 0 0 var(--spacer-0) 0;
-		}
-		
-		.tribe-events-address {
-			margin: 0;
-		}
-
-		&.primary,
-		&.secondary {
-			width: 100%;
-			
-			@media (--viewport-medium) {
-				width: auto;
-			}
-		}
-	}
-	
-	/* Details column */
-	.tribe-events-meta-group {
-		flex: 1 0 140px;
-		margin-right: var(--spacer-5);
-		
-		@media (--viewport-medium) {
-			padding: var(--spacer-7) 0 var(--spacer-3);
-			width: 168px;
-		}
-	
-		.tribe-events-single-section-title {
-			margin-bottom: var(--spacer-1);
-		}
-	}
-	
-	/* Venue block */
-	.tribe-events-venue-map {
-		margin: 0 0 var(--spacer-3) 0;
-		order: -1;
-		width: 100%;
-		
-		@media (--viewport-medium) {
-			margin-top: var(--spacer-7);
-			order: 1;
-			width: 211px;
-		}
-		
-		&, & > div {
-			@media (--viewport-medium) {
-				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
-			}
-		}
-	}
-	
-	/* Details block */
-	.tribe-events-event-meta {
-		display: flex;
-		flex-wrap: wrap;
-		margin: var(--spacer-5) 0 var(--spacer-7);
-		
-		@media (--viewport-medium) {
-			margin-bottom: var(--spacer-3);
-		}
-		
-		dt, dd {
-			margin: 0 0 var(--spacer-0) 0;
-		}
-		
-		.tribe-events-address {
-			margin: 0;
-		}
-
-		&.primary,
-		&.secondary {
-			order: 2;
-			width: 100%;
-			
-			@media (--viewport-medium) {
-				width: auto;
-			}
-		}
-		
-		&.primary {
-			padding-top: var(--spacer-5);
-			position: relative;
-			
-			@media (--viewport-medium) {
-				padding-top: 0;
-				position: static;
-			}
-		}
-		
-		&:not(.secondary):before {
-			content: '';
-			position: absolute;
-			left: 0;
-			right: 0;
-			top: 0;
-			
-			@media (--viewport-medium) {
-				top: auto;
-			}
-		}
-	}
-	
-	/* Details column */
-	.tribe-events-meta-group {
-		flex: 1 0 140px;
-		margin-right: var(--spacer-5);
-		
-		@media (--viewport-medium) {
-			padding: var(--spacer-7) 0 var(--spacer-3);
-			width: 168px;
-		}
-	
-		.tribe-events-single-section-title {
-			margin-bottom: var(--spacer-1);
-		}
-	}
-	
-	/* Venue block */
-	.tribe-events-venue-map {
-		margin: 0 0 var(--spacer-3) 0;
-		order: -1;
-		width: 100%;
-		
-		@media (--viewport-medium) {
-			margin-top: var(--spacer-7);
-			order: 1;
-			width: 211px;
-		}
-		
-		&, & > div {
-			@media (--viewport-medium) {
-				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
-			}
-		}
-	}
-	
-	/* Related Events block */
-	.tribe-events-related-events-title,
-	.tribe-related-events {
-		order: 2;
-	}
-	
-	.tribe-events-related-events-title {
-		margin-bottom: var(--spacer-5);
-		padding-top: var(--spacer-7);
-		width: 100%;
-	}
-	
-	ul.tribe-related-events {
-		display: flex;
-		flex-direction: column;
-		
-		@media (--viewport-medium) {
-			flex-direction: row;
-			justify-content: space-between;
-		}
-		
-		li {
-			display: flex;
-			flex: 1;
-			flex-direction: column;
-			margin-bottom: var(--spacer-7);
-			padding: 0;
-			width: auto;
-			
-			&:last-child {
-				margin-right: 0;
-			}
-			
-			.tribe-related-events-thumbnail {
-				margin-bottom: var(--spacer-3);
-				width: 100%;
-			}
-			
-			.tribe-related-event-info {
-				align-items: baseline;
-				display: flex;
-				flex-wrap: wrap;
-				padding: 0;
-				width: 100%;
-				
-				.tribe-event-date-start {
-					margin: var(--spacer-0) 0;
-				}
-				
-				.recurringinfo {
-					margin: 0 0 0 var(--spacer-1);
-				}
-			}
-			
-			.tribe-related-events-title {
-				margin-bottom: var(--spacer-1);
-				width: 100%;
-			}
+			margin-bottom: var(--spacer-2);
 		}
 	}
 }
+
+/* Cal export links block */
+.tribe-events-cal-links {
+	margin-bottom: var(--spacer-7);
+	
+	@media (--viewport-medium) {
+		margin-bottom: var(--spacer-8);
+	}
+	
+	.tribe-events-gcal {
+		margin-right: var(--spacer-5);
+		
+		@media (--viewport-medium) {
+			margin-right: var(--spacer-8);
+		}
+	}
+	
+	.tribe-events-gcal,
+	.tribe-events-ical {
+		padding-left: var(--spacer-7);
+	}
+}
+
+/* Details block */
+.tribe-events-event-meta {
+	display: flex;
+	flex-wrap: wrap;
+	margin: var(--spacer-5) 0 var(--spacer-7);
+	
+	dt, dd {
+		margin: 0 0 var(--spacer-0) 0;
+	}
+	
+	.tribe-events-address {
+		margin: 0;
+	}
+
+	&.primary,
+	&.secondary {
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			width: auto;
+		}
+	}
+}
+
+/* Details column */
+.tribe-events-meta-group {
+	flex: 1 0 140px;
+	margin-right: var(--spacer-5);
+	
+	@media (--viewport-medium) {
+		padding: var(--spacer-7) 0 var(--spacer-3);
+		width: 168px;
+	}
+
+	.tribe-events-single-section-title {
+		margin-bottom: var(--spacer-1);
+	}
+}
+
+/* Venue block */
+.tribe-events-venue-map {
+	margin: 0 0 var(--spacer-3) 0;
+	order: -1;
+	width: 100%;
+	
+	@media (--viewport-medium) {
+		margin-top: var(--spacer-7);
+		order: 1;
+		width: 211px;
+	}
+	
+	&, & > div {
+		@media (--viewport-medium) {
+			height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+		}
+	}
+}
+
+/* Details block */
+.tribe-events-event-meta {
+	display: flex;
+	flex-wrap: wrap;
+	margin: var(--spacer-5) 0 var(--spacer-7);
+	
+	@media (--viewport-medium) {
+		margin-bottom: var(--spacer-3);
+	}
+	
+	dt, dd {
+		margin: 0 0 var(--spacer-0) 0;
+	}
+	
+	.tribe-events-address {
+		margin: 0;
+	}
+
+	&.primary,
+	&.secondary {
+		order: 2;
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			width: auto;
+		}
+	}
+	
+	&.primary {
+		padding-top: var(--spacer-5);
+		position: relative;
+		
+		@media (--viewport-medium) {
+			padding-top: 0;
+			position: static;
+		}
+	}
+	
+	&:not(.secondary):before {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		
+		@media (--viewport-medium) {
+			top: auto;
+		}
+	}
+}
+
+/* Details column */
+.tribe-events-meta-group {
+	flex: 1 0 140px;
+	margin-right: var(--spacer-5);
+	
+	@media (--viewport-medium) {
+		padding: var(--spacer-7) 0 var(--spacer-3);
+		width: 168px;
+	}
+
+	.tribe-events-single-section-title {
+		margin-bottom: var(--spacer-1);
+	}
+}
+
+/* Venue block */
+.tribe-events-venue-map {
+	margin: 0 0 var(--spacer-3) 0;
+	order: -1;
+	width: 100%;
+	
+	@media (--viewport-medium) {
+		margin-top: var(--spacer-7);
+		order: 1;
+		width: 211px;
+	}
+	
+	&, & > div {
+		@media (--viewport-medium) {
+			height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+		}
+	}
+}
+
+/* Related Events block */
+.tribe-events-related-events-title,
+.tribe-related-events {
+	order: 2;
+}
+
+.tribe-events-related-events-title {
+	margin-bottom: var(--spacer-5);
+	padding-top: var(--spacer-7);
+	width: 100%;
+}
+
+ul.tribe-related-events {
+	display: flex;
+	flex-direction: column;
+	
+	@media (--viewport-medium) {
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	li {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		margin-bottom: var(--spacer-7);
+		padding: 0;
+		width: auto;
+		
+		&:last-child {
+			margin-right: 0;
+		}
+		
+		.tribe-related-events-thumbnail {
+			margin-bottom: var(--spacer-3);
+			width: 100%;
+		}
+		
+		.tribe-related-event-info {
+			align-items: baseline;
+			display: flex;
+			flex-wrap: wrap;
+			padding: 0;
+			width: 100%;
+			
+			.tribe-event-date-start {
+				margin: var(--spacer-0) 0;
+			}
+			
+			.recurringinfo {
+				margin: 0 0 0 var(--spacer-1);
+			}
+		}
+		
+		.tribe-related-events-title {
+			margin-bottom: var(--spacer-1);
+			width: 100%;
+		}
+	}
+}
+

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -104,6 +104,17 @@
 	.tribe-events-divider {
 		display: none;
 	}
+	
+	.event-is-recurring {
+		letter-spacing: -9999px; /* To hide the "Recurring Event" label on mobile */
+		padding-left: var(--spacer-4);
+		visibility: hidden;
+	}
+	
+	a {
+		visibility: visible;
+		letter-spacing: normal;
+	}
 }
 
 /* Recurring info block */
@@ -123,24 +134,11 @@
 		}
 	}
 	
-	.tribe-events-divider {
-		display: none;
-	}
-
 	.event-is-recurring {
-		letter-spacing: -9999px; /* To hide the "Recurring Event" label on mobile */
-		padding-left: var(--spacer-4);
-		visibility: hidden;
-		
 		@media (--viewport-medium) {
 			letter-spacing: normal;
 			visibility: visible;
 		}
-	}
-	
-	a {
-		visibility: visible;
-		letter-spacing: normal;
 	}
 }
 

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -9,6 +9,26 @@
 	
 	#tribe-events-pg-template {
 		max-width: 1048px;
+		padding: var(--spacer-8) var(--spacer-4) var(--spacer-4);
+	}
+	
+	.tribe-events-before-html,
+	.tribe-events-after-html {
+		p {
+			margin: 0 0 10px;
+		}
+	}
+	
+	.tribe-events-single > .tribe_events {
+		display: flex;
+		flex-wrap: wrap;
+		overflow: hidden;
+		position: relative;
+		
+		& > *:not(.primary, .secondary, .tribe-events-related-events-title, .tribe-related-events) {
+			order: 1;
+			width: 100%;
+		}
 	}
 	
 	/* Back navigation block */
@@ -49,15 +69,11 @@
 	}
 	
 	/* Recurring info block */
-	.tribe-events-schedule .recurringinfo {
+	.tribe-events-schedule .recurringinfo,
+	.tribe-related-event-info .recurringinfo {
 		margin-right: var(--spacer-1);
 		order: 2;
 		padding: 0 var(--spacer-1);
-		
-		@media (--viewport-medium) {
-			margin-left: var(--spacer-1);
-			padding: var(--spacer-1) var(--spacer-3);
-		}
 		
 		&:before {
 			background: svg-inline(recurring-active) 0 / 12px no-repeat;
@@ -68,10 +84,6 @@
 			top: 50%;
 			transform: translateY(-50%);
 			width: 20px;
-			
-			@media (--viewport-medium) {
-				left: 16px;
-			}
 		}
 		
 		.tribe-events-divider {
@@ -96,6 +108,26 @@
 		}
 	}
 	
+	.tribe-events-schedule .recurringinfo {
+		@media (--viewport-medium) {
+			margin-left: var(--spacer-1);
+			padding: var(--spacer-1) var(--spacer-3);
+		}
+		
+		&:before {
+			@media (--viewport-medium) {
+				left: 16px;
+			}
+		}
+		
+		.event-is-recurring {
+			@media (--viewport-medium) {
+				letter-spacing: normal;
+				visibility: visible;
+			}
+		}
+	}
+	
 	/* Cost block */
 	.tribe-events-schedule .tribe-events-cost {
 		margin-right: var(--spacer-1);
@@ -103,6 +135,257 @@
 		
 		@media (--viewport-medium) {
 			margin: 0 var(--spacer-1);
+		}
+	}
+	
+	/* Featured Image */
+	.tribe-events-event-image {
+		margin-bottom: var(--spacer-3);
+		
+		img {
+			display: block;
+		}
+		
+		@media (--viewport-medium) {
+			margin-bottom: var(--spacer-7);
+		}
+	}
+	
+	/* Description Block */
+	.tribe-events-content {
+		
+		h2 {
+			margin-bottom: var(--spacer-1);
+			
+			@media (--viewport-medium) {
+				margin-bottom: var(--spacer-2);
+			}
+		}
+	}
+	
+	/* Cal export links block */
+	.tribe-events-cal-links {
+		margin-bottom: var(--spacer-7);
+		
+		@media (--viewport-medium) {
+			margin-bottom: var(--spacer-8);
+		}
+		
+		.tribe-events-gcal {
+			margin-right: var(--spacer-5);
+			
+			@media (--viewport-medium) {
+				margin-right: var(--spacer-8);
+			}
+		}
+		
+		.tribe-events-gcal,
+		.tribe-events-ical {
+			padding-left: var(--spacer-7);
+		}
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		display: flex;
+		flex-wrap: wrap;
+		margin: var(--spacer-5) 0 var(--spacer-7);
+		
+		dt, dd {
+			margin: 0 0 var(--spacer-0) 0;
+		}
+		
+		.tribe-events-address {
+			margin: 0;
+		}
+
+		&.primary,
+		&.secondary {
+			width: 100%;
+			
+			@media (--viewport-medium) {
+				width: auto;
+			}
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		flex: 1 0 140px;
+		margin-right: var(--spacer-5);
+		
+		@media (--viewport-medium) {
+			padding: var(--spacer-7) 0 var(--spacer-3);
+			width: 168px;
+		}
+	
+		.tribe-events-single-section-title {
+			margin-bottom: var(--spacer-1);
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		margin: 0 0 var(--spacer-3) 0;
+		order: -1;
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			margin-top: var(--spacer-7);
+			order: 1;
+			width: 211px;
+		}
+		
+		&, & > div {
+			@media (--viewport-medium) {
+				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+			}
+		}
+	}
+	
+	/* Details block */
+	.tribe-events-event-meta {
+		display: flex;
+		flex-wrap: wrap;
+		margin: var(--spacer-5) 0 var(--spacer-7);
+		
+		@media (--viewport-medium) {
+			margin-bottom: var(--spacer-3);
+		}
+		
+		dt, dd {
+			margin: 0 0 var(--spacer-0) 0;
+		}
+		
+		.tribe-events-address {
+			margin: 0;
+		}
+
+		&.primary,
+		&.secondary {
+			order: 2;
+			width: 100%;
+			
+			@media (--viewport-medium) {
+				width: auto;
+			}
+		}
+		
+		&.primary {
+			padding-top: var(--spacer-5);
+			position: relative;
+			
+			@media (--viewport-medium) {
+				padding-top: 0;
+				position: static;
+			}
+		}
+		
+		&:not(.secondary):before {
+			content: '';
+			position: absolute;
+			left: 0;
+			right: 0;
+			top: 0;
+			
+			@media (--viewport-medium) {
+				top: auto;
+			}
+		}
+	}
+	
+	/* Details column */
+	.tribe-events-meta-group {
+		flex: 1 0 140px;
+		margin-right: var(--spacer-5);
+		
+		@media (--viewport-medium) {
+			padding: var(--spacer-7) 0 var(--spacer-3);
+			width: 168px;
+		}
+	
+		.tribe-events-single-section-title {
+			margin-bottom: var(--spacer-1);
+		}
+	}
+	
+	/* Venue block */
+	.tribe-events-venue-map {
+		margin: 0 0 var(--spacer-3) 0;
+		order: -1;
+		width: 100%;
+		
+		@media (--viewport-medium) {
+			margin-top: var(--spacer-7);
+			order: 1;
+			width: 211px;
+		}
+		
+		&, & > div {
+			@media (--viewport-medium) {
+				height: 211px !important; /* TODO: look into an alternative way to restrain gmaps' size */
+			}
+		}
+	}
+	
+	/* Related Events block */
+	.tribe-events-related-events-title,
+	.tribe-related-events {
+		order: 2;
+	}
+	
+	.tribe-events-related-events-title {
+		margin-bottom: var(--spacer-5);
+		padding-top: var(--spacer-7);
+		width: 100%;
+	}
+	
+	ul.tribe-related-events {
+		display: flex;
+		flex-direction: column;
+		
+		@media (--viewport-medium) {
+			flex-direction: row;
+			justify-content: space-between;
+		}
+		
+		li {
+			display: flex;
+			flex: 1;
+			flex-direction: column;
+			margin-bottom: var(--spacer-7);
+			padding: 0;
+			width: auto;
+			
+			&:last-child {
+				margin-right: 0;
+			}
+			
+			.tribe-related-events-thumbnail {
+				margin-bottom: var(--spacer-3);
+				width: 100%;
+			}
+			
+			.tribe-related-event-info {
+				align-items: baseline;
+				display: flex;
+				flex-wrap: wrap;
+				padding: 0;
+				width: 100%;
+				
+				.tribe-event-date-start {
+					margin: var(--spacer-0) 0;
+				}
+				
+				.recurringinfo {
+					margin: 0 0 0 var(--spacer-1);
+				}
+			}
+			
+			.tribe-related-events-title {
+				margin-bottom: var(--spacer-1);
+				width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Description:** Adds styles to update the way Related Events block displays

**Note:** This also modifies the whole single event layout to re-order blocks according to the designs. It also separates part of the `.recurringinfo` styles to display things a bit differently between the top header and the related events metadata.

**Ticket:** https://theeventscalendar.atlassian.net/browse/ECP-673

**Screenshots:**

![Screen Shot 2021-02-11 at 12 08 11 PM](https://user-images.githubusercontent.com/5049893/107629095-e5ebde80-6c61-11eb-8a9b-d2fa318ce6e2.png)

![Screen Shot 2021-02-11 at 12 08 29 PM](https://user-images.githubusercontent.com/5049893/107629086-e2f0ee00-6c61-11eb-86a1-bb9e2c4bab48.png)
