### PR TITLE
Simplify the registration of new views

### DIFF
--- a/src/Tribe/Views/V2/Manager.php
+++ b/src/Tribe/Views/V2/Manager.php
@@ -43,6 +43,19 @@ class Manager {
 	public static $option_mobile_default = 'mobile_default_view';
 
 	/**
+	 * Registration objects for auto-registered views.
+	 *
+	 * @since TBD
+	 *
+	 * @var array
+	 */
+	private $view_registration = [];
+
+	public function register_view( $slug, $name, $class, $priority = 30 ) {
+		$this->view_registration[ $slug ] = new View_Register( $slug, $name, $class, $priority );
+	}
+
+	/**
 	 * Returns an associative array of Views currently registered.
 	 *
 	 * @since  4.9.4

--- a/src/Tribe/Views/V2/Manager.php
+++ b/src/Tribe/Views/V2/Manager.php
@@ -51,8 +51,29 @@ class Manager {
 	 */
 	private $view_registration = [];
 
+	/**
+	 * Registers a view such that sensible defaults are registered and hooked.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug View slug.
+	 * @param string $name View name.
+	 * @param string $class View class.
+	 * @param int $priority View registration priority.
+	 */
 	public function register_view( $slug, $name, $class, $priority = 30 ) {
 		$this->view_registration[ $slug ] = new View_Register( $slug, $name, $class, $priority );
+	}
+
+	/**
+	 * Gets all generated View_Register objects.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_view_registration_objects() {
+		return $this->view_registration;
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Manager.php
+++ b/src/Tribe/Views/V2/Manager.php
@@ -60,9 +60,11 @@ class Manager {
 	 * @param string $name View name.
 	 * @param string $class View class.
 	 * @param int $priority View registration priority.
+	 *
+	 * @return View_Register
 	 */
 	public function register_view( $slug, $name, $class, $priority = 30 ) {
-		$this->view_registration[ $slug ] = new View_Register( $slug, $name, $class, $priority );
+		return $this->view_registration[ $slug ] = new View_Register( $slug, $name, $class, $priority );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -2463,4 +2463,38 @@ class View implements View_Interface {
 
 		return $ids;
 	}
+
+	/**
+	 * Gets the base object for asset registration.
+	 *
+	 * @since TBD
+	 *
+	 * @return \stdClass $object Object to tie registered assets to.
+	 */
+	public static function get_asset_origin( $slug ) {
+		$asset_registration_object = tribe( 'tec.main' );
+
+		/**
+		 * Filters the object used for registering assets.
+		 *
+		 * @since TBD
+		 *
+		 * @param \stdClass $origin_object Object used for asset registration.
+		 * @param string $slug View slug.
+		 */
+		$asset_registration_object = apply_filters( "tribe_events_views_v2_view_{$slug}_asset_origin_object", $asset_registration_object, $slug );
+
+		return $asset_registration_object;
+	}
+
+	/**
+	 * Registers assets for the view.
+	 *
+	 * Should be overridden if there are assets for the view.
+	 *
+	 * @since TBD
+	 *
+	 * @param \stdClass $object Object to tie registered assets to.
+	 */
+	public static function register_assets( $object ) {}
 }

--- a/src/Tribe/Views/V2/View_Register.php
+++ b/src/Tribe/Views/V2/View_Register.php
@@ -102,8 +102,10 @@ class View_Register {
 			->archive( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
 			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1' ] )
 			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1', 'featured' => true ] )
+			->tax( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%2' ] )
 			->tax( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
 			->tax( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
+			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%2' ] )
 			->tag( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
 			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] );
 	}

--- a/src/Tribe/Views/V2/View_Register.php
+++ b/src/Tribe/Views/V2/View_Register.php
@@ -51,7 +51,7 @@ class View_Register {
 	 * @param string $class Class name for the view.
 	 * @param int $priority Priority order for the view registration.
 	 */
-	public function __construct( $slug, $name, $class, $priority = 10 ) {
+	public function __construct( $slug, $name, $class, $priority = 40 ) {
 		$this->slug     = $slug;
 		$this->name     = $name;
 		$this->class    = $class;

--- a/src/Tribe/Views/V2/View_Register.php
+++ b/src/Tribe/Views/V2/View_Register.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * The View registration facade.
+ *
+ * @package Tribe\Events\Views\V2
+ * @since   TBD
+ */
+
+namespace Tribe\Events\Views\V2;
+
+/**
+ * Class View_Register
+ *
+ * @package Tribe\Events\Views\V2
+ * @since   TBD
+ */
+class View_Register {
+	/**
+	 * Slug for the view.
+	 *
+	 * @var string
+	 */
+	protected $slug;
+
+	/**
+	 * Name for the view.
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * Class name for the view.
+	 *
+	 * @var string
+	 */
+	protected $class;
+
+	/**
+	 * Priority order for the view registration.
+	 *
+	 * @var int
+	 */
+	protected $priority;
+
+	/**
+	 * View_Register constructor.
+	 *
+	 * @param string $slug Slug for the view.
+	 * @param string $name Name for the view.
+	 * @param string $class Class name for the view.
+	 * @param int $priority Priority order for the view registration.
+	 */
+	public function __construct( $slug, $name, $class, $priority = 10 ) {
+		$this->slug     = $slug;
+		$this->name     = $name;
+		$this->class    = $class;
+		$this->priority = $priority;
+
+		$this->add_actions();
+		$this->add_filters();
+	}
+
+	/**
+	 * Adds actions for view registration.
+	 *
+	 * @since TBD
+	 */
+	protected function add_actions() {
+		add_action( 'tribe_events_pre_rewrite', [ $this, 'filter_add_routes' ], 5 );
+	}
+
+	/**
+	 * Adds filters for view registration.
+	 *
+	 * @since TBD
+	 */
+	protected function add_filters() {
+		add_filter( 'tribe_events_views', [ $this, 'filter_events_views' ] );
+		add_filter( 'tribe-events-bar-views', [ $this, 'filter_tec_bar_views' ], $this->priority, 1 );
+		add_filter( 'tribe_events_rewrite_base_slugs', [ $this, 'filter_add_base_slugs' ], $this->priority );
+		add_filter( 'tribe_events_rewrite_matchers_to_query_vars_map', [ $this, 'filter_add_matchers_to_query_vars_map' ], $this->priority, 2 );
+	}
+
+	/**
+	 * Add rewrite routes for custom PRO stuff and views.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__Events__Rewrite $rewrite The Tribe__Events__Rewrite object
+	 *
+	 * @return void
+	 */
+	public function filter_add_routes( $rewrite ) {
+		$rewrite
+			->archive( [ '{{ ' . $this->slug . ' }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'paged' => '%1' ] )
+			->archive( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%1' ] )
+			->archive( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
+			->archive( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
+			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1' ] )
+			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1', 'featured' => true ] )
+			->tax( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
+			->tax( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
+			->tag( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
+			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] );
+	}
+
+	/**
+	 * Add the required bases for the Pro Views
+	 *
+	 * @since TBD
+	 *
+	 * @param array $bases Bases that are already set
+	 *
+	 * @return array         The modified version of the array of bases
+	 */
+	public function filter_add_base_slugs( $bases = [] ) {
+		// Support the original and translated forms for added robustness
+		$bases[ $this->slug ] = [  $this->slug , $this->slug ];
+
+		return $bases;
+	}
+
+	/**
+	 * Add the required bases for the Summary View.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $bases Bases that are already set.
+	 *
+	 * @return array         The modified version of the array of bases.
+	 */
+	public function filter_add_matchers_to_query_vars_map( $matchers = [], $rewrite = null ) {
+		$matchers[ $this->slug ] = 'eventDisplay';
+
+		return $matchers;
+	}
+
+	/**
+	 * Filters the available views.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $views An array of available Views.
+	 *
+	 * @return array The array of available views, including the PRO ones.
+	 */
+	public function filter_events_views( array $views = [] ) {
+		$views[ $this->slug ] = $this->class;
+
+		return $views;
+	}
+
+	/**
+	 * Add the view to the views selector in the TEC bar.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $views The current array of views registered to the tribe bar.
+	 *
+	 * @return array The views registered with photo view added.
+	 */
+	public function filter_tec_bar_views( $views ) {
+		$views[] = array(
+			'displaying'     => $this->slug,
+			'anchor'         => $this->name,
+			'event_bar_hook' => 'tribe_events_before_template',
+			'url'            => \tribe_get_view_permalink( $this->slug ),
+		);
+
+		return $views;
+	}
+}

--- a/src/Tribe/Views/V2/View_Register.php
+++ b/src/Tribe/Views/V2/View_Register.php
@@ -59,6 +59,9 @@ class View_Register {
 
 		$this->add_actions();
 		$this->add_filters();
+
+		$asset_registration_object = call_user_func( $this->class . '::get_asset_origin', $this->slug );
+		call_user_func( $this->class . '::register_assets', $asset_registration_object );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/View_Register.php
+++ b/src/Tribe/Views/V2/View_Register.php
@@ -95,19 +95,28 @@ class View_Register {
 	 * @return void
 	 */
 	public function filter_add_routes( $rewrite ) {
+		// Setup base rewrite rules
 		$rewrite
 			->archive( [ '{{ ' . $this->slug . ' }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'paged' => '%1' ] )
 			->archive( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%1' ] )
 			->archive( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
 			->archive( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
 			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1' ] )
-			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1', 'featured' => true ] )
+			->archive( [ '{{ ' . $this->slug . ' }}', '(\d{4}-\d{2}-\d{2})', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'eventDate' => '%1', 'featured' => true ] );
+
+		// Setup taxonomy based rewrite rules.
+		$rewrite
+			->tax( [ '{{ ' . $this->slug . ' }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'paged' => '%2' ] )
 			->tax( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%2' ] )
-			->tax( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
 			->tax( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
+			->tax( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] );
+
+		// Setup post_tag rewrite rules.
+		$rewrite
+			->tag( [ '{{ ' . $this->slug . ' }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'paged' => '%2' ] )
 			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}', '{{ page }}', '(\d+)' ], [ 'eventDisplay' => $this->slug, 'featured' => true, 'paged' => '%2' ] )
-			->tag( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] )
-			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] );
+			->tag( [ '{{ ' . $this->slug . ' }}', '{{ featured }}' ], [ 'eventDisplay' => $this->slug, 'featured' => true ] )
+			->tag( [ '{{ ' . $this->slug . ' }}' ], [ 'eventDisplay' => $this->slug ] );
 	}
 
 	/**

--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -141,6 +141,37 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
+	 * Gets a view permalink.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool|int|null $term
+	 *
+	 * @return string $permalink
+	 */
+	function tribe_get_view_permalink( $slug, $term = null ) {
+		$permalink = Tribe__Events__Main::instance()->getLink( $slug, null, $term );
+
+		/**
+		 * Provides an opportunity to modify the overall view permalink.
+		 *
+		 * @var string $permalink
+		 * @var string $slug
+		 * @var mixed  $term
+		 */
+		$permalink = apply_filters( 'tribe_get_view_permalink', $permalink, $slug, $term );
+
+		/**
+		 * Provides an opportunity to modify the specific view permalink.
+		 *
+		 * @var string $permalink
+		 * @var string $slug
+		 * @var mixed  $term
+		 */
+		return apply_filters( "tribe_get_{$slug}_view_permalink", $permalink, $slug, $term );
+	}
+
+	/**
 	 * Link to Grid View
 	 *
 	 * Returns a link to the general or category calendar grid view

--- a/src/functions/views/provider.php
+++ b/src/functions/views/provider.php
@@ -2,6 +2,18 @@
 use Tribe\Events\Views\V2\Manager;
 
 /**
+ * Registers a view.
+ *
+ * @param string $slug View slug.
+ * @param string $name View name.
+ * @param string $class View class.
+ * @param int $priority View registration priority.
+ */
+function tribe_register_view( $slug, $name, $class, $priority = 30 ) {
+	tribe( Manager::class )->register_view( $slug, $name, $class, $priority );
+}
+
+/**
  * Checks whether v2 of the Views is enabled or not.
  *
  * In order the function will check the `TRIBE_EVENTS_V2_VIEWS` constant,

--- a/src/functions/views/provider.php
+++ b/src/functions/views/provider.php
@@ -4,6 +4,8 @@ use Tribe\Events\Views\V2\Manager;
 /**
  * Registers a view.
  *
+ * @since TBD
+ *
  * @param string $slug View slug.
  * @param string $name View name.
  * @param string $class View class.

--- a/src/functions/views/provider.php
+++ b/src/functions/views/provider.php
@@ -11,8 +11,8 @@ use Tribe\Events\Views\V2\Manager;
  * @param string $class View class.
  * @param int $priority View registration priority.
  */
-function tribe_register_view( $slug, $name, $class, $priority = 30 ) {
-	tribe( Manager::class )->register_view( $slug, $name, $class, $priority );
+function tribe_register_view( $slug, $name, $class, $priority = 50 ) {
+	return tribe( Manager::class )->register_view( $slug, $name, $class, $priority );
 }
 
 /**

--- a/tests/views_integration/Tribe/Events/Views/V2/ManagerTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace Tribe\Events\Views\V2;
 
+use Tribe\Events\Views\V2\Views\List_View;
 use Tribe\Events\Views\V2\Views\Reflector_View;
 use Tribe\Events\Test\Factories\Event;
-use Tribe__Context as Context;
 
 // Include a Test View Class
 require_once codecept_data_dir( 'Views/V2/classes/Test_View.php' );
@@ -132,4 +132,18 @@ class ManagerTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEmpty( $manager->get_publicly_visible_views() );
 	}
 
+	/**
+	 * @test
+	 */
+	public function should_create_view_register_objects_when_registering_a_view() {
+		$manager = $this->make_instance();
+		$manager->register_view( 'test', 'Test View', List_View::class, 10 );
+		$view_register_objects = $manager->get_view_registration_objects();
+
+		$this->assertCount( 1, $view_register_objects );
+		$this->assertEquals( View_Register::class, get_class( reset( $view_register_objects ) ) );
+
+		$registered_views = $manager->get_registered_views();
+		$this->assertContains( 'test', array_keys( $registered_views ) );
+	}
 }

--- a/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
@@ -62,8 +62,8 @@ class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @return Manager
 	 */
-	private function make_instance( $slug = 'test', $name = 'Test View', $class = List_View::class, $priority = 10 ) {
-		return new View_Register( $slug, $name, $class, $priority );
+	private function make_instance( $slug = 'test', $name = 'Test View', $class = List_View::class, $priority = 50 ) {
+		return tribe_register_view( $slug, $name, $class, $priority );
 	}
 
 	/**
@@ -104,8 +104,6 @@ class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $args, $parsed );
 		$this->assertEquals( $pretty_archive_url, $canonical_url );
-
-		codecept_debug( $rewrite->rewrite->rules );
 	}
 
 	public function endpoint_provider() {

--- a/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
@@ -104,6 +104,8 @@ class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $args, $parsed );
 		$this->assertEquals( $pretty_archive_url, $canonical_url );
+
+		codecept_debug( $rewrite->rewrite->rules );
 	}
 
 	public function endpoint_provider() {
@@ -171,12 +173,54 @@ class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
 			],
 		];
 
+		yield 'tag featured' => [
+			'url'  => '/events/tag/bacon/bork/featured/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'tag'          => 'bacon',
+				'featured'     => true,
+			],
+		];
+
+		yield 'tag featured and paged' => [
+			'url'  => '/events/tag/bacon/bork/featured/page/2/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'tag'          => 'bacon',
+				'featured'     => true,
+				'paged'        => 2,
+			],
+		];
+
 		yield 'category' => [
 			'url'  => '/events/category/potato/bork/',
 			'args' => [
 				'post_type'        => TEC::POSTTYPE,
 				'eventDisplay'     => 'bork',
 				'tribe_events_cat' => 'potato',
+			],
+		];
+
+		yield 'category featured' => [
+			'url'  => '/events/category/potato/bork/featured/',
+			'args' => [
+				'post_type'        => TEC::POSTTYPE,
+				'eventDisplay'     => 'bork',
+				'tribe_events_cat' => 'potato',
+				'featured'         => true,
+			],
+		];
+
+		yield 'category featured and paged' => [
+			'url'  => '/events/category/potato/bork/featured/page/3/',
+			'args' => [
+				'post_type'        => TEC::POSTTYPE,
+				'eventDisplay'     => 'bork',
+				'tribe_events_cat' => 'potato',
+				'featured'         => true,
+				'paged'            => 3,
 			],
 		];
 	}

--- a/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tribe\Events\Views\V2;
+
+use Tribe__Events__Main as TEC;
+use Tribe\Events\Views\V2\Views\List_View;
+use Tribe\Events\Test\Factories\Event;
+
+// Include a Test View Class
+require_once codecept_data_dir( 'Views/V2/classes/Test_View.php' );
+require_once codecept_data_dir( 'Views/V2/classes/Publicly_Visible_Test_View.php' );
+
+class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * A backup of the global `$wp` object query vars.
+	 *
+	 * @var string[]|RewriteTest
+	 */
+	protected static $wp_public_query_vars;
+
+	/**
+	 * The original, global WP_Rewrite.
+	 *
+	 * @var \WP_Rewrite
+	 */
+	protected static $wp_rewrite;
+
+	/**
+	 * @var \Tribe\Events\Pro\Rewrite\Rewrite
+	 */
+	protected $rewrite;
+
+	public function setUp() {
+		parent::setUp();
+
+		tribe_unset_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+
+		static::factory()->event = new Event();
+	}
+
+	public function wpSetUpBeforeClass() {
+		static::factory()->event = new Event();
+		// Let's backup the query vars to make sure we're using the full ones.
+		global $wp, $wp_rewrite;
+		$wp_rewrite->permalink_structure = '/%postname%/';
+		$wp_rewrite->rewrite_rules();
+		static::$wp_public_query_vars = $wp->public_query_vars;
+		static::$wp_rewrite = $wp_rewrite;
+
+		// Let's create some terms that we'll be using.
+		wp_insert_term( 'bacon', 'post_tag' );
+		wp_insert_term( 'potato', 'tribe_events_cat' );
+	}
+
+	public function tearDown() {
+		global $wp, $wp_rewrite;
+		$wp->public_query_vars = static::$wp_public_query_vars;
+		$wp_rewrite            = static::$wp_rewrite;
+		parent::tearDown();
+	}
+
+	/**
+	 * @return Manager
+	 */
+	private function make_instance( $slug = 'test', $name = 'Test View', $class = List_View::class, $priority = 10 ) {
+		return new View_Register( $slug, $name, $class, $priority );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( View_Register::class, $sut );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider endpoint_provider
+	 */
+	public function it_should_contain_the_registered_view_in_rewrite_routes( $url, $args ) {
+		global $wp, $wp_rewrite;
+
+		$sut = $this->make_instance( 'bork' );
+
+		wp_cache_flush();
+		$wp_rewrite->permalink_structure = '/%postname%/';
+		// Let's make sure to set rewrite rules.
+		$wp->public_query_vars = static::$wp_public_query_vars;
+
+		$rewrite        = \Tribe__Events__Rewrite::instance();
+		$rewrite->bases = null;
+		$rewrite->rules = null;
+		$rewrite->setup( $wp_rewrite );
+
+		flush_rewrite_rules();
+
+		$pretty_archive_url = home_url( $url );
+		$ugly_archive_url   = add_query_arg( $args, home_url() );
+
+		$parsed             = $rewrite->parse_request( $pretty_archive_url );
+		$canonical_url      = $rewrite->get_canonical_url( $ugly_archive_url );
+
+		$this->assertEquals( $args, $parsed );
+		$this->assertEquals( $pretty_archive_url, $canonical_url );
+	}
+
+	public function endpoint_provider() {
+		yield 'base view' => [
+			'url'  => '/events/bork/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+			],
+		];
+
+		yield 'paged' => [
+			'url'  => '/events/bork/page/2/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'paged'        => 2,
+			],
+		];
+
+		yield 'featured' => [
+			'url'  => '/events/bork/featured/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'featured'     => true,
+			],
+		];
+
+		yield 'featured and paged' => [
+			'url'  => '/events/bork/featured/page/3/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'featured'     => true,
+				'paged'        => 3,
+			],
+		];
+
+		yield 'base view with date' => [
+			'url'  => '/events/bork/2020-01-30/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'eventDate'    => '2020-01-30',
+			],
+		];
+
+		yield 'featured with date' => [
+			'url'  => '/events/bork/2020-01-30/featured/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'featured'     => true,
+				'eventDate'    => '2020-01-30',
+			],
+		];
+
+		yield 'tag' => [
+			'url'  => '/events/tag/bacon/bork/',
+			'args' => [
+				'post_type'    => TEC::POSTTYPE,
+				'eventDisplay' => 'bork',
+				'tag'          => 'bacon',
+			],
+		];
+
+		yield 'category' => [
+			'url'  => '/events/category/potato/bork/',
+			'args' => [
+				'post_type'        => TEC::POSTTYPE,
+				'eventDisplay'     => 'bork',
+				'tribe_events_cat' => 'potato',
+			],
+		];
+	}
+}


### PR DESCRIPTION
In working on the Summary View implementation via the extension, I identified a number of ways that adding a new view was painful—hooking to all the right places in all the right classes to plumb in the view. This body of work adds a `View_Register` object for any view we wish to auto-plumb.

The `View_Register` object (with a helper-function: `tribe_register_view( $slug, $name, $class, $priority )`) sets up the rewrite rules, hooks in to the dashboard Display options, and adds the view to the TEC bar.

:movie_camera: https://d.pr/v/cXLU1E
:ticket: [ECP-799]