### PR TITLE
Fix / event single themes compatibility

### DIFF
--- a/src/resources/postcss/views/skeleton/_single-event.pcss
+++ b/src/resources/postcss/views/skeleton/_single-event.pcss
@@ -54,8 +54,10 @@
 	margin-bottom: var(--spacer-4);
 	padding-bottom: var(--spacer-2);
 	
-	ul {
+	ul,
+	li {
 		margin: 0;
+		padding: 0;
 	}
 }
 


### PR DESCRIPTION
**Description:** Fixes an issue where the "This event has passed." notice wasn't left aligned in Twenty Twenty and Twenty Twenty One themes.

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3693

**Screenshots:**

![Screen Shot 2021-03-16 at 3 19 04 PM](https://user-images.githubusercontent.com/5049893/111324335-f7fadb80-866a-11eb-870b-e611345b640e.png)
