### PR TITLE
Feature/tec 3767 single event customizer

### DIFF
--- a/src/Tribe/Customizer/Single_Event.php
+++ b/src/Tribe/Customizer/Single_Event.php
@@ -147,40 +147,43 @@ final class Tribe__Events__Customizer__Single_Event extends Tribe__Customizer__S
 			)
 		);
 
-		// Add an heading that is a Control only in name: it does not, actually, control or save any setting.
-		$manager->add_control(
-			new Heading(
-				$manager,
-				$customizer->get_setting_name( 'details_bg_color_heading', $section ),
-				[
-					'label'    => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
-					'section'  => $section->id,
-					'priority' => 10,
-				]
-			)
-		);
+		// The Details Background Color control won't be present if the Single Event styles overrides are enabled
+		if ( ! tribe_events_single_view_v2_is_enabled() ) {
+			// Add an heading that is a Control only in name: it does not, actually, control or save any setting.
+			$manager->add_control(
+				new Heading(
+					$manager,
+					$customizer->get_setting_name( 'details_bg_color_heading', $section ),
+					[
+						'label'    => esc_html__( 'Adjust Appearance', 'the-events-calendar' ),
+						'section'  => $section->id,
+						'priority' => 10,
+					]
+				)
+			);
 
-		$manager->add_setting(
-			$customizer->get_setting_name( 'details_bg_color', $section ),
-			[
-				'default'              => $this->get_default( 'details_bg_color' ),
-				'type'                 => 'option',
-				'sanitize_callback'    => 'sanitize_hex_color',
-				'sanitize_js_callback' => 'maybe_hash_hex_color',
-			]
-		);
-
-		$manager->add_control(
-			new WP_Customize_Color_Control(
-				$manager,
+			$manager->add_setting(
 				$customizer->get_setting_name( 'details_bg_color', $section ),
 				[
-					'label'       => esc_html__( 'Event Details Background Color', 'the-events-calendar' ),
-					'description' => esc_html__( 'For classic editor', 'the-events-calendar' ),
-					'section'     => $section->id,
+					'default'              => $this->get_default( 'details_bg_color' ),
+					'type'                 => 'option',
+					'sanitize_callback'    => 'sanitize_hex_color',
+					'sanitize_js_callback' => 'maybe_hash_hex_color',
 				]
-			)
-		);
+			);
+
+			$manager->add_control(
+				new WP_Customize_Color_Control(
+					$manager,
+					$customizer->get_setting_name( 'details_bg_color', $section ),
+					[
+						'label'       => esc_html__( 'Event Details Background Color', 'the-events-calendar' ),
+						'description' => esc_html__( 'For classic editor', 'the-events-calendar' ),
+						'section'     => $section->id,
+					]
+				)
+			);
+		}
 
 		// Introduced to make Selective Refresh have less code duplication
 		$customizer->add_setting_name( $customizer->get_setting_name( 'post_title_color', $section ) );

--- a/src/Tribe/Views/V2/Customizer.php
+++ b/src/Tribe/Views/V2/Customizer.php
@@ -663,6 +663,30 @@ class Customizer {
 					color: <%= global_elements.accent_color %>;
 				}
 			';
+			
+			// Single Event styles overrides
+			if ( tribe_events_single_view_v2_is_enabled() ) {
+				$css_template .= '
+					.tribe-events-cal-links .tribe-events-gcal,
+					.tribe-events-cal-links .tribe-events-ical,
+					.tribe-events-event-meta a,
+					.tribe-events-schedule .recurringinfo a,
+					.tribe-related-event-info .recurringinfo a,
+					.tribe-events-single ul.tribe-related-events li .tribe-related-events-title a {
+						color: <%= global_elements.accent_color %>;
+					}
+					
+					.tribe-events-virtual-link-button {
+						background-color: <%= global_elements.accent_color %>;
+					}
+					
+					.tribe-events-virtual-link-button:active,
+					.tribe-events-virtual-link-button:focus,
+					.tribe-events-virtual-link-button:hover {
+						background-color: ' . $accent_color_hover . ';
+					}
+				';
+			}
 		}
 
 		return $css_template;
@@ -702,5 +726,35 @@ class Customizer {
 	 */
 	public function enqueue_customizer_controls_styles() {
 		tribe_asset_enqueue( 'tribe-customizer-views-v2-controls' );
+	}
+	
+	/**
+	 * Check whether the Single Event styles overrides can be applied
+	 *
+	 * @return void
+	 */
+	function tribe_events_single_view_v2_is_enabled() {
+		// If the constant is defined, returns the opposite of the constant.
+		if ( defined( 'TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED' ) ) {
+			return (bool) ! TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED;
+		}
+	
+		// Allow env_var to short-circuit for testing.
+		$env_var = (bool) getenv( 'TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED' );
+		if ( false !== $env_var ) {
+			return ! $env_var;
+		}
+		
+		// Bail if not Single Event.
+		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
+			return false;
+		}
+		
+		// Bail if Block Editor.
+		if ( has_blocks( get_queried_object_id() ) ) {
+			return false;
+		}
+	
+		return true;
 	}
 }

--- a/tests/views_v2_customizer_integration/__snapshots__/CustomizerSettingsTest__should_allow_taking_a_css_template_snapshot__1.php
+++ b/tests/views_v2_customizer_integration/__snapshots__/CustomizerSettingsTest__should_allow_taking_a_css_template_snapshot__1.php
@@ -223,5 +223,24 @@
 			
 				.tribe-common--breakpoint-medium.tribe-events .tribe-events-calendar-day__event-datetime-featured-text {
 					color: #238923;
-				}',
+				}
+			
+					.tribe-events-cal-links .tribe-events-gcal,
+					.tribe-events-cal-links .tribe-events-ical,
+					.tribe-events-event-meta a,
+					.tribe-events-schedule .recurringinfo a,
+					.tribe-related-event-info .recurringinfo a,
+					.tribe-events-single ul.tribe-related-events li .tribe-related-events-title a {
+						color: #238923;
+					}
+					
+					.tribe-events-virtual-link-button {
+						background-color: #238923;
+					}
+					
+					.tribe-events-virtual-link-button:active,
+					.tribe-events-virtual-link-button:focus,
+					.tribe-events-virtual-link-button:hover {
+						background-color: rgba(35,137,35,0.8);
+					}',
 );


### PR DESCRIPTION
**Description:** Hides the Event Details Background Color control on the Customizer's Single Event section, as not needed for the new overrides. Also applies a bunch of styles when an accent color is defined.

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3767

**Screenshots:**

![Screen Shot 2021-02-12 at 3 03 11 PM](https://user-images.githubusercontent.com/5049893/107777674-72220280-6d43-11eb-80d5-0afcae3c391e.png)

![Screen Shot 2021-02-12 at 2 29 22 PM](https://user-images.githubusercontent.com/5049893/107777530-3c7d1980-6d43-11eb-8c09-5850115a60e1.png)

![Screen Shot 2021-02-12 at 2 29 30 PM](https://user-images.githubusercontent.com/5049893/107777545-40a93700-6d43-11eb-95c7-01bf9d8a9c29.png)

![Screen Shot 2021-02-12 at 2 29 33 PM](https://user-images.githubusercontent.com/5049893/107777553-456deb00-6d43-11eb-8de4-41191dbcf28d.png)

![Screen Shot 2021-02-12 at 2 29 38 PM](https://user-images.githubusercontent.com/5049893/107777571-4c94f900-6d43-11eb-912f-8242e5bf429d.png)

