### PR TITLE
Feature/widget compatibility containers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 * Version - The Events Calendar 5.4.0 is only compatible with Events Calendar PRO 5.3.0 and higher
 * Fix - Navigation for the Views will no longer use current browser URL as previous url, preventing problems on shortcodes.
 * Fix - Latest Past view moved to not publicly visible, which was the intended behavior.
+* Tweak - Add compatibility container to widgets - to allow for a non-body target for compatibility classes.
 * Tweak - Include the `tribe_events_views_v2_view_page_reset_ignored_params` filter to prevent certain params from interfering with pagination resetting. [FBAR-222]
 * Tweak - Use filterable attributes for the view more link and text. Add customizer styling for the link. [ECP-568]
 * Tweak - Removed `tribe_events_views_v2_widget_admin_form_{$field_type}_input` from the List Widget admin form in favor of using `Tribe__Template::do_entry_point()` [ECP-486]

--- a/src/Tribe/Views/V2/Theme_Compatibility.php
+++ b/src/Tribe/Views/V2/Theme_Compatibility.php
@@ -91,7 +91,6 @@ class Theme_Compatibility {
 	 * @return boolean Whether body classes should be added or not.
 	 */
 	public function should_add_body_class_to_queue( $add, $class, $queue ) {
-		$a = ! tribe( Template_Bootstrap::class )->should_load();
 		if (
 			'admin' === $queue
 			|| ! tribe( Template_Bootstrap::class )->should_load()

--- a/src/Tribe/Views/V2/Theme_Compatibility.php
+++ b/src/Tribe/Views/V2/Theme_Compatibility.php
@@ -91,6 +91,7 @@ class Theme_Compatibility {
 	 * @return boolean Whether body classes should be added or not.
 	 */
 	public function should_add_body_class_to_queue( $add, $class, $queue ) {
+		$a = ! tribe( Template_Bootstrap::class )->should_load();
 		if (
 			'admin' === $queue
 			|| ! tribe( Template_Bootstrap::class )->should_load()

--- a/src/Tribe/Views/V2/Views/Widgets/Widget_View.php
+++ b/src/Tribe/Views/V2/Views/Widgets/Widget_View.php
@@ -11,6 +11,7 @@ namespace Tribe\Events\Views\V2\Views\Widgets;
 use Tribe\Widget\Widget_Abstract;
 use Tribe__Context as Context;
 use Tribe\Events\Views\V2\View;
+use Tribe\Events\Views\V2\Theme_Compatibility;
 
 /**
  * Class Widget_View
@@ -99,10 +100,11 @@ class Widget_View extends View {
 	protected function setup_template_vars() {
 		$template_vars = parent::setup_template_vars();
 
-		$template_vars['container_classes'] = $this->get_html_classes();
-		$template_vars['view_more_text']    = $this->get_view_more_text();
-		$template_vars['view_more_title']   = $this->get_view_more_title();
-		$template_vars['view_more_link']    = $this->get_view_more_link();
+		$template_vars['compatibility_classes'] = $this->get_compatibility_classes();
+		$template_vars['container_classes']     = $this->get_html_classes();
+		$template_vars['view_more_text']        = $this->get_view_more_text();
+		$template_vars['view_more_title']       = $this->get_view_more_title();
+		$template_vars['view_more_link']        = $this->get_view_more_link();
 
 		return $template_vars;
 	}
@@ -147,6 +149,49 @@ class Widget_View extends View {
 		$args = apply_filters( "tribe_events_views_v2_{$this->get_slug()}_widget_repository_args", $args, $context, $this );
 
 		return $args;
+	}
+
+	/**
+	 * Adds compatibility classes to the widget view container.
+	 * Not the view itself - the wrapping div around that
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string> An Array of class names to add to the container. Will contain
+	 *                       _at least_ 'tribe-compatibility-container' as an indicator.
+	 */
+	public function get_compatibility_classes() {
+		$theme_compatibility = tribe( Theme_Compatibility::class );
+		$classes = [ 'tribe-compatibility-container' ];
+
+		if ( ! $theme_compatibility->is_compatibility_required() ) {
+			return $classes;
+		}
+
+		$classes = array_merge( $classes, $theme_compatibility->get_body_classes() );
+
+		/**
+		 * Filters the HTML classes applied to a widget top-level container.
+		 *
+		 * @since 5.3.0
+		 *
+		 * @param array  $html_classes Array of classes used for this widget.
+		 * @param string $view_slug    The current widget slug.
+		 * @param View   $instance     The current View object.
+		 */
+		$classes = apply_filters( 'tribe_events_views_v2_widget_compatibility_classes', $classes, $this->get_slug(), $this );
+
+		/**
+		 * Filters the HTML classes applied to a specific widget top-level container.
+		 *
+		 * @since 5.3.0
+		 *
+		 * @param array $classes Array of classes used for this widget.
+		 * @param View  $instance     The current View object.
+		 */
+		$classes = apply_filters( "tribe_events_views_v2_{$this->get_slug()}_widget_compatibility_classes", $classes, $this );
+
+		return $classes;
 	}
 
 	/**

--- a/src/views/v2/widgets/widget-events-list.php
+++ b/src/views/v2/widgets/widget-events-list.php
@@ -18,6 +18,7 @@
  * @var string               $rest_url                   The REST URL.
  * @var string               $rest_nonce                 The REST nonce.
  * @var int                  $should_manage_url          int containing if it should manage the URL.
+ * @var array<string>        $compatibility_classes      Classes used for the compatibility container.
  * @var array<string>        $container_classes          Classes used for the container of the view.
  * @var array<string,mixed>  $container_data             An additional set of container `data` attributes.
  * @var string               $breakpoint_pointer         String we use as pointer to the current view we are setting up with breakpoints.
@@ -32,47 +33,48 @@ if ( empty( $events ) && $hide_if_no_upcoming_events ) {
 	return;
 }
 ?>
-<div
-	<?php tribe_classes( $container_classes ); ?>
-	data-js="tribe-events-view"
-	data-view-rest-nonce="<?php echo esc_attr( $rest_nonce ); ?>"
-	data-view-rest-url="<?php echo esc_url( $rest_url ); ?>"
-	data-view-manage-url="<?php echo esc_attr( $should_manage_url ); ?>"
-	<?php foreach ( $container_data as $key => $value ) : ?>
-		data-view-<?php echo esc_attr( $key ); ?>="<?php echo esc_attr( $value ); ?>"
-	<?php endforeach; ?>
-	<?php if ( ! empty( $breakpoint_pointer ) ) : ?>
-		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
-	<?php endif; ?>
->
-	<div class="tribe-events-widget-events-list">
-
-		<?php $this->template( 'components/json-ld-data' ); ?>
-
-		<?php $this->template( 'components/data' ); ?>
-
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-				<?php echo esc_html( $widget_title ); ?>
-			</h2>
-		</header>
-
-		<?php if ( ! empty( $events ) ) : ?>
-
-			<div class="tribe-events-widget-events-list__events">
-				<?php foreach ( $events as $event ) : ?>
-					<?php $this->template( 'widgets/widget-events-list/event', [ 'event' => $event ] ); ?>
-				<?php endforeach; ?>
-			</div>
-
-			<?php $this->template( 'widgets/widget-events-list/view-more' ); ?>
-
-		<?php else : ?>
-
-			<?php $this->template( 'components/messages' ); ?>
-
+<div <?php tribe_classes( $compatibility_classes); ?>>
+	<div
+		<?php tribe_classes( $container_classes ); ?>
+		data-js="tribe-events-view"
+		data-view-rest-nonce="<?php echo esc_attr( $rest_nonce ); ?>"
+		data-view-rest-url="<?php echo esc_url( $rest_url ); ?>"
+		data-view-manage-url="<?php echo esc_attr( $should_manage_url ); ?>"
+		<?php foreach ( $container_data as $key => $value ) : ?>
+			data-view-<?php echo esc_attr( $key ); ?>="<?php echo esc_attr( $value ); ?>"
+		<?php endforeach; ?>
+		<?php if ( ! empty( $breakpoint_pointer ) ) : ?>
+			data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
 		<?php endif; ?>
+	>
+		<div class="tribe-events-widget-events-list">
+
+			<?php $this->template( 'components/json-ld-data' ); ?>
+
+			<?php $this->template( 'components/data' ); ?>
+
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+					<?php echo esc_html( $widget_title ); ?>
+				</h2>
+			</header>
+
+			<?php if ( ! empty( $events ) ) : ?>
+
+				<div class="tribe-events-widget-events-list__events">
+					<?php foreach ( $events as $event ) : ?>
+						<?php $this->template( 'widgets/widget-events-list/event', [ 'event' => $event ] ); ?>
+					<?php endforeach; ?>
+				</div>
+
+				<?php $this->template( 'widgets/widget-events-list/view-more' ); ?>
+
+			<?php else : ?>
+
+				<?php $this->template( 'components/messages' ); ?>
+
+			<?php endif; ?>
+		</div>
 	</div>
 </div>
-
 <?php $this->template( 'components/breakpoints' ); ?>

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/__snapshots__/EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/__snapshots__/EventTest__test_render_with_event__1.php
@@ -1,4 +1,4 @@
-<?php return '<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-8 tribe_events type-tribe_events status-publish hentry" >
+<?php return '<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
 
 		

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
@@ -1,4 +1,4 @@
-<?php return '<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-day__event--featured" >
+<?php return '<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-day__event--featured" >
 	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
 
 		

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Latest_Past_View/__snapshots__/EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Latest_Past_View/__snapshots__/EventTest__test_render_with_event__1.php
@@ -12,7 +12,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Latest_Past_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Latest_Past_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
@@ -12,7 +12,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/__snapshots__/EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/__snapshots__/EventTest__test_render_with_event__1.php
@@ -10,7 +10,7 @@
 </div>
 
 	<div class="tribe-events-calendar-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-list__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/__snapshots__/EventTest__test_render_with_featured_event__1.php
@@ -10,7 +10,7 @@
 </div>
 
 	<div class="tribe-events-calendar-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-list__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Calendar_Events/__snapshots__/Calendar_EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Calendar_Events/__snapshots__/Calendar_EventTest__test_render_with_event__1.php
@@ -1,5 +1,5 @@
 <?php return '
-<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Calendar_Events/__snapshots__/Calendar_EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Calendar_Events/__snapshots__/Calendar_EventTest__test_render_with_featured_event__1.php
@@ -1,5 +1,5 @@
 <?php return '
-<article  class="tribe-events-calendar-month__calendar-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__calendar-event--featured" >
+<article  class="tribe-events-calendar-month__calendar-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__calendar-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_featured_multiday_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_featured_multiday_event__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
+	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_does_not_start_this_week_does_not_end_this_week_spans_multiple_weeks__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_does_not_start_this_week_does_not_end_this_week_spans_multiple_weeks__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--width-7 tribe-events-calendar-month__multiday-event--display"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--width-7 tribe-events-calendar-month__multiday-event--display"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_ends_this_week_spans_multiple_weeks__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_ends_this_week_spans_multiple_weeks__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--width-3 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--width-3 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_past__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_past__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_start_of_week__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_start_of_week__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--width-3 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--width-3 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_start_of_week_start_date_is_day_date__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_is_start_of_week_start_date_is_day_date__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--width-5 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--start tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--width-5 tribe-events-calendar-month__multiday-event--display tribe-events-calendar-month__multiday-event--start tribe-events-calendar-month__multiday-event--end"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_start_date_is_day_date__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_start_date_is_day_date__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_starts_this_week_ends_this_week__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_starts_this_week_ends_this_week__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_starts_this_week_spans_multiple_weeks__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/Multiday_Events/__snapshots__/Multiday_EventTest__test_render_with_multiday_event_starts_this_week_spans_multiple_weeks__1.php
@@ -1,5 +1,5 @@
 <?php return '<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Calendar_EventsTest__test_render_with_multiple_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Calendar_EventsTest__test_render_with_multiple_events__1.php
@@ -1,7 +1,7 @@
 <?php return '
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__calendar-event--featured" >
+<article  class="tribe-events-calendar-month__calendar-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__calendar-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">
@@ -68,7 +68,7 @@
 
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">
@@ -121,7 +121,7 @@
 
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-9 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-9 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Calendar_EventsTest__test_render_with_one_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Calendar_EventsTest__test_render_with_one_event__1.php
@@ -1,7 +1,7 @@
 <?php return '
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events__1.php
@@ -1,6 +1,6 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
+	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -29,7 +29,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -51,7 +51,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry"  data-event-id="9">
+	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="9">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacer_before_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacer_before_events__1.php
@@ -1,7 +1,7 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper tribe-events-calendar-month__multiday-event--empty"></div>
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
+	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -30,7 +30,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -52,7 +52,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry"  data-event-id="9">
+	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="9">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacer_between_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacer_between_events__1.php
@@ -1,6 +1,6 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
+	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -29,7 +29,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -52,7 +52,7 @@
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper tribe-events-calendar-month__multiday-event--empty"></div>
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry"  data-event-id="9">
+	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="9">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacers_before_and_between_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_multiple_multiday_events_and_spacers_before_and_between_events__1.php
@@ -1,7 +1,7 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper tribe-events-calendar-month__multiday-event--empty"></div>
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
+	<article  class="tribe-events-calendar-month__multiday-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__multiday-event--featured"  data-event-id="7">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -30,7 +30,7 @@
 </div>
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"
@@ -53,7 +53,7 @@
 
 	<div class="tribe-events-calendar-month__multiday-event-wrapper tribe-events-calendar-month__multiday-event--empty"></div>
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry"  data-event-id="9">
+	<article  class="tribe-events-calendar-month__multiday-event post-9 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="9">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_one_multiday_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_one_multiday_event__1.php
@@ -1,6 +1,6 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_one_multiday_event_and_spacer__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Calendar_Body/Day/__snapshots__/Multiday_EventsTest__test_render_with_one_multiday_event_and_spacer__1.php
@@ -1,7 +1,7 @@
 <?php return '
 	<div class="tribe-events-calendar-month__multiday-event-wrapper tribe-events-calendar-month__multiday-event--empty"></div>
 	<div class="tribe-events-calendar-month__multiday-event-wrapper">
-	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry"  data-event-id="8">
+	<article  class="tribe-events-calendar-month__multiday-event post-8 tribe_events type-tribe_events status-publish hentry entry"  data-event-id="8">
 		<div class="tribe-events-calendar-month__multiday-event-hidden">
 	<time
 	datetime="2019-06-20"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/Mobile_Day/__snapshots__/Mobile_EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/Mobile_Day/__snapshots__/Mobile_EventTest__test_render_with_event__1.php
@@ -1,5 +1,5 @@
 <?php return '
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/Mobile_Day/__snapshots__/Mobile_EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/Mobile_Day/__snapshots__/Mobile_EventTest__test_render_with_featured_event__1.php
@@ -1,5 +1,5 @@
 <?php return '
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_multiple_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_multiple_events__1.php
@@ -10,7 +10,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -34,7 +34,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_multiple_multiday_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_multiple_multiday_events__1.php
@@ -10,7 +10,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -34,7 +34,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_normal_and_multiday_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_normal_and_multiday_events__1.php
@@ -10,7 +10,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-9 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -34,7 +34,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_one_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_one_event__1.php
@@ -10,7 +10,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_one_multiday_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/Mobile_Events/__snapshots__/Mobile_DayTest__test_render_with_one_multiday_event__1.php
@@ -10,7 +10,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Mobile_EventsTest__test_render_with_days_with_found_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Mobile_EventsTest__test_render_with_days_with_found_events__1.php
@@ -14,7 +14,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-7 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-7 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -47,7 +47,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_List/__snapshots__/EventTest__test_render_with_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_List/__snapshots__/EventTest__test_render_with_event__1.php
@@ -10,7 +10,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_List/__snapshots__/EventTest__test_render_with_featured_event__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_List/__snapshots__/EventTest__test_render_with_featured_event__1.php
@@ -10,7 +10,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_ListTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/Widget_Events_ListTest.php
@@ -25,6 +25,7 @@ class Widget_Events_ListTest extends HtmlPartialTestCase
 			'rest_nonce'                 => '1122334455',
 			'should_manage_url'          => false,
 			'container_classes'          => [ 'tribe-common', 'tribe-events', 'tribe-events-widget' ],
+			'compatibility_classes'      => [ 'tribe-compatibility-container' ],
 			'container_data'             => [],
 			'breakpoint_pointer'         => 'aabbccddee',
 			'messages'                   => [],
@@ -49,6 +50,7 @@ class Widget_Events_ListTest extends HtmlPartialTestCase
 			'rest_nonce'                 => '1122334455',
 			'should_manage_url'          => false,
 			'container_classes'          => [ 'tribe-common', 'tribe-events', 'tribe-events-widget' ],
+			'compatibility_classes'      => [ 'tribe-compatibility-container' ],
 			'container_data'             => [],
 			'breakpoint_pointer'         => 'aabbccddee',
 			'messages'                   => [
@@ -77,6 +79,7 @@ class Widget_Events_ListTest extends HtmlPartialTestCase
 			'rest_nonce'                 => '1122334455',
 			'should_manage_url'          => false,
 			'container_classes'          => [ 'tribe-common', 'tribe-events', 'tribe-events-widget' ],
+			'compatibility_classes'      => [ 'tribe-compatibility-container' ],
 			'container_data'             => [],
 			'breakpoint_pointer'         => 'aabbccddee',
 			'messages'                   => [

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/__snapshots__/Widget_Events_ListTest__test_render_with_no_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/__snapshots__/Widget_Events_ListTest__test_render_with_no_upcoming_events__1.php
@@ -1,23 +1,24 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="1122334455"
-	data-view-rest-url="https://rest.tri.be/"
-	data-view-manage-url=""
-				data-view-breakpoint-pointer="aabbccddee"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container" >
+	<div
+		 class="tribe-common tribe-events tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="1122334455"
+		data-view-rest-url="https://rest.tri.be/"
+		data-view-manage-url=""
+							data-view-breakpoint-pointer="aabbccddee"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		{}
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"reflector","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Reflector_View","view_slug":"reflector","view_label":"Reflector","events":[],"is_initial_load":true,"rest_url":"https:\\/\\/rest.tri.be\\/","rest_nonce":"1122334455","should_manage_url":false,"container_classes":["tribe-common","tribe-events","tribe-events-widget"],"container_data":[],"breakpoint_pointer":"aabbccddee","messages":{"notice":["There are no upcoming events."]},"hide_if_no_upcoming_events":false,"view_more_link":"https:\\/\\/test.tri.be\\/","view_more_text":"View More","view_more_title":"View more events.","widget_title":"Upcoming Events"}</script>
+			{}
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"reflector","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Reflector_View","view_slug":"reflector","view_label":"Reflector","events":[],"is_initial_load":true,"rest_url":"https:\\/\\/rest.tri.be\\/","rest_nonce":"1122334455","should_manage_url":false,"container_classes":["tribe-common","tribe-events","tribe-events-widget"],"compatibility_classes":["tribe-compatibility-container"],"container_data":[],"breakpoint_pointer":"aabbccddee","messages":{"notice":["There are no upcoming events."]},"hide_if_no_upcoming_events":false,"view_more_link":"https:\\/\\/test.tri.be\\/","view_more_text":"View More","view_more_title":"View more events.","widget_title":"Upcoming Events"}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-				Upcoming Events			</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+					Upcoming Events				</h2>
+			</header>
 
-		
-			<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2" >
+			
+				<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2" >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
 			<ul class="tribe-events-c-messages__message-list">
@@ -27,9 +28,9 @@
 		</div>
 	</div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/__snapshots__/Widget_Events_ListTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Widgets/__snapshots__/Widget_Events_ListTest__test_render_with_upcoming_events__1.php
@@ -1,24 +1,25 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="1122334455"
-	data-view-rest-url="https://rest.tri.be/"
-	data-view-manage-url=""
-				data-view-breakpoint-pointer="aabbccddee"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container" >
+	<div
+		 class="tribe-common tribe-events tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="1122334455"
+		data-view-rest-url="https://rest.tri.be/"
+		data-view-manage-url=""
+							data-view-breakpoint-pointer="aabbccddee"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		{}
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"reflector","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Reflector_View","view_slug":"reflector","view_label":"Reflector","events":[8,9],"is_initial_load":true,"rest_url":"https:\\/\\/rest.tri.be\\/","rest_nonce":"1122334455","should_manage_url":false,"container_classes":["tribe-common","tribe-events","tribe-events-widget"],"container_data":[],"breakpoint_pointer":"aabbccddee","messages":[],"hide_if_no_upcoming_events":false,"view_more_link":"https:\\/\\/test.tri.be\\/","view_more_text":"View More","view_more_title":"View more events.","widget_title":"Upcoming Events"}</script>
+			{}
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"reflector","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Reflector_View","view_slug":"reflector","view_label":"Reflector","events":[8,9],"is_initial_load":true,"rest_url":"https:\\/\\/rest.tri.be\\/","rest_nonce":"1122334455","should_manage_url":false,"container_classes":["tribe-common","tribe-events","tribe-events-widget"],"compatibility_classes":["tribe-compatibility-container"],"container_data":[],"breakpoint_pointer":"aabbccddee","messages":[],"hide_if_no_upcoming_events":false,"view_more_link":"https:\\/\\/test.tri.be\\/","view_more_text":"View More","view_more_title":"View more events.","widget_title":"Upcoming Events"}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-				Upcoming Events			</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+					Upcoming Events				</h2>
+			</header>
 
-		
-			<div class="tribe-events-widget-events-list__events">
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
+			
+				<div class="tribe-events-widget-events-list__events">
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -30,7 +31,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -55,7 +56,7 @@
 	</div>
 
 </div>
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -67,7 +68,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-9 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-9 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -92,9 +93,9 @@
 	</div>
 
 </div>
-							</div>
+									</div>
 
-			<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+				<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
 	<a
 		href="https://test.tri.be/"
 		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
@@ -103,9 +104,9 @@
 		View More	</a>
 </div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
@@ -258,7 +258,7 @@
 	>
 		1:00 pm	</time>
 </div>
-				<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-904385349785 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-day__event--featured" >
+				<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-904385349785 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-day__event--featured" >
 	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
 
 		
@@ -296,7 +296,7 @@
 </article>
 
 							
-												<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-349589759485 tribe_events type-tribe_events status-publish hentry" >
+												<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-349589759485 tribe_events type-tribe_events status-publish hentry entry" >
 	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
 
 		
@@ -325,7 +325,7 @@
 </article>
 
 							
-												<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-340934095850 tribe_events type-tribe_events status-publish hentry" >
+												<article  class="tribe-common-g-row tribe-common-g-row--gutters tribe-events-calendar-day__event post-340934095850 tribe_events type-tribe_events status-publish hentry entry" >
 	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
 
 		

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
@@ -283,7 +283,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 
@@ -328,7 +328,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
@@ -283,7 +283,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 
@@ -328,7 +328,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
@@ -280,7 +280,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-89 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 
@@ -325,7 +325,7 @@
 </div>
 
 	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -273,7 +273,7 @@
 </div>
 
 	<div class="tribe-events-calendar-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-list__event-details tribe-common-g-col">
 
@@ -323,7 +323,7 @@
 </div>
 
 	<div class="tribe-events-calendar-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-calendar-list__event tribe-common-g-row tribe-common-g-row--gutters post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			
 			<div class="tribe-events-calendar-list__event-details tribe-common-g-col">
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -462,7 +462,7 @@
 			
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-234234234 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month__calendar-event--featured" >
+<article  class="tribe-events-calendar-month__calendar-event post-234234234 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month__calendar-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">
@@ -529,7 +529,7 @@
 
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-2453454355 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-2453454355 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">
@@ -582,7 +582,7 @@
 
 	
 	
-<article  class="tribe-events-calendar-month__calendar-event post-3094853477 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month__calendar-event post-3094853477 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month__calendar-event-details">
@@ -2274,7 +2274,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-234234234 tribe_events type-tribe_events status-publish hentry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-234234234 tribe_events type-tribe_events status-publish hentry entry tribe-events-calendar-month-mobile-events__mobile-event--featured" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -2307,7 +2307,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-2453454355 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-2453454355 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">
@@ -2331,7 +2331,7 @@
 
 			
 		
-<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-3094853477 tribe_events type-tribe_events status-publish hentry" >
+<article  class="tribe-events-calendar-month-mobile-events__mobile-event post-3094853477 tribe_events type-tribe_events status-publish hentry entry" >
 
 	
 	<div class="tribe-events-calendar-month-mobile-events__mobile-event-details">

--- a/tests/views_ui/MainQueryRenderCest.php
+++ b/tests/views_ui/MainQueryRenderCest.php
@@ -12,7 +12,7 @@ class MainQueryRenderCest {
 	}
 
 	/**
-	 * @test
+	 * @skip
 	 */
 	public function should_correctly_render_a_mock_list_view( Tester $I, $scenario ) {
 		$I->comment( 'Skipped due to revision to how basic template should work' );

--- a/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_empty__1.php
+++ b/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_empty__1.php
@@ -1,23 +1,24 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="2ab7cc6b39"
-	data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
-	data-view-manage-url="1"
-				data-view-breakpoint-pointer="random-id"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container tribe-theme-twentytwentyone tribe-theme-child-twentytwenty" >
+	<div
+		 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="2ab7cc6b39"
+		data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
+		data-view-manage-url="1"
+							data-view-breakpoint-pointer="random-id"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"widget-events-list","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":{"notice":["There are no upcoming events."]},"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
+			
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"widget-events-list","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":{"notice":["There are no upcoming events."]},"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"compatibility_classes":["tribe-compatibility-container","tribe-theme-twentytwentyone","tribe-theme-child-twentytwenty"],"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-							</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+									</h2>
+			</header>
 
-		
-			<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2" >
+			
+				<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2" >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
 			<ul class="tribe-events-c-messages__message-list">
@@ -27,9 +28,9 @@
 		</div>
 	</div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_json_with_upcoming_events__1.php
+++ b/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_json_with_upcoming_events__1.php
@@ -1,26 +1,27 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="2ab7cc6b39"
-	data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
-	data-view-manage-url="1"
-				data-view-breakpoint-pointer="random-id"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container tribe-theme-twentytwentyone tribe-theme-child-twentytwenty" >
+	<div
+		 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="2ab7cc6b39"
+		data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
+		data-view-manage-url="1"
+							data-view-breakpoint-pointer="random-id"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		<script type="application/ld+json">
+			<script type="application/ld+json">
 [{"@context":"http://schema.org","@type":"Event","name":"Test Event &#8211; +9 days","description":"","url":"http://test.tri.be/?tribe_events=test-event-9-days-2%2F","startDate":"2019-06-20T13:01:20+00:00","endDate":"2019-06-20T17:01:20+00:00","performer":"Organization"},{"@context":"http://schema.org","@type":"Event","name":"Single Event 1","description":"","url":"http://test.tri.be/?tribe_events=single-event-1%2F","startDate":"2019-06-20T13:04:08+00:00","endDate":"2019-06-20T17:04:08+00:00","performer":"Organization"}]
 </script>
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":1,"display":[],"_context":{"slug":"widget-events-list"}}</script>
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"compatibility_classes":["tribe-compatibility-container","tribe-theme-twentytwentyone","tribe-theme-child-twentytwenty"],"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":1,"display":[],"_context":{"slug":"widget-events-list"}}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-							</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+									</h2>
+			</header>
 
-		
-			<div class="tribe-events-widget-events-list__events">
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
+			
+				<div class="tribe-events-widget-events-list__events">
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -32,7 +33,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -66,7 +67,7 @@
 	</div>
 
 </div>
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -78,7 +79,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -103,9 +104,9 @@
 	</div>
 
 </div>
-							</div>
+									</div>
 
-			<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+				<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
 	<a
 		href="http://test.tri.be/events/"
 		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
@@ -114,9 +115,9 @@
 		View More	</a>
 </div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_no_json_with_upcoming_events__1.php
+++ b/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_no_json_with_upcoming_events__1.php
@@ -1,24 +1,25 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="2ab7cc6b39"
-	data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
-	data-view-manage-url="1"
-				data-view-breakpoint-pointer="random-id"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container tribe-theme-twentytwentyone tribe-theme-child-twentytwenty" >
+	<div
+		 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="2ab7cc6b39"
+		data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
+		data-view-manage-url="1"
+							data-view-breakpoint-pointer="random-id"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
+			
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"compatibility_classes":["tribe-compatibility-container","tribe-theme-twentytwentyone","tribe-theme-child-twentytwenty"],"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-							</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+									</h2>
+			</header>
 
-		
-			<div class="tribe-events-widget-events-list__events">
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
+			
+				<div class="tribe-events-widget-events-list__events">
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -30,7 +31,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -64,7 +65,7 @@
 	</div>
 
 </div>
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -76,7 +77,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -101,9 +102,9 @@
 	</div>
 
 </div>
-							</div>
+									</div>
 
-			<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+				<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
 	<a
 		href="http://test.tri.be/events/"
 		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
@@ -112,9 +113,9 @@
 		View More	</a>
 </div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_with_featured_upcoming_events__1.php
+++ b/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_with_featured_upcoming_events__1.php
@@ -1,26 +1,27 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="2ab7cc6b39"
-	data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
-	data-view-manage-url="1"
-				data-view-breakpoint-pointer="random-id"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container tribe-theme-twentytwentyone tribe-theme-child-twentytwenty" >
+	<div
+		 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="2ab7cc6b39"
+		data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
+		data-view-manage-url="1"
+							data-view-breakpoint-pointer="random-id"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		<script type="application/ld+json">
+			<script type="application/ld+json">
 [{"@context":"http://schema.org","@type":"Event","name":"Test Event &#8211; +9 days","description":"","url":"http://test.tri.be/?tribe_events=test-event-9-days-2%2F","startDate":"2019-06-20T13:01:20+00:00","endDate":"2019-06-20T17:01:20+00:00","performer":"Organization"}]
 </script>
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"widget-events-list","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&featured=1","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&featured=1","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/featured\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01\\/featured\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/featured\\/","view_label":"Day"}},"show_latest_past":false,"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"widget-events-list","prev_url":"","next_url":"","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&featured=1","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&featured=1","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/featured\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01\\/featured\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/featured\\/","view_label":"Day"}},"show_latest_past":false,"compatibility_classes":["tribe-compatibility-container","tribe-theme-twentytwentyone","tribe-theme-child-twentytwenty"],"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-							</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+									</h2>
+			</header>
 
-		
-			<div class="tribe-events-widget-events-list__events">
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
+			
+				<div class="tribe-events-widget-events-list__events">
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -32,7 +33,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -66,9 +67,9 @@
 	</div>
 
 </div>
-							</div>
+									</div>
 
-			<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+				<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
 	<a
 		href="http://test.tri.be/events/"
 		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
@@ -77,9 +78,9 @@
 		View More	</a>
 </div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {

--- a/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_widgets/Tribe/Events/Views/V2/Widgets/__snapshots__/Widget_ListTest__test_render_with_upcoming_events__1.php
@@ -1,26 +1,27 @@
-<?php return '<div
-	 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 	data-js="tribe-events-view"
-	data-view-rest-nonce="2ab7cc6b39"
-	data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
-	data-view-manage-url="1"
-				data-view-breakpoint-pointer="random-id"
-	>
-	<div class="tribe-events-widget-events-list">
+<?php return '<div  class="tribe-compatibility-container tribe-theme-twentytwentyone tribe-theme-child-twentytwenty" >
+	<div
+		 class="tribe-common tribe-events tribe-events-view tribe-events-view--widget-events-list tribe-events-widget" 		data-js="tribe-events-view"
+		data-view-rest-nonce="2ab7cc6b39"
+		data-view-rest-url="http://test.tri.be/index.php?rest_route=/tribe/views/v2/html"
+		data-view-manage-url="1"
+							data-view-breakpoint-pointer="random-id"
+			>
+		<div class="tribe-events-widget-events-list">
 
-		<script type="application/ld+json">
+			<script type="application/ld+json">
 [{"@context":"http://schema.org","@type":"Event","name":"Test Event &#8211; +9 days","description":"","url":"http://test.tri.be/?tribe_events=test-event-9-days-2%2F","startDate":"2019-06-20T13:01:20+00:00","endDate":"2019-06-20T17:01:20+00:00","performer":"Organization"},{"@context":"http://schema.org","@type":"Event","name":"Single Event 1","description":"","url":"http://test.tri.be/?tribe_events=single-event-1%2F","startDate":"2019-06-20T13:04:08+00:00","endDate":"2019-06-20T17:04:08+00:00","performer":"Organization"}]
 </script>
-		<script data-js="tribe-events-view-data" type="application/json">
-	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
+			<script data-js="tribe-events-view-data" type="application/json">
+	{"slug":"widget-events-list","prev_url":"","next_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list&page=2","view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Widgets\\\\Widget_List_View","view_slug":"widget-events-list","view_label":"Widget-events-list","title":"The Events Calendar Tests","events":[7,8],"url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","url_event_date":"2019-01-01","bar":{"keyword":"","date":"2019-01-01 09:00:00"},"today":"2019-01-01 09:00:00","now":"2019-01-01 09:00:00","rest_url":"http:\\/\\/test.tri.be\\/index.php?rest_route=\\/tribe\\/views\\/v2\\/html","rest_method":"POST","rest_nonce":"2ab7cc6b39","should_manage_url":true,"today_url":"http:\\/\\/test.tri.be\\/?post_type=tribe_events&eventDisplay=widget-events-list","prev_label":"","next_label":"","date_formats":{"compact":"n\\/j\\/Y","month_and_year_compact":"n\\/j\\/Y","month_and_year":"F Y","time_range_separator":" - ","date_time_separator":" @ "},"messages":[],"start_of_week":"1","breadcrumbs":[],"before_events":"<div id=\\"tribe-events\\" class=\\"tribe-no-js\\" data-live_ajax=\\"1\\" data-datepicker_format=\\"1\\" data-category=\\"\\" data-featured=\\"\\">","after_events":"<\\/div><!-- #tribe-events -->\\n<!--\\nThis calendar is powered by The Events Calendar.\\nhttp:\\/\\/evnt.is\\/18wn\\n-->\\n","display_events_bar":false,"disable_event_search":false,"live_refresh":true,"ical":{"display_link":true,"link":{"url":"http:\\/\\/test.tri.be\\/events\\/?ical=1","text":"Export Events","title":"Use this to share calendar data with Google Calendar, Apple iCal and other compatible apps"}},"container_classes":["tribe-common","tribe-events","tribe-events-view","tribe-events-view--widget-events-list","tribe-events-widget"],"container_data":[],"is_past":false,"breakpoints":{"xsmall":500,"medium":768,"full":960},"breakpoint_pointer":"random-id","is_initial_load":true,"public_views":{"list":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\List_View","view_url":"http:\\/\\/test.tri.be\\/events\\/list\\/?tribe-bar-date=2019-01-01","view_label":"List"},"month":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Month_View","view_url":"http:\\/\\/test.tri.be\\/events\\/month\\/2019-01\\/","view_label":"Month"},"day":{"view_class":"Tribe\\\\Events\\\\Views\\\\V2\\\\Views\\\\Day_View","view_url":"http:\\/\\/test.tri.be\\/events\\/2019-01-01\\/","view_label":"Day"}},"show_latest_past":false,"compatibility_classes":["tribe-compatibility-container","tribe-theme-twentytwentyone","tribe-theme-child-twentytwenty"],"view_more_text":"View More","view_more_title":"View more events.","view_more_link":"http:\\/\\/test.tri.be\\/events\\/","widget_title":null,"hide_if_no_upcoming_events":null,"jsonld_enable":0,"display":[],"_context":{"slug":"widget-events-list"}}</script>
 
-		<header class="tribe-events-widget-events-list__header">
-			<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
-							</h2>
-		</header>
+			<header class="tribe-events-widget-events-list__header">
+				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+									</h2>
+			</header>
 
-		
-			<div class="tribe-events-widget-events-list__events">
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
+			
+				<div class="tribe-events-widget-events-list__events">
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row tribe-events-widget-events-list__event-row--featured" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -32,7 +33,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-7 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -66,7 +67,7 @@
 	</div>
 
 </div>
-									<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
+											<div  class="tribe-common-g-row tribe-events-widget-events-list__event-row" >
 
 	<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="2019-06-20">
@@ -78,7 +79,7 @@
 </div>
 
 	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry" >
+		<article  class="tribe-events-widget-events-list__event post-8 tribe_events type-tribe_events status-publish hentry entry" >
 			<div class="tribe-events-widget-events-list__event-details">
 
 				<header class="tribe-events-widget-events-list__event-header">
@@ -103,9 +104,9 @@
 	</div>
 
 </div>
-							</div>
+									</div>
 
-			<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+				<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
 	<a
 		href="http://test.tri.be/events/"
 		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
@@ -114,9 +115,9 @@
 		View More	</a>
 </div>
 
-			</div>
+					</div>
+	</div>
 </div>
-
 <script class="tribe-events-breakpoints">
 	(function(){
 		if ( \'undefined\' === typeof window.tribe ) {


### PR DESCRIPTION
This adds a wrapper around the list widget view container that we add compatibility classes to.

The removes the need to add a body class - as the widgets show up in places where we can't be guaranteed the body class will be applied. The hope is that this will remove the need for widgets and widget shortcodes to add body classes, and eventually for _any_ view to add body classes - let's stop relying on _unreliable_ globals ;)

See also https://github.com/the-events-calendar/events-pro/pull/1701 for use on ECP widgets.

Passing tests are artifact enough, but here are the widgets without the url underline enforced by 2021: https://d.pr/i/mahdYO