### PR TITLE
Fix / TEC-3418 - deprecated warnings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Use filterable attributes for the view more link and text. Add customizer styling for the link. [ECP-568]
 * Tweak - Removed `tribe_events_views_v2_widget_admin_form_{$field_type}_input` from the List Widget admin form in favor of using `Tribe__Template::do_entry_point()` [ECP-486]
 * Tweak - Moved administration templates for List Widget components to Common. [ECP-486]
+* Language - 1 new strings added, 10 updated, 1 fuzzied, and 0 obsoleted
 
 = [5.3.2.1] 2021-02-02 =
 

--- a/src/modules/blocks/classic-event-details/container.js
+++ b/src/modules/blocks/classic-event-details/container.js
@@ -72,7 +72,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	toggleDashboardDateTime: () => {
 		// there may be a better way to do this, but for now there's no way to access context
 		// outside of the provider.
-		const blocks = globals.wpDataSelectCoreEditor.getBlocks();
+		const blocks = globals.wpDataSelectCoreEditor().getBlocks();
 
 		const filteredBlocks = blocks.filter( ( block ) => {
 			return block.name === `tribe/${ dateTimeBlock.id }`;

--- a/src/modules/blocks/classic-event-details/container.js
+++ b/src/modules/blocks/classic-event-details/container.js
@@ -72,7 +72,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	toggleDashboardDateTime: () => {
 		// there may be a better way to do this, but for now there's no way to access context
 		// outside of the provider.
-		const blocks = globals.wpData.select( 'core/editor' ).getBlocks();
+		const blocks = globals.wpDataSelectCoreEditor.getBlocks();
 
 		const filteredBlocks = blocks.filter( ( block ) => {
 			return block.name === `tribe/${ dateTimeBlock.id }`;

--- a/src/modules/blocks/classic-event-details/event-details-organizers/event-details-organizer/template.js
+++ b/src/modules/blocks/classic-event-details/event-details-organizers/event-details-organizer/template.js
@@ -9,12 +9,13 @@ import { unescape, trim, isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dashicon, IconButton } from '@wordpress/components';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { Loading } from '@moderntribe/events/elements';
+import { IconButton } from '@moderntribe/common/utils/globals';
 import './style.pcss';
 
 /**

--- a/src/modules/blocks/classic-event-details/event-details-organizers/template.js
+++ b/src/modules/blocks/classic-event-details/event-details-organizers/template.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton, Dashicon } from '@wordpress/components';
+import { Dropdown, Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,6 +17,7 @@ import { Dropdown, IconButton, Dashicon } from '@wordpress/components';
 import { OrganizerForm, SearchPosts } from '@moderntribe/events/elements';
 import EventDetailsOrganizer from './event-details-organizer/container';
 import { editor } from '@moderntribe/common/data';
+import { IconButton } from '@moderntribe/common/utils/globals';
 
 const EventDetailsOrganizers = ( props ) => {
 	const renderDropdownToggle = ( { onToggle } ) => (

--- a/src/modules/blocks/classic-event-details/template.js
+++ b/src/modules/blocks/classic-event-details/template.js
@@ -11,14 +11,15 @@ import AutosizeInput from 'react-input-autosize';
  */
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
-import { PlainText, InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
 import { date, moment as momentUtil } from '@moderntribe/common/utils';
+import { wpEditor } from '@moderntribe/common/utils/globals';
 import { TermsList, MetaGroup } from '@moderntribe/events/elements';
 import EventDetailsOrganizers from './event-details-organizers/container';
+const { PlainText, InspectorControls } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-datetime/content/template.js
+++ b/src/modules/blocks/event-datetime/content/template.js
@@ -9,7 +9,6 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PlainText } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -21,8 +20,9 @@ import {
 	date,
 	moment as momentUtil,
 } from '@moderntribe/common/utils';
-import { editor, settings, wpHooks } from '@moderntribe/common/utils/globals';
+import { editor, settings, wpEditor, wpHooks } from '@moderntribe/common/utils/globals';
 import HumanReadableInput from '../human-readable-input/container';
+const { PlainText } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-datetime/controls/template.js
+++ b/src/modules/blocks/event-datetime/controls/template.js
@@ -14,7 +14,6 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -22,6 +21,8 @@ import { InspectorControls } from '@wordpress/editor';
 import {
 	date,
 } from '@moderntribe/common/utils';
+import { wpEditor } from '@moderntribe/common/utils/globals';
+const { InspectorControls } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-links/template.js
+++ b/src/modules/blocks/event-links/template.js
@@ -9,7 +9,6 @@ import AutosizeInput from 'react-input-autosize';
  * WordPress dependencies
  */
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -17,7 +16,9 @@ import { __ } from '@wordpress/i18n';
  */
 import { Link as LinkIcon } from '@moderntribe/events/icons';
 import { input } from '@moderntribe/common/utils';
+import { wpEditor } from '@moderntribe/common/utils/globals';
 import './style.pcss';
+const { InspectorControls } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-organizer/container.js
+++ b/src/modules/blocks/event-organizer/container.js
@@ -81,7 +81,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 			ownProps.setAttributes( { organizer: 0 } );
 			dispatch( actions.removeOrganizerInBlock( clientId, organizer ) );
 
-			const blocks = globals.wpData.select( 'core/editor' ).getBlocks();
+			const blocks = globals.wpDataSelectCoreEditor.getBlocks();
 			const classicBlock = blocks.filter( block => block.name === `tribe/${ classicEventDetailsBlock.id }` );
 
 			if ( ! classicBlock.length || volatile ) {

--- a/src/modules/blocks/event-organizer/container.js
+++ b/src/modules/blocks/event-organizer/container.js
@@ -81,7 +81,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 			ownProps.setAttributes( { organizer: 0 } );
 			dispatch( actions.removeOrganizerInBlock( clientId, organizer ) );
 
-			const blocks = globals.wpDataSelectCoreEditor.getBlocks();
+			const blocks = globals.wpDataSelectCoreEditor().getBlocks();
 			const classicBlock = blocks.filter( block => block.name === `tribe/${ classicEventDetailsBlock.id }` );
 
 			if ( ! classicBlock.length || volatile ) {

--- a/src/modules/blocks/event-organizer/form/template.js
+++ b/src/modules/blocks/event-organizer/form/template.js
@@ -10,7 +10,6 @@ import validator from 'validator';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { RichText } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 import './style.pcss';
@@ -18,6 +17,8 @@ import './style.pcss';
 /**
  * Internal dependencies
  */
+import { wpEditor } from '@moderntribe/common/utils/globals';
+const { RichText } = wpEditor;
 
 export default class OrganizerForm extends Component {
 	static defaultProps = {

--- a/src/modules/blocks/event-organizer/template.js
+++ b/src/modules/blocks/event-organizer/template.js
@@ -13,11 +13,11 @@ import {
 	PanelBody,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
+import { wpEditor } from '@moderntribe/common/utils/globals';
 import {
 	SearchOrCreate,
 	EditLink,
@@ -26,6 +26,7 @@ import OrganizerDetails from './details';
 import OrganizerForm from './form';
 import { Organizer as OrganizerIcon } from '@moderntribe/events/icons';
 import { toFields } from '@moderntribe/events/elements/organizer-form/utils';
+const InspectorControls = wpEditor;
 
 class EventOrganizer extends PureComponent {
 

--- a/src/modules/blocks/event-organizer/template.js
+++ b/src/modules/blocks/event-organizer/template.js
@@ -14,7 +14,6 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-
 /**
  * Internal dependencies
  */

--- a/src/modules/blocks/event-organizer/template.js
+++ b/src/modules/blocks/event-organizer/template.js
@@ -26,7 +26,7 @@ import OrganizerDetails from './details';
 import OrganizerForm from './form';
 import { Organizer as OrganizerIcon } from '@moderntribe/events/icons';
 import { toFields } from '@moderntribe/events/elements/organizer-form/utils';
-const InspectorControls = wpEditor;
+const { InspectorControls } = wpEditor;
 
 class EventOrganizer extends PureComponent {
 

--- a/src/modules/blocks/event-price/template.js
+++ b/src/modules/blocks/event-price/template.js
@@ -14,7 +14,6 @@ import {
 	TextControl,
 	PanelBody,
 } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -22,6 +21,8 @@ import { InspectorControls } from '@wordpress/editor';
 import { Dashboard } from '@moderntribe/events/elements';
 import { range } from '@moderntribe/common/utils';
 import './style.pcss';
+import { wpEditor } from '@moderntribe/common/utils/globals';
+const { InspectorControls } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -18,7 +18,6 @@ import {
 	PanelBody,
 	Dashicon,
 } from '@wordpress/components';
-import { InspectorControls } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -34,8 +33,9 @@ import { editor } from '@moderntribe/common/data';
 import VenueDetails from './venue-details';
 import { Venue as VenueIcon } from '@moderntribe/events/icons';
 import { utils } from '@moderntribe/events/data/blocks/venue';
-import { google } from '@moderntribe/common/utils/globals';
+import { google, wpEditor } from '@moderntribe/common/utils/globals';
 import './style.pcss';
+const { InspectorControls } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/blocks/event-website/template.js
+++ b/src/modules/blocks/event-website/template.js
@@ -10,13 +10,14 @@ import AutosizeInput from 'react-input-autosize';
  * WordPress dependencies
  */
 import { Dashicon } from '@wordpress/components';
-import { URLInput } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { wpEditor } from '@moderntribe/common/utils/globals';
 import './style.pcss';
+const { URLInput } = wpEditor;
 
 /**
  * Module Code

--- a/src/modules/data/blocks/organizers/subscribers.js
+++ b/src/modules/data/blocks/organizers/subscribers.js
@@ -155,7 +155,7 @@ export const onBlocksChangeListener = ( selector ) => {
 const subscribe = () => {
 	globals.wpData.subscribe(
 		onBlocksChangeListener(
-			globals.wpDataSelectCoreEditor.getBlocks()
+			globals.wpDataSelectCoreEditor().getBlocks
 		)
 	);
 };

--- a/src/modules/data/blocks/organizers/subscribers.js
+++ b/src/modules/data/blocks/organizers/subscribers.js
@@ -155,7 +155,7 @@ export const onBlocksChangeListener = ( selector ) => {
 const subscribe = () => {
 	globals.wpData.subscribe(
 		onBlocksChangeListener(
-			globals.wpData.select( 'core/editor' ).getBlocks
+			globals.wpDataSelectCoreEditor.getBlocks()
 		)
 	);
 };

--- a/src/modules/elements/search-posts/template.js
+++ b/src/modules/elements/search-posts/template.js
@@ -12,7 +12,6 @@ import { decode } from 'he';
  */
 import {
 	Dropdown,
-	IconButton,
 	Dashicon,
 	Spinner,
 	Placeholder,
@@ -21,6 +20,7 @@ import {
 /**
  * Internal dependencies
  */
+import { IconButton } from '@moderntribe/common/utils/globals';
 import './style.pcss';
 
 /**

--- a/src/modules/elements/venue-form/element.js
+++ b/src/modules/elements/venue-form/element.js
@@ -9,7 +9,6 @@ import { get, values, noop, pick } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -17,8 +16,9 @@ import { RichText } from '@wordpress/editor';
 import { Input } from '@moderntribe/events/elements';
 import list, { getCountries, getStates, getCountryCode, getStateCode } from '@moderntribe/events/editor/utils/geo-data';
 import { setDefault, getVenueCountry, getVenueStateProvince } from '@moderntribe/events/data/blocks/venue/utils';
-import { editorDefaults } from '@moderntribe/common/utils/globals';
+import { editorDefaults, wpEditor } from '@moderntribe/common/utils/globals';
 import './style.pcss';
+const { RichText } = wpEditor;
 
 export function toFields( venue ) {
 	const title = get( venue, 'title', {} );


### PR DESCRIPTION
**Description:** Fixes some deprecation warnings when using the block editor with the dev tools console open. It depends on https://github.com/the-events-calendar/tribe-common/pull/1554

**Note:** Some might still appear as they need a fix in the WordPress core:
- `Found 2 elements with non-unique id #_wpnonce` [development/production]
- React rename lifecycle methods (due to an old version of Redux used by core) [development]
- `Legacy context API has been detected within a strict-mode tree.` [development]

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3418