### PR TITLE
Remove field

### DIFF
--- a/src/modules/blocks/event-datetime/content/template.js
+++ b/src/modules/blocks/event-datetime/content/template.js
@@ -21,7 +21,7 @@ import {
 	date,
 	moment as momentUtil,
 } from '@moderntribe/common/utils';
-import { editor, settings, wpHooks } from '@moderntribe/common/utils/globals';
+import { settings, wpHooks } from '@moderntribe/common/utils/globals';
 import HumanReadableInput from '../human-readable-input/container';
 
 /**
@@ -70,29 +70,6 @@ const renderSeparator = ( props, type, className ) => {
 		default:
 			return null;
 	}
-};
-
-const renderPrice = ( { cost, currencyPosition, currencySymbol, setCost } ) => {
-	// Bail when not classic
-	if ( ! editor() || ! editor().isClassic ) {
-		return null;
-	}
-
-	return (
-		<div
-			key="tribe-editor-event-cost"
-			className="tribe-editor__event-cost"
-		>
-			{ 'prefix' === currencyPosition && <span>{ currencySymbol }</span> }
-			<PlainText
-				className={ classNames( 'tribe-editor__event-cost__value', `tribe-editor-cost-symbol-position-${ currencyPosition }` ) }
-				value={ cost }
-				placeholder={ __( 'Enter price', 'the-events-calendar' ) }
-				onChange={ setCost }
-			/>
-			{ 'suffix' === currencyPosition && <span>{ currencySymbol }</span> }
-		</div>
-	);
 };
 
 const renderStartDate = ( { start, end } ) => {
@@ -176,7 +153,6 @@ const renderTimezone = ( props ) => {
 const renderExtras = ( props ) => (
 	<Fragment>
 		{ renderTimezone( props ) }
-		{ renderPrice( props ) }
 	</Fragment>
 );
 


### PR DESCRIPTION
**Description:** Removes the price field inside the datetime block for events migrated from the Classic editor to the Blocks editor.

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3458

**Screenshots:**

![tec tribe_wp-admin_post php_post=668 action=edit](https://user-images.githubusercontent.com/5049893/109313733-d3b89580-7848-11eb-8621-28726274bc39.png)

![tec tribe_wp-admin_post php_post=668 action=edit (1)](https://user-images.githubusercontent.com/5049893/109313754-dca96700-7848-11eb-9f14-e1f9a5f39a90.png)
