### PR TITLE
Only enqueue full styles for event single v2 when display setting is full styles

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Ensure when saving on Blocks editor Organizer and Venue IDs don't throw notices for failed deletion. [TEC-3844]
 * Tweak - Added the ability to filter cached view HTML. Hooks added were: `tribe_events_views_v2_view_cached_html` and `tribe_events_views_v2_view_{$view_slug}_cached_html`. [ECP-770]
 * Fix - Resolve compatibility problem between The Events Calendar and other plugins using Select2. [TEC-3748]
+* Fix - Enqueue full styles for v2 event single only when using full styles. [TEC-3848]
 
 = [5.5.0.1] 2021-04-05  =
 

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -402,7 +402,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 			[],
 			'wp_enqueue_scripts',
 			[
-				'priority' => 15,
+				'priority'     => 15,
 				'conditionals' => [
 					[ $this, 'should_enqueue_single_event_styles' ],
 				],
@@ -418,9 +418,11 @@ class Assets extends \tad_DI52_ServiceProvider {
 			],
 			'wp_enqueue_scripts',
 			[
-				'priority' => 15,
+				'priority'     => 15,
 				'conditionals' => [
+					'operator' => 'AND',
 					[ $this, 'should_enqueue_single_event_styles' ],
+					[ $this, 'should_enqueue_full_styles' ],
 				],
 			]
 		);


### PR DESCRIPTION
**Ticket:** [TEC-3848]

This PR ensures the v2 event single full styles are only enqueued when the setting is set to full styles, not skeleton.

**Artifact:**

![image](https://user-images.githubusercontent.com/16699941/115346894-56bff180-a1e3-11eb-8846-a057ae20f0f2.png)


[TEC-3848]: https://theeventscalendar.atlassian.net/browse/TEC-3848