### PR TITLE
Feature / single event reskin website label

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -138,7 +138,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_events_get_event_website_title', '__return_empty_string' );
 		
 		add_filter( 'tribe_get_venue_website_link_label', [ $this, 'filter_single_event_details_venue_website_label' ], 10, 2 );
-		add_filter( 'tribe_events_get_venue_website_title', '__return_empty_string', 10 );
+		add_filter( 'tribe_events_get_venue_website_title', '__return_empty_string' );
 		
 		add_filter( 'tribe_get_organizer_website_link_label', [ $this, 'filter_single_event_details_organizer_website_label' ], 10, 2 );
 		add_filter( 'tribe_events_get_organizer_website_title', '__return_empty_string' );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -134,7 +134,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'customize_controls_print_styles', [ $this, 'enqueue_customizer_controls_styles' ] );
 		
 		// Add filter to change the display of website links on the Single Event template.
-		add_filter( 'tribe_events_single_event_details_website_label', [ $this, 'filter_single_event_details_website_label' ], 10, 2 );
+		add_filter( 'tribe_get_venue_website_link_label', [ $this, 'filter_single_event_details_website_label' ], 10, 2 );
 	}
 
 	/**
@@ -947,18 +947,23 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	}
 	
 	/**
-	 * Filter the website link label and change it for Single Event Classic Editor
+	 * Filter the website link label and change it for Single Event Classic Editor.
+	 * Use the following in functions.php to disable:
+	 * remove_filter( 'tribe_get_venue_website_link_label', [ tribe( 'events.views.v2.hooks' ), 'filter_single_event_details_website_label' ] );
 	 * 
 	 * @since TBD
 	 * 
-	 * @param string $label The filtered label.
+	 * @param string     $label The filtered label.
+	 * @param string|int $post_id The current post ID.
+	 * 
+	 * @return string
 	 */
-	public function filter_single_event_details_website_label( $label ) {
+	public function filter_single_event_details_website_label( $label, $post_id ) {
 		// If not V2 or not Classic Editor, return the website url.
-		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( get_queried_object_id() ) ) {
+		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( $post_id ) ) {
 			return $label;
 		}
 		
-		return esc_html__( 'View', 'the-events-calendar' );
+		return __( 'View', 'the-events-calendar' );
 	}
 }

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -132,6 +132,9 @@ class Hooks extends \tad_DI52_ServiceProvider {
 
 		// Register the asset for Customizer controls.
 		add_action( 'customize_controls_print_styles', [ $this, 'enqueue_customizer_controls_styles' ] );
+		
+		// Add filter to change the display of website links on the Single Event template.
+		add_filter( 'tribe_events_single_event_details_website_label', [ $this, 'filter_single_event_details_website_label' ], 10, 2 );
 	}
 
 	/**
@@ -941,5 +944,21 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	public function enqueue_customizer_controls_styles() {
 		return $this->container->make( Customizer::class )->enqueue_customizer_controls_styles();
+	}
+	
+	/**
+	 * Filter the website link label and change it for Single Event Classic Editor
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string $label The filtered label.
+	 */
+	public function filter_single_event_details_website_label( $label ) {
+		// If not V2 or not Classic Editor, return the website url.
+		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( get_queried_object_id() ) ) {
+			return $label;
+		}
+		
+		return esc_html__( 'View', 'the-events-calendar' );
 	}
 }

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -133,8 +133,15 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		// Register the asset for Customizer controls.
 		add_action( 'customize_controls_print_styles', [ $this, 'enqueue_customizer_controls_styles' ] );
 		
-		// Add filter to change the display of website links on the Single Event template.
-		add_filter( 'tribe_get_venue_website_link_label', [ $this, 'filter_single_event_details_website_label' ], 10, 2 );
+		// Add filters to change the display of website links on the Single Event template.
+		add_filter( 'tribe_get_event_website_link_label', [ $this, 'filter_single_event_details_event_website_label' ], 10, 2 );
+		add_filter( 'tribe_events_get_event_website_title', '__return_empty_string' );
+		
+		add_filter( 'tribe_get_venue_website_link_label', [ $this, 'filter_single_event_details_venue_website_label' ], 10, 2 );
+		add_filter( 'tribe_events_get_venue_website_title', '__return_empty_string', 10 );
+		
+		add_filter( 'tribe_get_organizer_website_link_label', [ $this, 'filter_single_event_details_organizer_website_label' ], 10, 2 );
+		add_filter( 'tribe_events_get_organizer_website_title', '__return_empty_string' );
 	}
 
 	/**
@@ -958,12 +965,54 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * 
 	 * @return string
 	 */
