### PR TITLE
 Move all common classes to the beginning of the list

### DIFF
--- a/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
+++ b/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
@@ -55,7 +55,7 @@ trait With_Fast_Forward_Link {
 		$link = sprintf(
 		/* translators: 1: opening href tag 2: event label plural 3: closing href tag */
 			__( 'Jump to the %1$snext upcoming %2$s%3$s.', 'the-events-calendar' ),
-			'<a href="' . esc_url( $url ) . '" class="tribe-events-c-messages__message-list-item-link tribe-common-anchor-thin-alt" data-js="tribe-events-view-link">',
+			'<a href="' . esc_url( $url ) . '" class="tribe-common-anchor-thin-alt tribe-events-c-messages__message-list-item-link" data-js="tribe-events-view-link">',
 			tribe_get_event_label_plural_lowercase(),
 			'</a>'
 		);

--- a/src/views/kitchen-sink/page.php
+++ b/src/views/kitchen-sink/page.php
@@ -156,7 +156,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 			aria-selected="false"
 			data-js="tribe-events-accordion-trigger"
 		>
-			<span class="tribe-events-c-view-selector__button-icon tribe-common-svgicon tribe-common-svgicon--month"></span>
+			<span class="tribe-common-svgicon tribe-common-svgicon--month tribe-events-c-view-selector__button-icon"></span>
 			<span class="tribe-events-c-view-selector__button-text">
 				Month
 			</span>
@@ -169,7 +169,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 			<ul class="tribe-events-c-view-selector__list">
 				<li class="tribe-events-c-view-selector__list-item">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--month"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--month tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							Month
 						</span>
@@ -177,7 +177,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 				</li>
 				<li class="tribe-events-c-view-selector__list-item tribe-events-c-view-selector__list-item--active">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--list"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--list tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							List
 						</span>
@@ -185,7 +185,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 				</li>
 				<li class="tribe-events-c-view-selector__list-item">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--day"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--day tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							Day
 						</span>
@@ -203,7 +203,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 			aria-selected="false"
 			data-js="tribe-events-accordion-trigger"
 		>
-			<span class="tribe-events-c-view-selector__button-icon tribe-common-svgicon tribe-common-svgicon--month"></span>
+			<span class="tribe-common-svgicon tribe-common-svgicon--month tribe-events-c-view-selector__button-icon"></span>
 			<span class="tribe-events-c-view-selector__button-text">
 				Month
 			</span>
@@ -216,7 +216,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 			<ul class="tribe-events-c-view-selector__list">
 				<li class="tribe-events-c-view-selector__list-item">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--month"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--month tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							Month
 						</span>
@@ -224,7 +224,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 				</li>
 				<li class="tribe-events-c-view-selector__list-item tribe-events-c-view-selector__list-item--active">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--list"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--list tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							List
 						</span>
@@ -232,7 +232,7 @@ tribe_asset_enqueue( 'tribe-common-style' );
 				</li>
 				<li class="tribe-events-c-view-selector__list-item">
 					<a href="#" class="tribe-events-c-view-selector__list-item-link">
-						<span class="tribe-events-c-view-selector__list-item-icon tribe-common-svgicon tribe-common-svgicon--day"></span>
+						<span class="tribe-common-svgicon tribe-common-svgicon--day tribe-events-c-view-selector__list-item-icon"></span>
 						<span class="tribe-events-c-view-selector__list-item-text">
 							Day
 						</span>

--- a/src/views/v2/components/events-bar.php
+++ b/src/views/v2/components/events-bar.php
@@ -23,10 +23,11 @@ $heading = $disable_event_search
 	? __( 'Views Navigation', 'the-events-calendar' )
 	: sprintf( __( '%s Search and Views Navigation', 'the-events-calendar' ), tribe_get_event_label_plural() );
 
-$classes = [ 'tribe-events-header__events-bar', 'tribe-events-c-events-bar' ];
-if ( empty( $disable_event_search ) ) {
-	$classes[] = 'tribe-events-c-events-bar--border';
-}
+$classes = [
+	'tribe-events-c-events-bar',
+	'tribe-events-c-events-bar--border' => empty( $disable_event_search ),
+	'tribe-events-header__events-bar',
+];
 ?>
 <div
 	<?php tribe_classes( $classes ); ?>

--- a/src/views/v2/components/ical-link.php
+++ b/src/views/v2/components/ical-link.php
@@ -19,7 +19,7 @@ if ( empty( $ical->display_link ) ) {
 }
 
 ?>
-<div class="tribe-events-c-ical tribe-common-b2 tribe-common-b3--min-medium">
+<div class="tribe-common-b2 tribe-common-b3--min-medium tribe-events-c-ical">
 	<a
 		class="tribe-events-c-ical__link"
 		title="<?php echo esc_attr( $ical->link->title ); ?>"

--- a/src/views/v2/components/loader.php
+++ b/src/views/v2/components/loader.php
@@ -21,7 +21,7 @@
 	<span class="tribe-events-view-loader__text tribe-common-a11y-visual-hide">
 		<?php esc_html_e( 'Loading view.', 'the-events-calendar' ); ?>
 	</span>
-	<div class="tribe-events-view-loader__dots tribe-common-c-loader">
+	<div class="tribe-common-c-loader tribe-events-view-loader__dots">
 		<?php $this->template( 'components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--first' ] ] ); ?>
 		<?php $this->template( 'components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--second' ] ] ); ?>
 		<?php $this->template( 'components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--third' ] ] ); ?>

