### PR TITLE
Build the time with the specified timezone

### DIFF
--- a/tests/_support/Factories/Event.php
+++ b/tests/_support/Factories/Event.php
@@ -72,10 +72,8 @@ class Event extends \WP_UnitTest_Factory_For_Post {
 			                    ->setTimezone( $utc )->format( Dates::DBDATETIMEFORMAT );
 		} else {
 			// Use the timezone to create the "local" (to the site) times.
-			$local_start = Dates::build_date_object( $start_timestamp )
-			                    ->setTimezone( $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
-			$local_end   = Dates::build_date_object( $end_timestamp )
-			                    ->setTimezone( $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
+			$local_start = Dates::build_date_object( $start_timestamp, $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
+			$local_end   = Dates::build_date_object( $end_timestamp, $timezone_obj )->format( Dates::DBDATETIMEFORMAT );
 		}
 
 		$meta_input = [


### PR DESCRIPTION
Out of the box build the local start and end date, instead if a local time is provided it should be constructed using the provided timezone so the local time is adjusted accordingly if a timezone change occurs around the initial local times.

The current behavior creates an event with the wrong dates information when creating an event using the following signature.

```php
factory()->event->create( [
			'timezone' => 'America/Los_Angeles',
			'when'     => '2020-01-01 08:00:00',
		] );
```

The current behavior it creates and event with the start date as: `+2020-01-01T00:00:00.000000-0800` (UTC) date instead of the expected date `-2020-01-01T08:00:00.000000-0800` this date instead is used as the `UTC` date of the event.