-	public function filter_single_event_details_website_label( $label, $post_id ) {
+	public function filter_single_event_details_event_website_label( $label, $post_id ) {
 		// If not V2 or not Classic Editor, return the website url.
 		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( $post_id ) ) {
 			return $label;
 		}
 		
-		return __( 'View', 'the-events-calendar' );
+		return __( 'View Event Website', 'the-events-calendar' );
+	}
+	
+		/**
+	 * Filter the website link label and change it for Single Event Classic Editor.
+	 * Use the following in functions.php to disable:
+	 * remove_filter( 'tribe_get_venue_website_link_label', [ tribe( 'events.views.v2.hooks' ), 'filter_single_event_details_website_label' ] );
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string     $label The filtered label.
+	 * @param string|int $post_id The current post ID.
+	 * 
+	 * @return string
+	 */
+	public function filter_single_event_details_venue_website_label( $label, $post_id ) {
+		// If not V2 or not Classic Editor, return the website url.
+		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( $post_id ) ) {
+			return $label;
+		}
+		
+		return __( 'View Venue Website', 'the-events-calendar' );
+	}
+	
+		/**
+	 * Filter the website link label and change it for Single Event Classic Editor.
+	 * Use the following in functions.php to disable:
+	 * remove_filter( 'tribe_get_venue_website_link_label', [ tribe( 'events.views.v2.hooks' ), 'filter_single_event_details_website_label' ] );
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string     $label The filtered label.
+	 * @param string|int $post_id The current post ID.
+	 * 
+	 * @return string
+	 */
+	public function filter_single_event_details_organizer_website_label( $label, $post_id ) {
+		// If not V2 or not Classic Editor, return the website url.
+		if ( ! tribe_events_single_view_v2_is_enabled() || has_blocks( $post_id ) ) {
+			return $label;
+		}
+		
+		return __( 'View Organizer Website', 'the-events-calendar' );
 	}
 }

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -363,6 +363,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 * Filter the target attribute for the event website link
 		 *
 		 * @since 5.1.0
+		 * @since TBD Added $event argument
 		 *
 		 * @param string          $target The target attribute string. Defaults to "_self".
 		 * @param string          $url    The link URL.
@@ -380,7 +381,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			 *
 			 * @param string the link label/text.
 			 */
-			$label = apply_filters( 'tribe_get_event_website_link_label', $label );
+			$label = apply_filters( 'tribe_get_event_website_link_label', $label, $event );
 			$html  = sprintf(
 				'<a href="%s" target="%s" rel="%s">%s</a>',
 				esc_url( $url ),
@@ -402,6 +403,27 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		return apply_filters( 'tribe_get_event_website_link', $html );
 	}
 
+	/**
+	 * Get the link for the event website.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|int $post_id The event or event ID.
+	 * @return string  Formatted title for the event website link
+	 */
+	function tribe_events_get_event_website_title( $post_id = null ) {
+		$post_id = Tribe__Main::post_id_helper( $post_id );
+
+		/**
+		 * Allows customization of a event's website title link.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $title The title of the event's website link.
+		 * @param int 	 $post_id The event ID.
+		 */
+		return apply_filters( 'tribe_events_get_event_website_title', __( 'Website:', 'the-events-calendar' ), $post_id );
+	}
 
 	/**
 	 * Event Website URL

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -426,7 +426,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * @param string the link label/text.
 		 */