--- a/src/views/v2/components/messages.php
+++ b/src/views/v2/components/messages.php
@@ -23,7 +23,11 @@ if ( empty( $messages ) ) {
 
 global $wp_version;
 
-$classes = [ 'tribe-events-header__messages', 'tribe-events-c-messages', 'tribe-common-b2' ];
+$classes = [
+	'tribe-common-b2',
+	'tribe-events-c-messages',
+	'tribe-events-header__messages',
+];
 
 ?>
 <div <?php tribe_classes( $classes ); ?>>

--- a/src/views/v2/components/read-more.php
+++ b/src/views/v2/components/read-more.php
@@ -18,6 +18,6 @@
 <div class="tribe-events-c-small-cta tribe-common-b3 tribe-events-c-read-more">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
-		class="tribe-events-c-small-cta__link tribe-common-cta tribe-common-cta--thin-alt"
+		class="tribe-common-cta tribe-common-cta--thin-alt tribe-events-c-small-cta__link"
 	><?php esc_html_e( 'Continue Reading', 'the-events-calendar' ); ?></a>
 </div>

--- a/src/views/v2/day/event.php
+++ b/src/views/v2/day/event.php
@@ -16,14 +16,21 @@
  * @see tribe_get_event() For the format of the event object.
  */
 
-$classes = tribe_get_post_class( [ 'tribe-common-g-row', 'tribe-common-g-row--gutters', 'tribe-events-calendar-day__event' ], $event->ID );
+$classes = tribe_get_post_class(
+	[
+		'tribe-common-g-row',
+		'tribe-common-g-row--gutters',
+		'tribe-events-calendar-day__event',
+	],
+	$event->ID
+);
 
 if ( ! empty( $event->featured ) ) {
 	$classes[] = 'tribe-events-calendar-day__event--featured';
 }
 ?>
 <article <?php tribe_classes( $classes ); ?>>
-	<div class="tribe-events-calendar-day__event-content tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-calendar-day__event-content">
 
 		<?php $this->template( 'day/event/featured-image', [ 'event' => $event ] ); ?>
 

--- a/src/views/v2/day/event/date.php
+++ b/src/views/v2/day/event/date.php
@@ -23,7 +23,7 @@ use Tribe__Date_Utils as Dates;
 $event_date_attr = $event->dates->start->format( Dates::DBDATEFORMAT );
 
 ?>
-<div class="tribe-events-calendar-day__event-datetime-wrapper tribe-common-b2">
+<div class="tribe-common-b2 tribe-events-calendar-day__event-datetime-wrapper">
 	<?php $this->template( 'day/event/date/featured' ); ?>
 	<time class="tribe-events-calendar-day__event-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<?php echo $event->schedule_details->value(); ?>

--- a/src/views/v2/day/event/title.php
+++ b/src/views/v2/day/event/title.php
@@ -16,12 +16,12 @@
  * @see tribe_get_event() For the format of the event object.
  */
 ?>
-<h3 class="tribe-events-calendar-day__event-title tribe-common-h6 tribe-common-h4--min-medium">
+<h3 class="tribe-common-h6 tribe-common-h4--min-medium tribe-events-calendar-day__event-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-day__event-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-calendar-day__event-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -25,8 +25,8 @@ $venue                = $event->venues[0];
 $append_after_address = array_filter( array_map( 'trim', [ $venue->city, $venue->state_province, $venue->state, $venue->province ] ) );
 $address              = $venue->address . ( $venue->address && $append_after_address ? $separator : '' );
 ?>
-<address class="tribe-events-calendar-day__event-venue tribe-common-b2">
-	<span class="tribe-events-calendar-day__event-venue-title tribe-common-b2--bold">
+<address class="tribe-common-b2 tribe-events-calendar-day__event-venue">
+	<span class="tribe-common-b2--bold tribe-events-calendar-day__event-venue-title">
 		<?php echo wp_kses_post( $venue->post_title ); ?>
 	</span>
 	<span class="tribe-events-calendar-day__event-venue-address">

--- a/src/views/v2/day/nav/next-disabled.php
+++ b/src/views/v2/day/nav/next-disabled.php
@@ -15,7 +15,7 @@
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--next">
 	<button
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		aria-label="<?php esc_attr_e( 'Next Day', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Next Day', 'the-events-calendar' ); ?>"
 		disabled

--- a/src/views/v2/day/nav/next.php
+++ b/src/views/v2/day/nav/next.php
@@ -19,7 +19,7 @@
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="next"
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		data-js="tribe-events-view-link"
 		aria-label="<?php esc_attr_e( 'Next Day', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Next Day', 'the-events-calendar' ); ?>"

--- a/src/views/v2/day/nav/prev-disabled.php
+++ b/src/views/v2/day/nav/prev-disabled.php
@@ -15,7 +15,7 @@
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--prev">
 	<button
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		aria-label="<?php esc_attr_e( 'Previous Day', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Previous Day', 'the-events-calendar' ); ?>"
 		disabled

--- a/src/views/v2/day/nav/prev.php
+++ b/src/views/v2/day/nav/prev.php
@@ -19,7 +19,7 @@
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="prev"
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		data-js="tribe-events-view-link"
 		aria-label="<?php esc_attr_e( 'Previous Day', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Previous Day', 'the-events-calendar' ); ?>"

--- a/src/views/v2/day/time-separator.php
+++ b/src/views/v2/day/time-separator.php
@@ -31,7 +31,7 @@ $time_attribute = date_i18n( 'H:i', $event_start_hour );
 ?>
 <div class="tribe-events-calendar-day__time-separator">
 	<time
-		class="tribe-events-calendar-day__time-separator-text tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt"
+		class="tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt tribe-events-calendar-day__time-separator-text"
 		datetime="<?php echo esc_attr( $time_attribute ); ?>"
 	>
 		<?php echo esc_html( $separator_text ); ?>

--- a/src/views/v2/day/type-separator.php
+++ b/src/views/v2/day/type-separator.php
@@ -30,7 +30,7 @@ if ( 'all_day' === $event->timeslot ) {
 }
 ?>
 <div class="tribe-events-calendar-day__type-separator">
-	<span class="tribe-events-calendar-day__type-separator-text tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt">
+	<span class="tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt tribe-events-calendar-day__type-separator-text">
 		<?php echo esc_html( $separator_text ); ?>
 	</span>
 </div>

--- a/src/views/v2/latest-past/event.php
+++ b/src/views/v2/latest-past/event.php
@@ -25,11 +25,11 @@ $event_classes = tribe_get_post_class( [ 'tribe-events-calendar-latest-past__eve
 
 	<?php $this->template( 'latest-past/event/date-tag', [ 'event' => $event ] ); ?>
 
-	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-calendar-latest-past__event-wrapper">
 		<article <?php tribe_classes( $event_classes ) ?>>
 			<?php $this->template( 'latest-past/event/featured-image', [ 'event' => $event ] ); ?>
 
-			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
+			<div class="tribe-common-g-col tribe-events-calendar-latest-past__event-details">
 
 				<header class="tribe-events-calendar-latest-past__event-header">
 					<?php $this->template( 'latest-past/event/date', [ 'event' => $event ] ); ?>

--- a/src/views/v2/latest-past/event/date-tag.php
+++ b/src/views/v2/latest-past/event/date-tag.php
@@ -23,12 +23,12 @@ $event_day_num   = $event->dates->start_display->format_i18n( 'j' );
 $event_year      = $event->dates->start_display->format_i18n( 'Y' );
 $event_date_attr = $event->dates->start_display->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-calendar-latest-past__event-date-tag">
 	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
 			<?php echo esc_html( $event_month ); ?>
 		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+		<span class="tribe-common-h5 tribe-common-h4--min-medium tribe-events-calendar-latest-past__event-date-tag-daynum">
 			<?php echo esc_html( $event_day_num ); ?>
 		</span>
 		<span class="tribe-events-calendar-latest-past__event-date-tag-year">

--- a/src/views/v2/latest-past/event/date.php
+++ b/src/views/v2/latest-past/event/date.php
@@ -23,7 +23,7 @@ use Tribe__Date_Utils as Dates;
 $event_date_attr = $event->dates->start->format( Dates::DBDATEFORMAT );
 
 ?>
-<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
+<div class="tribe-common-b2 tribe-events-calendar-latest-past__event-datetime-wrapper">
 	<?php $this->template( 'latest-past/event/date/featured', [ 'event' => $event ] ); ?>
 	<time class="tribe-events-calendar-latest-past__event-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<?php echo $event->schedule_details->value(); ?>

--- a/src/views/v2/latest-past/event/featured-image.php
+++ b/src/views/v2/latest-past/event/featured-image.php
@@ -21,7 +21,7 @@ if ( ! $event->thumbnail->exists ) {
 }
 
 ?>
-<div class="tribe-events-calendar-latest-past__event-featured-image-wrapper tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-calendar-latest-past__event-featured-image-wrapper">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"

--- a/src/views/v2/latest-past/event/title.php
+++ b/src/views/v2/latest-past/event/title.php
@@ -16,12 +16,12 @@
  * @see tribe_get_event() For the format of the event object.
  */
 ?>
-<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
+<h3 class="tribe-common-h6 tribe-common-h4--min-mediumtribe-events-calendar-latest-past__event-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-calendar-latest-past__event-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/latest-past/event/venue.php
+++ b/src/views/v2/latest-past/event/venue.php
@@ -25,8 +25,8 @@ $venue                = $event->venues[0];
 $append_after_address = array_filter( array_map( 'trim', [ $venue->city, $venue->state_province, $venue->state, $venue->province ] ) );
 $address              = $venue->address . ( $venue->address && $append_after_address ? $separator : '' );
 ?>
-<address class="tribe-events-calendar-latest-past__event-venue tribe-common-b2">
-	<span class="tribe-events-calendar-latest-past__event-venue-title tribe-common-b2--bold">
+<address class="tribe-common-b2 tribe-events-calendar-latest-past__event-venue">
+	<span class="tribe-common-b2--bold tribe-events-calendar-latest-past__event-venue-title">
 		<?php echo wp_kses_post( $venue->post_title ); ?>
 	</span>
 	<span class="tribe-events-calendar-latest-past__event-venue-address">

--- a/src/views/v2/latest-past/heading.php
+++ b/src/views/v2/latest-past/heading.php
@@ -14,6 +14,6 @@
 
 $label = sprintf( __( 'Latest Past %s', 'the-events-calendar' ), tribe_get_event_label_plural() );
 ?>
-<h2 class="tribe-events-calendar-latest-past__heading tribe-common-h5 tribe-common-h3--min-medium">
+<h2 class="tribe-common-h5 tribe-common-h3--min-medium tribe-events-calendar-latest-past__heading">
 	<?php echo esc_html( $label ); ?>
 </h2>

--- a/src/views/v2/list/event.php
+++ b/src/views/v2/list/event.php
@@ -19,17 +19,17 @@
 $container_classes = [ 'tribe-common-g-row', 'tribe-events-calendar-list__event-row' ];
 $container_classes['tribe-events-calendar-list__event-row--featured'] = $event->featured;
 
-$event_classes = tribe_get_post_class( [ 'tribe-events-calendar-list__event', 'tribe-common-g-row', 'tribe-common-g-row--gutters' ], $event->ID );
+$event_classes = tribe_get_post_class( [ 'tribe-common-g-row', 'tribe-common-g-row--gutters', 'tribe-events-calendar-list__event' ], $event->ID );
 ?>
 <div <?php tribe_classes( $container_classes ); ?>>
 
 	<?php $this->template( 'list/event/date-tag', [ 'event' => $event ] ); ?>
 
-	<div class="tribe-events-calendar-list__event-wrapper tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-calendar-list__event-wrapper">
 		<article <?php tribe_classes( $event_classes ) ?>>
 			<?php $this->template( 'list/event/featured-image', [ 'event' => $event ] ); ?>
 
-			<div class="tribe-events-calendar-list__event-details tribe-common-g-col">
+			<div class="tribe-common-g-col tribe-events-calendar-list__event-details">
 
 				<header class="tribe-events-calendar-list__event-header">
 					<?php $this->template( 'list/event/date', [ 'event' => $event ] ); ?>

--- a/src/views/v2/list/event/date-tag.php
+++ b/src/views/v2/list/event/date-tag.php
@@ -33,12 +33,12 @@ $event_week_day  = $display_date->format_i18n( 'D' );
 $event_day_num   = $display_date->format_i18n( 'j' );
 $event_date_attr = $display_date->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-calendar-list__event-date-tag tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-calendar-list__event-date-tag">
 	<time class="tribe-events-calendar-list__event-date-tag-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<span class="tribe-events-calendar-list__event-date-tag-weekday">
 			<?php echo esc_html( $event_week_day ); ?>
 		</span>
-		<span class="tribe-events-calendar-list__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+		<span class="tribe-common-h5 tribe-common-h4--min-medium tribe-events-calendar-list__event-date-tag-daynum">
 			<?php echo esc_html( $event_day_num ); ?>
 		</span>
 	</time>

--- a/src/views/v2/list/event/date.php
+++ b/src/views/v2/list/event/date.php
@@ -23,7 +23,7 @@ use Tribe__Date_Utils as Dates;
 $event_date_attr = $event->dates->start->format( Dates::DBDATEFORMAT );
 
 ?>
-<div class="tribe-events-calendar-list__event-datetime-wrapper tribe-common-b2">
+<div class="tribe-common-b2 tribe-events-calendar-list__event-datetime-wrapper">
 	<?php $this->template( 'list/event/date/featured' ); ?>
 	<time class="tribe-events-calendar-list__event-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<?php echo $event->schedule_details->value(); ?>

--- a/src/views/v2/list/event/featured-image.php
+++ b/src/views/v2/list/event/featured-image.php
@@ -21,7 +21,7 @@ if ( ! $event->thumbnail->exists ) {
 }
 
 ?>
-<div class="tribe-events-calendar-list__event-featured-image-wrapper tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-calendar-list__event-featured-image-wrapper">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"

--- a/src/views/v2/list/event/title.php
+++ b/src/views/v2/list/event/title.php
@@ -16,12 +16,12 @@
  * @see tribe_get_event() For the format of the event object.
  */
 ?>
-<h3 class="tribe-events-calendar-list__event-title tribe-common-h6 tribe-common-h4--min-medium">
+<h3 class="tribe-common-h6 tribe-common-h4--min-medium tribe-events-calendar-list__event-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-list__event-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-calendar-list__event-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/list/event/venue.php
+++ b/src/views/v2/list/event/venue.php
@@ -25,8 +25,8 @@ $venue                = $event->venues[0];
 $append_after_address = array_filter( array_map( 'trim', [ $venue->city, $venue->state_province, $venue->state, $venue->province ] ) );
 $address              = $venue->address . ( $venue->address && $append_after_address ? $separator : '' );
 ?>
-<address class="tribe-events-calendar-list__event-venue tribe-common-b2">
-	<span class="tribe-events-calendar-list__event-venue-title tribe-common-b2--bold">
+<address class="tribe-common-b2 tribe-events-calendar-list__event-venue">
+	<span class="tribe-common-b2--bold tribe-events-calendar-list__event-venue-title">
 		<?php echo wp_kses_post( $venue->post_title ); ?>
 	</span>
 	<span class="tribe-events-calendar-list__event-venue-address">

--- a/src/views/v2/list/month-separator.php
+++ b/src/views/v2/list/month-separator.php
@@ -42,7 +42,7 @@ $sep_date = empty( $is_past ) && ! empty( $request_date )
 ?>
 <div class="tribe-events-calendar-list__month-separator">
 	<time
-		class="tribe-events-calendar-list__month-separator-text tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt"
+		class="tribe-common-h7 tribe-common-h6--min-medium tribe-common-h--alt tribe-events-calendar-list__month-separator-text"
 		datetime="<?php
 		echo esc_attr( $sep_date->format( 'Y-m' ) ); ?>"
 	>

--- a/src/views/v2/list/nav/next-disabled.php
+++ b/src/views/v2/list/nav/next-disabled.php
@@ -21,7 +21,7 @@ $events_mobile_friendly_label = sprintf( __( 'Next %1$s', 'the-events-calendar' 
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--next">
 	<button
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"
 		disabled

--- a/src/views/v2/list/nav/next.php
+++ b/src/views/v2/list/nav/next.php
@@ -25,7 +25,7 @@ $events_mobile_friendly_label = sprintf( __( 'Next %1$s', 'the-events-calendar' 
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="next"
-		class="tribe-events-c-nav__next tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__next"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"

--- a/src/views/v2/list/nav/prev-disabled.php
+++ b/src/views/v2/list/nav/prev-disabled.php
@@ -20,7 +20,7 @@ $events_mobile_friendly_label = sprintf( __( 'Previous %1$s', 'the-events-calend
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--prev">
 	<button
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"
 		disabled

--- a/src/views/v2/list/nav/prev.php
+++ b/src/views/v2/list/nav/prev.php
@@ -25,7 +25,7 @@ $events_mobile_friendly_label = sprintf( __( 'Previous %1$s', 'the-events-calend
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="prev"
-		class="tribe-events-c-nav__prev tribe-common-b2 tribe-common-b1--min-medium"
+		class="tribe-common-b2 tribe-common-b1--min-medium tribe-events-c-nav__prev"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( $label ); ?>"
 		title="<?php echo esc_attr( $label ); ?>"

--- a/src/views/v2/list/nav/today.php
+++ b/src/views/v2/list/nav/today.php
@@ -18,7 +18,7 @@
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--today">
 	<a
 		href="<?php echo esc_url( $today_url ); ?>"
-		class="tribe-events-c-nav__today tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__today"
 		data-js="tribe-events-view-link"
 		aria-label="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"

--- a/src/views/v2/month/calendar-body/day.php
+++ b/src/views/v2/month/calendar-body/day.php
@@ -82,7 +82,7 @@ $num_events_label = sprintf(
 		data-js="tribe-events-calendar-month-day-cell-mobile"
 		tabindex="-1"
 	>
-		<h3 class="tribe-events-calendar-month__day-date tribe-common-h6 tribe-common-h--alt">
+		<h3 class="tribe-common-h6 tribe-common-h--alt tribe-events-calendar-month__day-date">
 			<span class="tribe-common-a11y-visual-hide">
 				<?php echo esc_html( $num_events_label ); ?>,
 			</span>
@@ -123,7 +123,7 @@ $num_events_label = sprintf(
 		id="<?php echo esc_attr( $day_id ); ?>"
 		class="tribe-events-calendar-month__day-cell tribe-events-calendar-month__day-cell--desktop tribe-common-a11y-hidden"
 	>
-		<h3 class="tribe-events-calendar-month__day-date tribe-common-h4">
+		<h3 class="tribe-common-h4 tribe-events-calendar-month__day-date">
 			<span class="tribe-common-a11y-visual-hide">
 				<?php echo esc_html( $num_events_label ); ?>,
 			</span>

--- a/src/views/v2/month/calendar-body/day/calendar-events/calendar-event.php
+++ b/src/views/v2/month/calendar-body/day/calendar-events/calendar-event.php
@@ -16,10 +16,14 @@
  * @see tribe_get_event() For the format of the event object.
  */
 
-$classes = tribe_get_post_class( [ 'tribe-events-calendar-month__calendar-event' ], $event->ID );
+$classes = [
+	'tribe-events-calendar-month__calendar-event',
+	'tribe-events-calendar-month__calendar-event--featured' => ! empty( $event->featured ),
+	'tribe-events-calendar-month__calendar-event--sticky'   => ( -1 === $event->menu_order )
+];
 
-$classes['tribe-events-calendar-month__calendar-event--featured'] = ! empty( $event->featured );
-$classes['tribe-events-calendar-month__calendar-event--sticky']   = ( -1 === $event->menu_order );
+$classes = tribe_get_post_class( $classes, $event->ID );
+
 ?>
 
 <article <?php tribe_classes( $classes ) ?>>

--- a/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/title.php
+++ b/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/title.php
@@ -17,12 +17,12 @@
  */
 
 ?>
-<h3 class="tribe-events-calendar-month__calendar-event-title tribe-common-h8 tribe-common-h--alt">
+<h3 class="tribe-common-h8 tribe-common-h--alt tribe-events-calendar-month__calendar-event-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ) ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-month__calendar-event-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-calendar-month__calendar-event-title-link"
 		data-js="tribe-events-tooltip"
 		data-tooltip-content="#tribe-events-tooltip-content-<?php echo esc_attr( $event->ID ); ?>"
 		aria-describedby="tribe-events-tooltip-content-<?php echo esc_attr( $event->ID ); ?>"

--- a/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/tooltip/description.php
+++ b/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/tooltip/description.php
@@ -20,6 +20,6 @@ if ( empty( (string) $event->excerpt ) ) {
 	return;
 }
 ?>
-<div class="tribe-events-calendar-month__calendar-event-tooltip-description tribe-common-b3">
+<div class="tribe-common-b3 tribe-events-calendar-month__calendar-event-tooltip-description">
 	<?php echo (string) $event->excerpt; ?>
 </div>

--- a/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/tooltip/title.php
+++ b/src/views/v2/month/calendar-body/day/calendar-events/calendar-event/tooltip/title.php
@@ -17,12 +17,12 @@
  */
 
 ?>
-<h3 class="tribe-events-calendar-month__calendar-event-tooltip-title tribe-common-h7">
+<h3 class="tribe-common-h7 tribe-events-calendar-month__calendar-event-tooltip-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ) ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-month__calendar-event-tooltip-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-calendar-month__calendar-event-tooltip-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/month/calendar-body/day/more-events.php
+++ b/src/views/v2/month/calendar-body/day/more-events.php
@@ -26,7 +26,7 @@ if ( empty( $more_events ) || empty( $more_url ) ) {
 <div class="tribe-events-calendar-month__more-events">
 	<a
 		href="<?php echo esc_url( $more_url ); ?>"
-		class="tribe-events-calendar-month__more-events-link tribe-common-h8 tribe-common-h--alt tribe-common-anchor-thin"
+		class="tribe-common-h8 tribe-common-h--alt tribe-common-anchor-thin tribe-events-calendar-month__more-events-link"
 		data-js="tribe-events-view-link"
 	>
 		<?php

--- a/src/views/v2/month/calendar-body/day/multiday-events/multiday-event/bar/title.php
+++ b/src/views/v2/month/calendar-body/day/multiday-events/multiday-event/bar/title.php
@@ -19,6 +19,6 @@
  */
 
 ?>
-<h3 class="tribe-events-calendar-month__multiday-event-bar-title tribe-common-h8">
+<h3 class="tribe-common-h8 tribe-events-calendar-month__multiday-event-bar-title">
 	<?php echo $event->title; // phpcs:ignore  ?>
 </h3>

--- a/src/views/v2/month/calendar-body/day/multiday-events/multiday-event/hidden/link/title.php
+++ b/src/views/v2/month/calendar-body/day/multiday-events/multiday-event/hidden/link/title.php
@@ -19,6 +19,6 @@
  */
 
 ?>
-<h3 class="tribe-events-calendar-month__multiday-event-hidden-title tribe-common-h8">
+<h3 class="tribe-common-h8 tribe-events-calendar-month__multiday-event-hidden-title">
 	<?php echo $event->title; // phpcs:ignore  ?>
 </h3>

--- a/src/views/v2/month/calendar-header.php
+++ b/src/views/v2/month/calendar-header.php
@@ -28,7 +28,7 @@ global $wp_locale;
 				role="columnheader"
 				aria-label="<?php echo esc_attr( $day ); ?>"
 			>
-				<h3 class="tribe-events-calendar-month__header-column-title tribe-common-b3">
+				<h3 class="tribe-common-b3 tribe-events-calendar-month__header-column-title">
 					<span class="tribe-events-calendar-month__header-column-title-mobile">
 						<?php echo esc_html( $wp_locale->get_weekday_initial( $day ) ); ?>
 					</span>

--- a/src/views/v2/month/mobile-events/mobile-day.php
+++ b/src/views/v2/month/mobile-events/mobile-day.php
@@ -41,11 +41,11 @@ if ( ! empty( $day['multiday_events'] ) ) {
 }
 $mobile_day_id = 'tribe-events-calendar-mobile-day-' . $day['year_number'] . '-' . $day['month_number'] . '-' . $day['day_number'];
 
-$classes = [ 'tribe-events-calendar-month-mobile-events__mobile-day' ];
+$classes = [
+	'tribe-events-calendar-month-mobile-events__mobile-day',
+	'tribe-events-calendar-month-mobile-events__mobile-day--show'=> ( $today_date === $day_date ),
+];
 
-if ( $today_date === $day_date ) {
-	$classes[] = 'tribe-events-calendar-month-mobile-events__mobile-day--show';
-}
 ?>
 
 <div <?php tribe_classes( $classes ); ?> id="<?php echo sanitize_html_class( $mobile_day_id ); ?>">

--- a/src/views/v2/month/mobile-events/mobile-day/day-marker.php
+++ b/src/views/v2/month/mobile-events/mobile-day/day-marker.php
@@ -27,7 +27,7 @@ $day_date_obj = Dates::build_date_object( $day_date );
 ?>
 <div class="tribe-events-c-day-marker tribe-events-calendar-month-mobile-events__day-marker">
 	<time
-		class="tribe-events-c-day-marker__date tribe-common-h7 tribe-common-h--alt"
+		class="tribe-common-h7 tribe-common-h--alt tribe-events-c-day-marker__date"
 		datetime="<?php echo esc_attr( $day_date_obj->format_i18n( Dates::DBDATEFORMAT ) ); ?>"
 	>
 		<?php echo esc_html( $day_date_obj->format_i18n( tribe_get_date_format() ) ); ?>

--- a/src/views/v2/month/mobile-events/mobile-day/mobile-event.php
+++ b/src/views/v2/month/mobile-events/mobile-day/mobile-event.php
@@ -15,8 +15,12 @@
  *
  * @see tribe_get_event() For the format of the event object.
  */
-$classes = tribe_get_post_class( [ 'tribe-events-calendar-month-mobile-events__mobile-event' ], $event->ID );
-$classes['tribe-events-calendar-month-mobile-events__mobile-event--featured'] = $event->featured;
+$classes = [
+	'tribe-events-calendar-month-mobile-events__mobile-event',
+	'tribe-events-calendar-month-mobile-events__mobile-event--featured' => $event->featured,
+];
+
+$classes = tribe_get_post_class( $classes, $event->ID );
 ?>
 
 <article <?php tribe_classes( $classes ); ?>>

--- a/src/views/v2/month/mobile-events/mobile-day/mobile-event/date.php
+++ b/src/views/v2/month/mobile-events/mobile-day/mobile-event/date.php
@@ -23,7 +23,7 @@ use Tribe__Date_Utils as Dates;
 $time_format = tribe_get_time_format();
 $event_date_attr = $event->dates->start->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-calendar-month-mobile-events__mobile-event-datetime tribe-common-b2">
+<div class="tribe-common-b2 tribe-events-calendar-month-mobile-events__mobile-event-datetime">
 	<?php $this->template( 'month/mobile-events/mobile-day/mobile-event/date/featured' ); ?>
 	<?php if ( $event->all_day ) : ?>
 		<time datetime="<?php echo esc_attr( $event->dates->start->format( Dates::DBDATEFORMAT ) ) ?>">

--- a/src/views/v2/month/mobile-events/mobile-day/mobile-event/title.php
+++ b/src/views/v2/month/mobile-events/mobile-day/mobile-event/title.php
@@ -16,7 +16,10 @@
  * @see tribe_get_event() For the format of the event object.
  */
 
-$classes = [ 'tribe-events-calendar-month-mobile-events__mobile-event-title', 'tribe-common-h7' ];
+$classes = [
+	'tribe-common-h7',
+	'tribe-events-calendar-month-mobile-events__mobile-event-title',
+];
 
 ?>
 <h3 <?php tribe_classes( $classes ); ?>>
@@ -24,7 +27,7 @@ $classes = [ 'tribe-events-calendar-month-mobile-events__mobile-event-title', 't
 		href="<?php echo esc_url( $event->permalink ) ?>"
 		title="<?php echo esc_attr( $event->title ) ?>"
 		rel="bookmark"
-		class="tribe-events-calendar-month-mobile-events__mobile-event-title-link tribe-common-anchor"
+		class="tribe-common-anchor tribe-events-calendar-month-mobile-events__mobile-event-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/month/mobile-events/mobile-day/more-events.php
+++ b/src/views/v2/month/mobile-events/mobile-day/more-events.php
@@ -21,10 +21,10 @@ if ( empty( $more_events ) || empty( $more_url ) ) {
 }
 ?>
 
-<div class="tribe-events-calendar-month-mobile-events__more-events tribe-events-c-small-cta tribe-common-b3">
+<div class="tribe-common-b3 tribe-events-c-small-cta tribe-events-calendar-month-mobile-events__more-events">
 	<a
 		href="<?php echo esc_url( $more_url ); ?>"
-		class="tribe-events-calendar-month-mobile-events__more-events-link tribe-events-c-small-cta__link tribe-common-cta tribe-common-cta--thin-alt"
+		class="tribe-common-cta tribe-common-cta--thin-alt tribe-events-c-small-cta__link tribe-events-calendar-month-mobile-events__more-events-link"
 		data-js="tribe-events-view-link"
 	>
 		<?php

--- a/src/views/v2/month/mobile-events/nav/next-disabled.php
+++ b/src/views/v2/month/mobile-events/nav/next-disabled.php
@@ -18,7 +18,7 @@
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--next">
 	<button
-		class="tribe-events-c-nav__next tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__next"
 		aria-label="<?php echo esc_attr( sprintf( __( 'Next month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		title="<?php echo esc_attr( sprintf( __( 'Next month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		disabled

--- a/src/views/v2/month/mobile-events/nav/next.php
+++ b/src/views/v2/month/mobile-events/nav/next.php
@@ -20,7 +20,7 @@
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="next"
-		class="tribe-events-c-nav__next tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__next"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( sprintf( __( 'Next month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		title="<?php echo esc_attr( sprintf( __( 'Next month, %1$s', 'the-events-calendar' ), $label ) ); ?>"

--- a/src/views/v2/month/mobile-events/nav/prev-disabled.php
+++ b/src/views/v2/month/mobile-events/nav/prev-disabled.php
@@ -17,7 +17,7 @@
 ?>
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--prev">
 	<button
-		class="tribe-events-c-nav__prev tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__prev"
 		aria-label="<?php echo esc_attr( sprintf( __( 'Previous month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		title="<?php echo esc_attr( sprintf( __( 'Previous month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		disabled

--- a/src/views/v2/month/mobile-events/nav/prev.php
+++ b/src/views/v2/month/mobile-events/nav/prev.php
@@ -20,7 +20,7 @@
 	<a
 		href="<?php echo esc_url( $link ); ?>"
 		rel="prev"
-		class="tribe-events-c-nav__prev tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__prev"
 		data-js="tribe-events-view-link"
 		aria-label="<?php echo esc_attr( sprintf( __( 'Previous month, %1$s', 'the-events-calendar' ), $label ) ); ?>"
 		title="<?php echo esc_attr( sprintf( __( 'Previous month, %1$s', 'the-events-calendar' ), $label ) ); ?>"

--- a/src/views/v2/month/mobile-events/nav/today.php
+++ b/src/views/v2/month/mobile-events/nav/today.php
@@ -18,7 +18,7 @@
 <li class="tribe-events-c-nav__list-item tribe-events-c-nav__list-item--today">
 	<a
 		href="<?php echo esc_url( $today_url ); ?>"
-		class="tribe-events-c-nav__today tribe-common-b2"
+		class="tribe-common-b2 tribe-events-c-nav__today"
 		data-js="tribe-events-view-link"
 		aria-label="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"
 		title="<?php esc_attr_e( 'Click to select today\'s date', 'the-events-calendar' ); ?>"

--- a/src/views/v2/widgets/widget-events-list.php
+++ b/src/views/v2/widgets/widget-events-list.php
@@ -54,7 +54,7 @@ if ( empty( $events ) && $hide_if_no_upcoming_events ) {
 			<?php $this->template( 'components/data' ); ?>
 
 			<header class="tribe-events-widget-events-list__header">
-				<h2 class="tribe-events-widget-events-list__header-title tribe-common-h6 tribe-common-h--alt">
+				<h2 class="tribe-common-h6 tribe-common-h--alt tribe-events-widget-events-list__header-title">
 					<?php echo esc_html( $widget_title ); ?>
 				</h2>
 			</header>

--- a/src/views/v2/widgets/widget-events-list/event.php
+++ b/src/views/v2/widgets/widget-events-list/event.php
@@ -25,7 +25,7 @@ $event_classes = tribe_get_post_class( [ 'tribe-events-widget-events-list__event
 
 	<?php $this->template( 'widgets/widget-events-list/event/date-tag', [ 'event' => $event ] ); ?>
 
-	<div class="tribe-events-widget-events-list__event-wrapper tribe-common-g-col">
+	<div class="tribe-common-g-col tribe-events-widget-events-list__event-wrapper">
 		<article <?php tribe_classes( $event_classes ) ?>>
 			<div class="tribe-events-widget-events-list__event-details">
 

--- a/src/views/v2/widgets/widget-events-list/event/date-tag.php
+++ b/src/views/v2/widgets/widget-events-list/event/date-tag.php
@@ -30,12 +30,12 @@ $event_month     = $display_date->format_i18n( 'M' );
 $event_day_num   = $display_date->format_i18n( 'j' );
 $event_date_attr = $display_date->format( Dates::DBDATEFORMAT );
 ?>
-<div class="tribe-events-widget-events-list__event-date-tag tribe-common-g-col">
+<div class="tribe-common-g-col tribe-events-widget-events-list__event-date-tag">
 	<time class="tribe-events-widget-events-list__event-date-tag-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<span class="tribe-events-widget-events-list__event-date-tag-month">
 			<?php echo esc_html( $event_month ); ?>
 		</span>
-		<span class="tribe-events-widget-events-list__event-date-tag-daynum tribe-common-h2 tribe-common-h4--min-medium">
+		<span class="tribe-common-h2 tribe-common-h4--min-medium tribe-events-widget-events-list__event-date-tag-daynum">
 			<?php echo esc_html( $event_day_num ); ?>
 		</span>
 	</time>

--- a/src/views/v2/widgets/widget-events-list/event/date.php
+++ b/src/views/v2/widgets/widget-events-list/event/date.php
@@ -29,7 +29,7 @@ if ( $event->multiday ) {
 	$event_date = $event->short_schedule_details->value();
 }
 ?>
-<div class="tribe-events-widget-events-list__event-datetime-wrapper tribe-common-b2 tribe-common-b3--min-medium">
+<div class="tribe-common-b2 tribe-common-b3--min-medium tribe-events-widget-events-list__event-datetime-wrapper">
 	<?php $this->template( 'widgets/widget-events-list/event/date/featured', [ 'event' => $event ] ); ?>
 	<time class="tribe-events-widget-events-list__event-datetime" datetime="<?php echo esc_attr( $event_date_attr ); ?>">
 		<?php echo $event_date; // phpcs:ignore. ?>

--- a/src/views/v2/widgets/widget-events-list/event/title.php
+++ b/src/views/v2/widgets/widget-events-list/event/title.php
@@ -16,12 +16,12 @@
  * @see tribe_get_event() For the format of the event object.
  */
 ?>
-<h3 class="tribe-events-widget-events-list__event-title tribe-common-h7">
+<h3 class="tribe-common-h7 tribe-events-widget-events-list__event-title">
 	<a
 		href="<?php echo esc_url( $event->permalink ); ?>"
 		title="<?php echo esc_attr( $event->title ); ?>"
 		rel="bookmark"
-		class="tribe-events-widget-events-list__event-title-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-widget-events-list__event-title-link"
 	>
 		<?php
 		// phpcs:ignore

--- a/src/views/v2/widgets/widget-events-list/view-more.php
+++ b/src/views/v2/widgets/widget-events-list/view-more.php
@@ -25,10 +25,10 @@ if ( empty( $view_more_link ) ) {
 	return;
 }
 ?>
-<div class="tribe-events-widget-events-list__view-more tribe-common-b1 tribe-common-b2--min-medium">
+<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-events-widget-events-list__view-more">
 	<a
 		href="<?php echo esc_url( $view_more_link ); ?>"
-		class="tribe-events-widget-events-list__view-more-link tribe-common-anchor-thin"
+		class="tribe-common-anchor-thin tribe-events-widget-events-list__view-more-link"
 		title="<?php echo esc_attr( $view_more_title ); ?>"
 	>
 		<?php echo esc_html( $view_more_text ); ?>


### PR DESCRIPTION
They should be "overridden" by the element class(es). 
Order doesn't really matter for this - _but_ it's easier to tell a user "grab the last class on the element and use that (then they don't accidentally override a common class) when you know the "last class" will be the most specific.

Element-specific classes should be listed in order of specificity:
Old: `'tribe-events-header__messages tribe-events-c-messages tribe-common-b2'`
New: `'tribe-common-b2 tribe-events-c-messages tribe-events-header__messages'`

This is also prep for using something like Tailwind or Atomic CSS - where the "utility classes" come first and the final class listed is a specific target class.

Also cleans up our implementations of `tribe_classes()`. To order the arrays in the same way.