### PR TITLE
Fix / website label disabled

### DIFF
--- a/src/views/modules/meta/venue.php
+++ b/src/views/modules/meta/venue.php
@@ -45,7 +45,7 @@ $website_title = tribe_events_get_venue_website_title();
 
 		<?php if ( ! empty( $website ) ): ?>
 			<?php if ( ! empty( $website_title ) ): ?>
-				<dt class="tribe-venue-url-label"> <?php esc_html( $website_title ) ?> </dt>
+				<dt class="tribe-venue-url-label"> <?php echo esc_html( $website_title ) ?> </dt>
 			<?php endif ?>
 			<dd class="tribe-venue-url"> <?php echo $website ?> </dd>
 		<?php endif ?>


### PR DESCRIPTION
**Description:** Fixes the website label when the filters are removed with the following:
```
remove_filter( 'tribe_get_venue_website_link_label', [ tribe( 'events.views.v2.hooks' ), 'filter_single_event_details_venue_website_label' ] );
remove_filter( 'tribe_events_get_venue_website_title', '__return_empty_string' );
```

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3758