-		$label = apply_filters( 'tribe_get_organizer_website_link_label', $label );
+		$label = apply_filters( 'tribe_get_organizer_website_link_label', $label, $post_id );
 
 		if ( ! empty( $url ) ) {
 			$label = is_null( $label ) ? $url : $label;
@@ -456,6 +456,28 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 * @param string the link HTML.
 		 */
 		return apply_filters( 'tribe_get_organizer_website_link', $html );
+	}
+	
+	/**
+	 * Get the link for the organizer website.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|int $post_id The event or organizer ID.
+	 * @return string  Formatted title for the organizer website link
+	 */
+	function tribe_events_get_organizer_website_title( $post_id = null ) {
+		$post_id = tribe_get_organizer_id( $post_id );
+
+		/**
+		 * Allows customization of a organizer's website title link.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $title The title of the organizer's website link.
+		 * @param int 	 $post_id The organizer ID.
+		 */
+		return apply_filters( 'tribe_events_get_organizer_website_title', __( 'Website:', 'the-events-calendar' ), $post_id );
 	}
 
 	/**

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -794,6 +794,28 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		return apply_filters( 'tribe_get_venue_website_link', $html, $post_id );
 	}
+	
+	/**
+	 * Get the link for the venue website.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|int $post_id The event or venue ID.
+	 * @return string  Formatted title for the venue website link
+	 */
+	function tribe_events_get_venue_website_title( $post_id = null ) {
+		$post_id = tribe_get_venue_id( $post_id );
+
+		/**
+		 * Allows customization of a venue's website title link.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $title The title of the venue's website link.
+		 * @param int 	 $post_id The venue ID.
+		 */
+		return apply_filters( 'tribe_events_get_venue_website_title', __( 'Website:', 'the-events-calendar' ), $post_id );
+	}
 
 	/**
 	 * Returns the venue website URL related to the current post or for the optionally

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -760,17 +760,6 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			 */
 			$website_link_target = apply_filters( 'tribe_get_venue_website_link_target', '_self', $url, $post_id );
 			$rel                 = ( '_blank' === $website_link_target ) ? 'noopener noreferrer' : 'external';
-			
-			/**
-			 * Filter the organizer link label.
-			 * 
-			 * @since TBD
-			 * 
-			 * @param string $label The string to show instead of the full url.
-			 */
-			if ( apply_filters( 'tribe_events_single_event_details_website_label', true ) ) {
-				$label = apply_filters( 'tribe_events_single_event_details_website_label', esc_html( $label ) );
-			};
 
 			/**
 			 * Allows customization of a venue's website link label.

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -760,6 +760,17 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			 */
 			$website_link_target = apply_filters( 'tribe_get_venue_website_link_target', '_self', $url, $post_id );
 			$rel                 = ( '_blank' === $website_link_target ) ? 'noopener noreferrer' : 'external';
