### PR TITLE
Manager JS using `defer`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Version - The Events Calendar 5.4.0 is only compatible with Events Calendar PRO 5.3.0 and higher
 * Fix - Compatibility with WordPress 5.7 and jQuery 3.5.X
+* Fix - Updated views JavaScript manager is now deferred to the end of the request, to make sure all dependencies are loaded.
 * Fix - Navigation for the Views will no longer use current browser URL as previous url, preventing problems on shortcodes.
 * Fix - Latest Past view moved to not publicly visible, which was the intended behavior.
 * Tweak - Add compatibility container to widgets - to allow for a non-body target for compatibility classes.

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -189,9 +189,10 @@ class Assets extends \tad_DI52_ServiceProvider {
 			],
 			'wp_enqueue_scripts',
 			[
-				'priority'     => 20,
+				'priority'     => 200,
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key ],
+				'defer'        => true,
 			]
 		);
 

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -187,9 +187,9 @@ class Assets extends \tad_DI52_ServiceProvider {
 				'tribe-query-string',
 				'underscore',
 			],
-			'wp_enqueue_scripts',
+			'wp_print_footer_scripts',
 			[
-				'priority'     => 200,
+				'priority'     => 9, // for `wp_print_footer_scripts` we are required to go before P10.
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key ],
 				'defer'        => true,

--- a/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
+++ b/src/Tribe/Views/V2/Widgets/Widget_Abstract.php
@@ -51,8 +51,6 @@ abstract class Widget_Abstract extends \Tribe\Widget\Widget_Abstract {
 
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'filter_widget_template_vars' ], 20, 2 );
 		add_filter( "tribe_events_views_v2_view{$this->view_slug}_template_vars", [ $this, 'filter_widget_template_vars' ], 20, 2 );
-		// Dequeue and enqueue manager JS to ensure it is the last JS file to be added.
-		add_action( 'tribe_events_views_v2_widget_after_enqueue_assets', [ $this, 'action_enqueue_manager' ], 10, 3 );
 	}
 
 	/**
@@ -188,24 +186,6 @@ abstract class Widget_Abstract extends \Tribe\Widget\Widget_Abstract {
 	public function enqueue_assets( $context, $view ) {
 		// Ensure we also have all the other things from Tribe\Events\Views\V2\Assets we need.
 		tribe_asset_enqueue_group( Assets::$widget_group_key );
-	}
-
-	/**
-	 * Dequeues and enqueues the manager JS.
-	 *
-	 * @since 5.4.0
-	 *
-	 * @param boolean         $should_enqueue Whether assets are enqueued or not.
-	 * @param \Tribe__Context $context        Context we are using to build the view.
-	 * @param View_Interface  $view           Which view we are using the template on.
-	 */
-	public function action_enqueue_manager( $should_enqueue, $context, $view ) {
-		if ( ! $should_enqueue ) {
-			return;
-		}
-
-		wp_dequeue_script( 'tribe-events-views-v2-manager' );
-		tribe_asset_enqueue( 'tribe-events-views-v2-manager' );
 	}
 
 	/**

--- a/src/resources/js/views/datepicker.js
+++ b/src/resources/js/views/datepicker.js
@@ -1,9 +1,10 @@
+/* globals tribe, jQuery */
 /**
  * Makes sure we have all the required levels on the Tribe Object
  *
  * @since 4.9.5
  *
- * @type {PlainObject}
+ * @type {Object}
  */
 tribe.events = tribe.events || {};
 tribe.events.views = tribe.events.views || {};
@@ -13,7 +14,7 @@ tribe.events.views = tribe.events.views || {};
  *
  * @since 4.9.5
  *
- * @type {PlainObject}
+ * @type {Object}
  */
 tribe.events.views.datepicker = {};
 
@@ -22,8 +23,8 @@ tribe.events.views.datepicker = {};
  *
  * @since 4.9.5
  *
- * @param  {PlainObject} $   jQuery
- * @param  {PlainObject} obj tribe.events.views.datepicker
+ * @param  {Object} $   jQuery
+ * @param  {Object} obj tribe.events.views.datepicker
  *
  * @return {void}
  */
