### PR TITLE
Correctly restore loop vars in View

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.6.1] TBD =
 
-
+* Fix - Resolve conflicts with Gravity Forms plugin that would prevent correct submission of forms data. [ECP-466]
 
 = [5.6.0] 2021-04-29 =
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1004,8 +1004,8 @@ class View implements View_Interface {
 		global $wp_query;
 
 		$this->global_backup = [
-			'wp_query'   => $wp_query,
-			'$_SERVER'   => isset( $_SERVER ) ? $_SERVER : []
+			'globals::wp_query'   => $wp_query,
+			'server::request_uri' => isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '',
 		];
 
 		$args = wp_parse_args( $args, $this->repository_args );
@@ -1034,8 +1034,11 @@ class View implements View_Interface {
 			return;
 		}
 
-		foreach ( $this->global_backup as $key => $value ) {
-			$GLOBALS[ $key ] = $value;
+		if ( isset( $this->global_backup['globals::wp_query'] ) ) {
+			$GLOBALS['wp_query'] = $this->global_backup['globals::wp_query'];
+		}
+		if ( isset( $this->global_backup['server::request_uri'] ) ) {
+			$_SERVER['REQUEST_URI'] = $this->global_backup['server::request_uri'];
 		}
 
 		wp_reset_postdata();

--- a/src/resources/postcss/views/skeleton/_header.pcss
+++ b/src/resources/postcss/views/skeleton/_header.pcss
@@ -50,9 +50,23 @@
 		margin-bottom: var(--spacer-3);
 		width: 100%;
 
+		/* By default hide the first one, show the second one. */
+		&:not([aria-hidden]) {
+			display: none;
+		}
+
 		.tribe-common--breakpoint-medium& {
 			margin-bottom: var(--spacer-7);
 			order: 1;
+
+			/* Hide the second one at the bottom on medium and above. */
+			&:not([aria-hidden]) {
+				display: flex;
+			}
+
+			&[aria-hidden] {
+				display: none;
+			}
 		}
 	}
 

--- a/src/views/v2/components/messages.php
+++ b/src/views/v2/components/messages.php
@@ -9,10 +9,11 @@
  *
  * @link http://evnt.is/1aiy
  *
- * @version 5.3.0
+ * @version TBD
  *
- * @var array  $messages     An array of user-facing messages, managed by the View.
- * @var string $wp_version  Global WP version.
+ * @var array<string,array<string>> $messages   An array of user-facing messages, managed by the View.
+ * @var array<string,mixed>         $attributes A optional map of attributes that should be applied to the wrapper div element.
+ * @var string                      $wp_version Global WP version.
  *
  * @package the-events-calendar/views/v2
  */
@@ -24,9 +25,10 @@ if ( empty( $messages ) ) {
 global $wp_version;
 
 $classes = [ 'tribe-events-header__messages', 'tribe-events-c-messages', 'tribe-common-b2' ];
+$attributes = isset( $attributes ) ? (array) $attributes : [];
 
 ?>
-<div <?php tribe_classes( $classes ); ?>>
+<div <?php tribe_classes( $classes ); ?> <?php tribe_attributes( $attributes ); ?>>
 	<?php foreach ( $messages as $message_type => $message_group ) : ?>
 		<div class="tribe-events-c-messages__message tribe-events-c-messages__message--<?php echo esc_attr( $message_type ); ?>" role="alert">
 			<?php $this->template( 'components/messages/' . esc_attr( $message_type ) . '-icon' ); ?>

--- a/src/views/v2/month.php
+++ b/src/views/v2/month.php
@@ -75,6 +75,9 @@ if ( empty( $disable_event_search ) ) {
 
 		</div>
 
+		<!-- This is the second occurrence of this, let's never show it to screen readers. -->
+		<?php $this->template( 'components/messages', [ 'attributes' => [ 'aria-hidden' => 'true' ] ] ); ?>
+
 		<?php $this->template( 'month/mobile-events' ); ?>
 
 		<?php $this->template( 'components/ical-link' ); ?>

--- a/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
@@ -329,4 +329,74 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $invalid_url_view->get_url_args() );
 	}
+
+	/**
+	 * It should correctly restore the loop
+	 *
+	 * @test
+	 */
+	public function should_correctly_restore_the_loop() {
+		// Let's register the test view as legit View.
+		add_filter( 'tribe_events_views', static function () {
+			return [ 'test' => Test_View::class ];
+		} );
+		// Set up the pre-view render context.
+		global $wp_query;
+		$page_name              = 'some-test-page';
+		$page_id                = static::factory()->post->create( [
+			'post_type' => 'page',
+			'post_name' => $page_name,
+		] );
+		$original_wp_query      = new \WP_Query( [ 'p' => $page_id ] );
+		$wp_query               = $original_wp_query;
+		$original_request_uri   = "/{$page_name}";
+		$_SERVER['REQUEST_URI'] = $original_request_uri;
+
+		$view = View::make( 'list' );
+		$view->setup_the_loop();
+
+		// We do not  care about the specifics, only that it changed.
+		$this->assertNotSame( $original_wp_query, $GLOBALS['wp_query'] );
+		$this->assertNotEquals( $original_request_uri, $_SERVER['REQUEST_URI'] );
+
+		$view->restore_the_loop();
+
+		$this->assertSame( $original_wp_query, $GLOBALS['wp_query'] );
+		$this->assertEquals( $original_request_uri, $_SERVER['REQUEST_URI'] );
+	}
+
+	/**
+	 * It should correctly restore the loop when set up with args
+	 *
+	 * @test
+	 */
+	public function should_correctly_restore_the_loop_when_set_up_with_args() {
+		// Let's register the test view as legit View.
+		add_filter( 'tribe_events_views', static function () {
+			return [ 'test' => Test_View::class ];
+		} );
+		// Set up the pre-view render context.
+		global $wp_query;
+		$page_name              = 'some-test-page';
+		$page_id                = static::factory()->post->create( [
+			'post_type' => 'page',
+			'post_name' => $page_name,
+		] );
+		$original_wp_query      = new \WP_Query( [ 'p' => $page_id ] );
+		$wp_query               = $original_wp_query;
+		$original_request_uri   = "/{$page_name}";
+		$_SERVER['REQUEST_URI'] = $original_request_uri;
+
+		$view = View::make( 'list' );
+		$view->setup_the_loop( [ 'eventDate' => '2020-01-01', 'tribe-bar-search' => 'lorem' ] );
+
+		// We do not  care about the specifics, only that it changed.
+		$this->assertNotSame( $original_wp_query, $GLOBALS['wp_query'] );
+		$this->assertNotEquals( $original_request_uri, $_SERVER['REQUEST_URI'] );
+
+		$view->restore_the_loop();
+
+		$this->assertSame( $original_wp_query, $GLOBALS['wp_query'] );
+		$this->assertEquals( $original_request_uri, $_SERVER['REQUEST_URI'] );
+	}
 }


### PR DESCRIPTION
- feat(v2/month) mobile messages below grid
- fix(V2/View.php) correctly restore the loop vars

Issue: https://theeventscalendar.atlassian.net/browse/ECP-466

This PR fixes the issue reported in the ticket and, potentially, another set of others.

The specific issues was caused by the fact that the form would set its `action` attribute to the current `$_SERVER['REQUEST_URI']` value.  
If the form shortcode came, in the HTML rendering order, **after** our shortcode (really **any** shortcode using a View), then that variable would have been altered in the context of the `View::setup_the_loop` method and, theoretically, restored after it.  

Since the `$_SERVER['REQUEST_URI']` variable was **not** restored correctly, the form, and in a similar way any other code rendering after a View and relying on the server request URI, would find the incorrect one.

[Screencap](https://www.dropbox.com/s/wv790tonpbg5b8e/Screen%20Recording%202021-05-05%20at%2015.05.07.mov?dl=0)