+			
+			/**
+			 * Filter the organizer link label.
+			 * 
+			 * @since TBD
+			 * 
+			 * @param string $label The string to show instead of the full url.
+			 */
+			if ( apply_filters( 'tribe_events_single_event_details_website_label', true ) ) {
+				$label = apply_filters( 'tribe_events_single_event_details_website_label', esc_html( $label ) );
+			};
 
 			/**
 			 * Allows customization of a venue's website link label.

--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -248,6 +248,15 @@
 		margin: 0 0 var(--spacer-0) 0;
 		padding: 0;
 	}
+	
+	dt:not(:first-child),
+	dd[class$="url"] {
+		margin-top: var(--spacer-3);
+	}
+	
+	dt[class*="url"] + dd {
+		margin-top: 0;
+	}
 
 	.tribe-events-address {
 		margin: 0;

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -164,7 +164,7 @@ $website_title = tribe_events_get_event_website_title();
 		// Event Website
 		if ( ! empty( $website ) ) : ?>
 			<?php if ( ! empty( $website_title ) ): ?>
-				<dt class="tribe-events-event-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ); ?> </dt>
+				<dt class="tribe-events-event-url-label"> <?php echo esc_html( $website_title ); ?> </dt>
 			<?php endif; ?>
 			<dd class="tribe-events-event-url"> <?php echo $website; ?> </dd>
 		<?php endif ?>

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -54,6 +54,7 @@ $time_title = apply_filters( 'tribe_events_single_event_time_title', __( 'Time:'
 
 $cost    = tribe_get_formatted_cost();
 $website = tribe_get_event_website_link();
+$website_title = tribe_events_get_event_website_title();
 ?>
 
 <div class="tribe-events-meta-group tribe-events-meta-group-details">
@@ -162,8 +163,9 @@ $website = tribe_get_event_website_link();
 		<?php
 		// Event Website
 		if ( ! empty( $website ) ) : ?>
-
-			<dt class="tribe-events-event-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ); ?> </dt>
+			<?php if ( ! empty( $website_title ) ): ?>
+				<dt class="tribe-events-event-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ); ?> </dt>
+			<?php endif; ?>
 			<dd class="tribe-events-event-url"> <?php echo $website; ?> </dd>
 		<?php endif ?>
 

--- a/src/views/modules/meta/organizer.php
+++ b/src/views/modules/meta/organizer.php
@@ -15,6 +15,7 @@ $multiple = count( $organizer_ids ) > 1;
 $phone = tribe_get_organizer_phone();
 $email = tribe_get_organizer_email();
 $website = tribe_get_organizer_website_link();
+$website_title = tribe_events_get_organizer_website_title();
 ?>
 
 <div class="tribe-events-meta-group tribe-events-meta-group-organizer">
@@ -61,9 +62,11 @@ $website = tribe_get_organizer_website_link();
 
 			if ( ! empty( $website ) ) {
 				?>
-				<dt class="tribe-organizer-url-label">
-					<?php esc_html_e( 'Website:', 'the-events-calendar' ) ?>
-				</dt>
+				<?php if ( ! empty( $website_title ) ): ?>
+					<dt class="tribe-organizer-url-label">
+						<?php esc_html_e( 'Website:', 'the-events-calendar' ) ?>
+					</dt>
+				<?php endif; ?>
 				<dd class="tribe-organizer-url">
 					<?php echo $website; ?>
 				</dd>

--- a/src/views/modules/meta/organizer.php
+++ b/src/views/modules/meta/organizer.php
@@ -64,7 +64,7 @@ $website_title = tribe_events_get_organizer_website_title();
 				?>
 				<?php if ( ! empty( $website_title ) ): ?>
 					<dt class="tribe-organizer-url-label">
-						<?php esc_html_e( 'Website:', 'the-events-calendar' ) ?>
+						<?php echo esc_html( $website_title ) ?>
 					</dt>
 				<?php endif; ?>
 				<dd class="tribe-organizer-url">

--- a/src/views/modules/meta/venue.php
+++ b/src/views/modules/meta/venue.php
@@ -43,7 +43,9 @@ $website = tribe_get_venue_website_link();
 		<?php endif ?>
 
 		<?php if ( ! empty( $website ) ): ?>
-			<dt class="tribe-venue-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ) ?> </dt>
+			<?php if ( ! has_filter( 'tribe_get_venue_website_link_label' ) ): ?>
+				<dt class="tribe-venue-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ) ?> </dt>
+			<?php endif ?>
 			<dd class="tribe-venue-url"> <?php echo $website ?> </dd>
 		<?php endif ?>
 

--- a/src/views/modules/meta/venue.php
+++ b/src/views/modules/meta/venue.php
@@ -15,6 +15,7 @@ if ( ! tribe_get_venue_id() ) {
 
 $phone   = tribe_get_phone();
 $website = tribe_get_venue_website_link();
+$website_title = tribe_events_get_venue_website_title();
 
 ?>
 
@@ -43,8 +44,8 @@ $website = tribe_get_venue_website_link();
 		<?php endif ?>
 
 		<?php if ( ! empty( $website ) ): ?>
-			<?php if ( ! has_filter( 'tribe_get_venue_website_link_label' ) ): ?>
-				<dt class="tribe-venue-url-label"> <?php esc_html_e( 'Website:', 'the-events-calendar' ) ?> </dt>
+			<?php if ( ! empty( $website_title ) ): ?>
+				<dt class="tribe-venue-url-label"> <?php esc_html( $website_title ) ?> </dt>
 			<?php endif ?>
 			<dd class="tribe-venue-url"> <?php echo $website ?> </dd>
 		<?php endif ?>


### PR DESCRIPTION
**Description:** Update the details block so that the website field displays as a named link by default. Customers are then allowed to disable that behaviour and return to "Website: [link]" via a filter removal.

**Note:** To disable use (venue example):
`remove_filter( 'tribe_get_venue_website_link_label', [ tribe( 'events.views.v2.hooks' ), 'filter_single_event_details_venue_website_label' ] );`
`remove_filter( 'tribe_events_get_venue_website_title', '__return_empty_string' );`

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3758

**Screenshots:**

![Screen Shot 2021-03-11 at 6 05 59 PM](https://user-images.githubusercontent.com/5049893/110825933-db3e5c80-8294-11eb-89bc-818edbc3066d.png)