@@ -36,7 +37,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 4.9.5
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 */
 	obj.selectors = {
 		datepickerFormClass: '.tribe-events-c-top-bar__datepicker-form',
@@ -55,7 +56,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 4.9.5
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 */
 	obj.state = {
 		initialized: false,
@@ -66,7 +67,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 4.9.10
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 */
 	obj.options = {
 		container: null,
@@ -86,7 +87,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 5.0.0
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 */
 	obj.keyCode = {
 		ENTER: 13,
@@ -107,7 +108,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 4.9.11
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 *
 	 * @see https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
 	 */
@@ -294,7 +295,7 @@ tribe.events.views.datepicker = {};
 	 * @return {void}
 	 */
 	obj.handleHide = function( event ) {
-		var $datepickerButton = event.data.datepickerButton
+		var $datepickerButton = event.data.datepickerButton;
 		var state = $datepickerButton.data( 'tribeEventsState' );
 
 		event.data.observer.disconnect();
@@ -375,7 +376,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @since 4.9.7
 	 *
-	 * @param {PlainObject} data data object to be passed for use in handler
+	 * @param {Object} data data object to be passed for use in handler
 	 *
 	 * @return {function}
 	 */
@@ -562,7 +563,7 @@ tribe.events.views.datepicker = {};
 	 *
 	 * @param  {Event}       event    event object for 'beforeAjaxSuccess.tribeEvents' event
 	 * @param  {jqXHR}       jqXHR    Request object
-	 * @param  {PlainObject} settings Settings that this request was made with
+	 * @param  {Object} settings Settings that this request was made with
 	 *
 	 * @return {void}
 	 */
@@ -627,8 +628,8 @@ tribe.events.views.datepicker = {};
 		var datepickerI18n = tribeL10nDatatables.datepicker || {};
 		var nextText = datepickerI18n.nextText || 'Next';
 		var prevText = datepickerI18n.prevText || 'Prev';
-		obj.options.templates.leftArrow = $prevIcon + '<span class="tribe-common-a11y-visual-hide">' + prevText + '</span>',
-		obj.options.templates.rightArrow = $nextIcon + '<span class="tribe-common-a11y-visual-hide">' + nextText + '</span>',
+		obj.options.templates.leftArrow = $prevIcon + '<span class="tribe-common-a11y-visual-hide">' + prevText + '</span>';
+		obj.options.templates.rightArrow = $nextIcon + '<span class="tribe-common-a11y-visual-hide">' + nextText + '</span>';
 		obj.options.beforeShowDay = obj.filterDayCells;
 		obj.options.beforeShowMonth = obj.filterMonthCells;
 		obj.options.beforeShowYear = obj.filterYearCells;

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -1,9 +1,10 @@
+/* globals tribe, jQuery */
 /**
  * Makes sure we have all the required levels on the Tribe Object
  *
  * @since  4.9.2
  *
- * @type   {PlainObject}
+ * @type   {Object}
  */
 tribe.events = tribe.events || {};
 tribe.events.views = tribe.events.views || {};
@@ -13,7 +14,7 @@ tribe.events.views = tribe.events.views || {};
  *
  * @since  4.9.2
  *
- * @type   {PlainObject}
+ * @type   {Object}
  */
 tribe.events.views.manager = {};
 
@@ -22,9 +23,9 @@ tribe.events.views.manager = {};
  *
  * @since  4.9.2
  *
- * @param  {PlainObject} $   jQuery
- * @param  {PlainObject} _   Underscore.js
- * @param  {PlainObject} obj tribe.events.views.manager
+ * @param  {Object} $   jQuery
+ * @param  {Object} _   Underscore.js
+ * @param  {Object} obj tribe.events.views.manager
  *
  * @return {void}
  */
@@ -37,7 +38,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.2
 	 *
-	 * @type {PlainObject}
+	 * @type {Object}
 	 */
 	obj.selectors = {
 		container: '[data-js="tribe-events-view"]',
@@ -126,7 +127,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @todo  Requirement to setup other JS modules after hijacking Click and Submit
 	 *
-	 * @param  {integer}        index     jQuery.each index param
+	 * @param  {Integer}        index     jQuery.each index param
 	 * @param  {Element|jQuery} container Which element we are going to setup
 	 *
 	 * @return {void}
@@ -200,7 +201,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.4
 	 *
-	 * @param  {Element|jQuery} element Which element we are using as the container.
+	 * @param  {Element|jQuery} $container Which element we are using as the container.
 	 *
 	 * @return {Boolean}
 	 */
@@ -466,7 +467,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @param  {Element|jQuery} $container Which container we are dealing with
 	 *
-	 * @return {PlainObject}
+	 * @return {Object}
 	 */
 	obj.getAjaxSettings = function( $container ) {
 		var ajaxSettings = {
@@ -495,7 +496,7 @@ tribe.events.views.manager = {};
 	 * @since 4.9.2
 	 *
 	 * @param  {jqXHR}       jqXHR    Request object
-	 * @param  {PlainObject} settings Settings that this request will be made with
+	 * @param  {Object} settings Settings that this request will be made with
 	 *
 	 * @return {void}
 	 */
@@ -607,7 +608,7 @@ tribe.events.views.manager = {};
 	 * @since 4.9.2
 	 *
 	 * @param  {jqXHR}       jqXHR    Request object
-	 * @param  {PlainObject} settings Settings that this request was made with
+	 * @param  {Object} settings Settings that this request was made with
 	 *
 	 * @return {void}
 	 */
@@ -628,10 +629,11 @@ tribe.events.views.manager = {};
 	 *
 	 * @since  4.9.12
 	 *
-	 * @return {void}
+	 * @return {jQuery} Which containers were selected.
 	 */
 	obj.selectContainers = function() {
 		obj.$containers = $( obj.selectors.container );
+		return obj.$containers;
 	};
 
 	/**
@@ -639,7 +641,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since  4.9.12
 	 *
-	 * @return {jQuery}
+	 * @return {jQuery} Last container element.
 	 */
 	obj.getLastContainer = function() {
 		/**
@@ -650,7 +652,7 @@ tribe.events.views.manager = {};
 		}
 
 		return obj.$lastContainer;
-	}
+	};
 
 	/**
 	 * Handles the initialization of the manager when Document is ready.
@@ -660,8 +662,7 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ready = function() {
-		obj.selectContainers();
-		obj.$containers.each( obj.setup );
+		obj.selectContainers().each( obj.setup );
 	};
 
 	// Configure on document ready.


### PR DESCRIPTION
#3426 introduced a problem related to the Manager not being enqueued in the correct time. Depending on the order of how your Widgets/Shortcodes are rendered in the screen it breaks the manager, to resolve that problem we stop messing with the actual enqueuing and defer the execution on a browser level.

Depends on https://github.com/the-events-calendar/tribe-common/pull/1549
Video: https://i.bordoni.me/yAu6kmN6
