### PR TITLE
Remove filters that haven't been developed yet.

### DIFF
--- a/src/Tribe/Repositories/Organizer.php
+++ b/src/Tribe/Repositories/Organizer.php
@@ -57,7 +57,6 @@ class Tribe__Events__Repositories__Organizer extends Tribe__Events__Repositories
 			[
 				'has_events'          => [ $this, 'filter_by_has_events' ],
 				'has_no_events'       => [ $this, 'filter_by_has_no_events' ],
-				'has_upcoming_events' => [ $this, 'filter_by_has_upcoming_events' ],
 			]
 		);
 	}

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -71,7 +71,6 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 			[
 				'has_events'          => [ $this, 'filter_by_has_events' ],
 				'has_no_events'       => [ $this, 'filter_by_has_no_events' ],
-				'has_upcoming_events' => [ $this, 'filter_by_has_upcoming_events' ],
 			]
 		);
 	}


### PR DESCRIPTION
@bordoni we discussed this.

When the filters were added, we'd intended to add one more each but they were never developed. They should be removed before release.