### PR TITLE
Correct implementation of tribe_get_event_website_link()

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -969,12 +969,6 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @return string
 	 */
 	public function filter_single_event_details_event_website_label( $label, $post_id = null ) {
-		bdump('filter_single_event_details_event_website_label');
-		bdump([
-			is_null( $post_id ),
-				! tribe_events_single_view_v2_is_enabled(),
-				has_blocks( $post_id ),
-		]);
 		// If not V2 or not Classic Editor, return the website url.
 		if ( $this->is_v1_or_blocks( $post_id ) ) {
 			return $label;

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -969,6 +969,12 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @return string
 	 */
 	public function filter_single_event_details_event_website_label( $label, $post_id = null ) {
+		bdump('filter_single_event_details_event_website_label');
+		bdump([
+			is_null( $post_id ),
+				! tribe_events_single_view_v2_is_enabled(),
+				has_blocks( $post_id ),
+		]);
 		// If not V2 or not Classic Editor, return the website url.
 		if ( $this->is_v1_or_blocks( $post_id ) ) {
 			return $label;

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -357,19 +357,21 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	 * @return string $html
 	 */
 	function tribe_get_event_website_link( $event = null, $label = null ) {
-		$url = tribe_get_event_website_url( $event );
+		// We won't get far without a post ID. Especially since we pass it to filters that depend on it.
+		$post_id = Tribe__Events__Main::postIdHelper( $event );
+		$url     = tribe_get_event_website_url( $post_id );
 
 		/**
 		 * Filter the target attribute for the event website link
 		 *
 		 * @since 5.1.0
-		 * @since 5.5.0 Added $event argument
+		 * @since 5.5.0 Added $post_id argument
 		 *
 		 * @param string          $target The target attribute string. Defaults to "_self".
 		 * @param string          $url    The link URL.
-		 * @param null|object|int $event  The event the url is attached to.
+		 * @param null|object|int $post_id  The event the url is attached to.
 		 */
-		$target = apply_filters( 'tribe_get_event_website_link_target', '_self', $url, $event );
+		$target = apply_filters( 'tribe_get_event_website_link_target', '_self', $url, $post_id );
 		$rel    = ( '_blank' === $target ) ? 'noopener noreferrer' : 'external';
 
 		if ( ! empty( $url ) ) {
@@ -381,7 +383,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			 *
 			 * @param string the link label/text.
 			 */
-			$label = apply_filters( 'tribe_get_event_website_link_label', $label, $event );
+			$label = apply_filters( 'tribe_get_event_website_link_label', $label, $post_id );
 			$html  = sprintf(
 				'<a href="%s" target="%s" rel="%s">%s</a>',
 				esc_url( $url ),

--- a/src/views/blocks/classic-event-details.php
+++ b/src/views/blocks/classic-event-details.php
@@ -51,7 +51,7 @@ $time_formatted = apply_filters( 'tribe_events_single_event_time_formatted', $ti
  */
 $time_title = apply_filters( 'tribe_events_single_event_time_title', __( 'Time:', 'the-events-calendar' ), $event_id );
 
-$website = tribe_get_event_website_link();
+$website = tribe_get_event_website_link( $event_id );
 ?>
 <div class="tribe-events-single-section tribe-events-event-meta primary tribe-clearfix">
 	<?php do_action( 'tribe_events_single_event_meta_primary_section_start' ); ?>

--- a/src/views/blocks/parts/details.php
+++ b/src/views/blocks/parts/details.php
@@ -53,7 +53,7 @@ $time_formatted = apply_filters( 'tribe_events_single_event_time_formatted', $ti
 $time_title = apply_filters( 'tribe_events_single_event_time_title', __( 'Time:', 'the-events-calendar' ), $event_id );
 
 $cost = tribe_get_formatted_cost();
-$website = tribe_get_event_website_link();
+$website = tribe_get_event_website_link( $event_id );
 ?>
 
 <div class="tribe-events-meta-group tribe-events-meta-group-details">

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -53,7 +53,7 @@ $time_formatted = apply_filters( 'tribe_events_single_event_time_formatted', $ti
 $time_title = apply_filters( 'tribe_events_single_event_time_title', __( 'Time:', 'the-events-calendar' ), $event_id );
 
 $cost    = tribe_get_formatted_cost();
-$website = tribe_get_event_website_link();
+$website = tribe_get_event_website_link( $event_id );
 $website_title = tribe_events_get_event_website_title();
 ?>
 


### PR DESCRIPTION
The issue: 
The event website link label is not being filtered correctly.

Reason:
The filters rely on a valid post ID - and we don't always pass one.

Correction:

1. Find our uses of tribe_get_event_website_link() and include the post ID - it's a param and since it's available in every case we should pass it.
2. Add functionality to _get_ the post ID if it's not passed (for backwards compatibility and customizations)

https://d.pr/i/YJlL0I

[ECP-761]

Related: https://github.com/the-events-calendar/events-pro/pull/1734

[ECP-761]: https://theeventscalendar.atlassian.net/browse/ECP-761