### PR TITLE
Add recurring notice about legacy views.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Added rel=noreferrer to Google Map links. [TEC-3795]
 * Tweak - Include actions before and after the creation of a view for REST API requests. Hooks added were: `tribe_events_views_v2_before_make_view_for_rest` and `tribe_events_views_v2_after_make_view_for_rest`
 * Tweak - Allow specific filtering to add other views into the HTML caching for performance using hook `tribe_events_views_v2_cached_views`.
+* Tweak - Include Legacy views deprecation notice [TEC-4809]
 
 = [5.4.0] 2021-02-24 =
 

--- a/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
+++ b/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
@@ -31,10 +31,24 @@ class Legacy_Views_Deprecation {
 		);
 	}
 
+	/**
+	 * Checks if we are using a debug constant.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
 	public function is_debug() {
 		return defined( 'WP_DEBUG' ) && WP_DEBUG;
 	}
 
+	/**
+	 * Checks if we are in a page we need to display.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
 	public function is_valid_screen() {
 		/** @var Tribe__Admin__Helpers $admin_helpers */
 		$admin_helpers = tribe( 'admin.helpers' );
@@ -43,6 +57,8 @@ class Legacy_Views_Deprecation {
 	}
 
 	/**
+	 * Checks all methods required for display.
+	 *
 	 * @since TBD
 	 *
 	 * @return bool
@@ -52,6 +68,8 @@ class Legacy_Views_Deprecation {
 	}
 
 	/**
+	 * Get the date in which we are meant to deprecate.
+	 *
 	 * @since TBD
 	 *
 	 * @return Tribe\Utils\Date_I18n_Immutable

--- a/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
+++ b/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tribe\Events\Admin\Notice;
+
+use Tribe__Date_Utils as Dates;
+
+/**
+ * Class Legacy_Views_Deprecation
+ *
+ * @since TBD
+ *
+ */
+class Legacy_Views_Deprecation {
+	/**
+	 * Register v1 deprecation notice.
+	 *
+	 * @since TBD
+	 */
+	public function hook() {
+		tribe_notice(
+			'events-legacy-views-deprecation',
+			[ $this, 'notice' ],
+			[
+				'dismiss'            => 1,
+				'type'               => 'info',
+				'wrap'               => 'p',
+				'recurring'          => true,
+				'recurring_interval' => 'P14D',
+			],
+			[ $this, 'should_display' ]
+		);
+	}
+
+	public function is_debug() {
+		return defined( 'WP_DEBUG' ) && WP_DEBUG;
+	}
+
+	public function is_valid_screen() {
+		/** @var Tribe__Admin__Helpers $admin_helpers */
+		$admin_helpers = tribe( 'admin.helpers' );
+
+		return $admin_helpers->is_screen() || $admin_helpers->is_post_type_screen();
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_display() {
+		return $this->is_valid_screen() && ! tribe_events_views_v2_is_enabled();
+	}
+
+	/**
+	 * @since TBD
+	 *
+	 * @return Tribe\Utils\Date_I18n_Immutable
+	 */
+	public function get_deprecation_date() {
+		return Dates::build_date_object( '2021-08-03' );
+	}
+
+	/**
+	 * HTML for the notice for sites using V1.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function notice() {
+		if ( $this->is_debug() ) {
+			$link = sprintf(
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+				esc_url( 'TBD_LINK' ),
+				esc_html_x( 'read more about how that might affect you', 'read more about deprecation of legacy views', 'the-events-calendar' )
+			);
+
+			return sprintf(
+				_x( '<b>Important warning about phasing out of functionality.</b><br> The legacy views design and code for The Events Calendar that you are currently using will be deprecated on %2$s, %1$s!', 'deprecation of legacy views for devs', 'the-events-calendar' ),
+				$link,
+				esc_html( $this->get_deprecation_date()->format_i18n( 'F d, Y' ) )
+			);
+		}
+
+		$link = sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			esc_url( 'TBD_LINK' ),
+			esc_html_x( 'read more about how that might affect you', 'read more about deprecation of legacy views', 'the-events-calendar' )
+		);
+
+		return sprintf(
+			_x( '<b>Important warning about phasing out of functionality.</b><br> The legacy views design and code for The Events Calendar that you are currently using will be deprecated on %2$s, %1$s!', 'deprecation of legacy views', 'the-events-calendar' ),
+			$link,
+			esc_html( $this->get_deprecation_date()->format_i18n( 'F d, Y' ) )
+		);
+	}
+}

--- a/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
+++ b/src/Tribe/Admin/Notice/Legacy_Views_Deprecation.php
@@ -90,7 +90,7 @@ class Legacy_Views_Deprecation {
 			$link = sprintf(
 				'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 				esc_url( 'TBD_LINK' ),
-				esc_html_x( 'read more about how that might affect you', 'read more about deprecation of legacy views', 'the-events-calendar' )
+				esc_html_x( 'Read more about how that might affect you.', 'Read more about deprecation of legacy views.', 'the-events-calendar' )
 			);
 
 			return sprintf(
@@ -103,7 +103,7 @@ class Legacy_Views_Deprecation {
 		$link = sprintf(
 			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 			esc_url( 'TBD_LINK' ),
-			esc_html_x( 'read more about how that might affect you', 'read more about deprecation of legacy views', 'the-events-calendar' )
+			esc_html_x( 'Read more about how that might affect you.', 'Read more about deprecation of legacy views.', 'the-events-calendar' )
 		);
 
 		return sprintf(

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -599,6 +599,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Admin Notices
 			tribe_singleton( 'tec.admin.notice.timezones', 'Tribe__Events__Admin__Notice__Timezones', [ 'hook' ] );
 			tribe_singleton( 'tec.admin.notice.marketing', 'Tribe__Events__Admin__Notice__Marketing', [ 'hook' ] );
+			tribe_singleton( Tribe\Events\Admin\Notice\Legacy_Views_Deprecation::class, Tribe\Events\Admin\Notice\Legacy_Views_Deprecation::class, [ 'hook' ] );
 
 			// GDPR Privacy
 			tribe_singleton( 'tec.privacy', 'Tribe__Events__Privacy', [ 'hook' ] );
@@ -973,6 +974,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			tribe( 'tec.gutenberg' );
 			tribe( 'tec.admin.notice.timezones' );
 			tribe( 'tec.admin.notice.marketing' );
+			tribe( Tribe\Events\Admin\Notice\Legacy_Views_Deprecation::class );
 			tribe( 'tec.privacy' );
 			tribe( Tribe__Events__Capabilities::class );
 		}


### PR DESCRIPTION
🎫 [TEC-3809]
---
Added a recurring notice every 2 weeks around the Legacy views usage.

Depends on https://github.com/the-events-calendar/tribe-common/pull/1563

📹 https://i.bordoni.me/12uoW9Q8

---

Note that the developer and user version of the notice are the same until we update the copy later on in the sprint.

[TEC-3809]: https://theeventscalendar.atlassian.net/browse/TEC-3809