### PR TITLE
TEC-3890: Prevent to trigger `xhr` requests for hash changes.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Add compatibility for the Full Site Editor navigation block. [TEC-3850]
 * Tweak - Filter the type of files allowed to upload into the EA Client. [TEC-3882]
 * Tweak - Updating lodash to 4.17.21. [TEC-3885]
+* Tweak - Prevent to list changes of hash on URL changes like `#content` [TEC-3890]
 
 = [5.6.0] 2021-04-29 =
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -30,7 +30,7 @@ tribe.events.views.manager = {};
  * @return {void}
  */
 ( function( $, _, obj ) {
-	const $window = $( window );
+	var $window = $( window );
 
 	/**
 	 * Selectors used for configuration and setup
@@ -98,10 +98,10 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.cleanup = function( container ) {
-		const $container = $( container );
-		const $form = $container.find( obj.selectors.form );
-		const $data = $container.find( obj.selectors.dataScript );
-		let data  = {};
+		var $container = $( container );
+		var $form = $container.find( obj.selectors.form );
+		var $data = $container.find( obj.selectors.dataScript );
+		var data  = {};
 
 		// If we have data element set it up.
 		if ( $data.length ) {
@@ -132,10 +132,10 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.setup = function( index, container ) {
-		const $container = $( container );
-		const $form = $container.find( obj.selectors.form );
-		const $data = $container.find( obj.selectors.dataScript );
-		let data  = {};
+		var $container = $( container );
+		var $form = $container.find( obj.selectors.form );
+		var $data = $container.find( obj.selectors.dataScript );
+		var data  = {};
 
 		// If we have data element set it up.
 		if ( $data.length ) {
@@ -164,7 +164,7 @@ tribe.events.views.manager = {};
 	 * @return {jQuery}
 	 */
 	obj.getContainer = function( element ) {
-		const $element = $( element );
+		var $element = $( element );
 
 		if ( ! $element.is( obj.selectors.container ) ) {
 			return $element.parents( obj.selectors.container ).eq( 0 );
@@ -183,14 +183,14 @@ tribe.events.views.manager = {};
 	 * @return {mixed}
 	 */
 	obj.getContainerData = function( $container ) {
-		const $data = $container.find( obj.selectors.dataScript );
+		var $data = $container.find( obj.selectors.dataScript );
 
 		// Bail in case we dont find data script.
 		if ( ! $data.length ) {
 			return;
 		}
 
-		const data = JSON.parse( $data.text().trim() );
+		var data = JSON.parse( $data.text().trim() );
 
 		return data;
 	};
@@ -205,8 +205,8 @@ tribe.events.views.manager = {};
 	 * @return {Boolean}
 	 */
 	obj.shouldManageUrl = function( $container ) {
-		let shouldManageUrl = $container.data( 'view-manage-url' );
-		const tribeIsTruthy   = /^(true|1|on|yes)$/;
+		var shouldManageUrl = $container.data( 'view-manage-url' );
+		var tribeIsTruthy   = /^(true|1|on|yes)$/;
 
 		// When undefined we use true as the default.
 		if ( typeof shouldManageUrl === typeof undefined ) {
@@ -243,14 +243,14 @@ tribe.events.views.manager = {};
 			return;
 		}
 
-		const $data = $container.find( obj.selectors.dataScript );
+		var $data = $container.find( obj.selectors.dataScript );
 
 		// Bail in case we dont find data script.
 		if ( ! $data.length ) {
 			return;
 		}
 
-		const data = JSON.parse( $data.text().trim() );
+		var data = JSON.parse( $data.text().trim() );
 
 		// Bail when the data is not a valid object
 		if ( ! _.isObject( data ) ) {
@@ -286,27 +286,27 @@ tribe.events.views.manager = {};
 	 * @return {boolean}
 	 */
 	obj.onLinkClick = function( event ) {
-		const $container = obj.getContainer( this );
+		var $container = obj.getContainer( this );
 
 		$container.trigger( 'beforeOnLinkClick.tribeEvents', event );
 
 		event.preventDefault();
 
-		const containerData = obj.getContainerData( $container );
+		var containerData = obj.getContainerData( $container );
 
-		const $link = $( this );
-		const url = $link.attr( 'href' );
-		const currentUrl = containerData.prev_url;
-		let nonce = $link.data( 'view-rest-nonce' );
-		const shouldManageUrl = obj.shouldManageUrl( $container );
-		const shortcodeId = $container.data( 'view-shortcode' );
+		var $link = $( this );
+		var url = $link.attr( 'href' );
+		var currentUrl = containerData.prev_url;
+		var nonce = $link.data( 'view-rest-nonce' );
+		var shouldManageUrl = obj.shouldManageUrl( $container );
+		var shortcodeId = $container.data( 'view-shortcode' );
 
 		// Fetch nonce from container if the link doesn't have any
 		if ( ! nonce ) {
 			nonce = $container.data( 'view-rest-nonce' );
 		}
 
-		const data = {
+		var data = {
 			prev_url: encodeURI( decodeURI( currentUrl ) ),
 			url: encodeURI( decodeURI( url ) ),
 			should_manage_url: shouldManageUrl,
@@ -336,18 +336,18 @@ tribe.events.views.manager = {};
 	 * @return {boolean}
 	 */
 	obj.onSubmit = function( event ) {
-		const $container = obj.getContainer( this );
+		var $container = obj.getContainer( this );
 		$container.trigger( 'beforeOnSubmit.tribeEvents', event );
 
 		event.preventDefault();
 
 		// The submit event is triggered on the form, not the container.
-		const $form = $( this );
-		const nonce = $container.data( 'view-rest-nonce' );
+		var $form = $( this );
+		var nonce = $container.data( 'view-rest-nonce' );
 
-		const formData = Qs.parse( $form.serialize() );
+		var formData = Qs.parse( $form.serialize() );
 
-		const data = {
+		var data = {
 			view_data: formData[ 'tribe-events-views' ],
 			_wpnonce: nonce,
 		};
@@ -372,9 +372,9 @@ tribe.events.views.manager = {};
 	 * @return {boolean}     Will always return false on this one.
 	 */
 	obj.onPopState = function( event ) {
-		const target = event.originalEvent.target;
-		const url = target.location.href;
-		const $container = obj.getLastContainer();
+		var target = event.originalEvent.target;
+		var url = target.location.href;
+		var $container = obj.getLastContainer();
 
 		// A pop state from a hash inside of the same URL has been trigger like #content  so no request is required.
 		if ( url && url.split( '#' ).length >= 2 ) {
@@ -394,9 +394,9 @@ tribe.events.views.manager = {};
 
 		$container.trigger( 'beforePopState.tribeEvents', event );
 
-		const nonce = $container.data( 'view-rest-nonce' );
+		var nonce = $container.data( 'view-rest-nonce' );
 
-		const data = {
+		var data = {
 			url: url,
 			_wpnonce: nonce,
 		};
@@ -417,8 +417,8 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.setupRequestData = function( data, $container ) {
-		const shouldManageUrl = obj.shouldManageUrl( $container );
-		const containerData = obj.getContainerData( $container );
+		var shouldManageUrl = obj.shouldManageUrl( $container );
+		var containerData = obj.getContainerData( $container );
 
 		if ( ! data.url ) {
 			data.url = containerData.url;
@@ -431,7 +431,7 @@ tribe.events.views.manager = {};
 		data.should_manage_url = shouldManageUrl;
 
 		// Allow other values to be passed to request from container data.
-		const requestData = $container.data( 'tribeRequestData' );
+		var requestData = $container.data( 'tribeRequestData' );
 
 		if ( ! $.isPlainObject( requestData ) ) {
 			return data;
@@ -454,7 +454,7 @@ tribe.events.views.manager = {};
 	obj.request = function( data, $container ) {
 		$container.trigger( 'beforeRequest.tribeEvents', [ data, $container ] );
 
-		const settings = obj.getAjaxSettings( $container );
+		var settings = obj.getAjaxSettings( $container );
 
 		// Pass the data setup to the $.ajax settings
 		settings.data = obj.setupRequestData( data, $container );
@@ -474,7 +474,7 @@ tribe.events.views.manager = {};
 	 * @return {Object}
 	 */
 	obj.getAjaxSettings = function( $container ) {
-		const ajaxSettings = {
+		var ajaxSettings = {
 			url: $container.data( 'view-rest-url' ),
 			accepts: 'html',
 			dataType: 'html',
@@ -505,14 +505,14 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxBeforeSend = function( jqXHR, settings ) {
-		const $container = this;
-		const $loader = $container.find( obj.selectors.loader );
+		var $container = this;
+		var $loader = $container.find( obj.selectors.loader );
 
 		$container.trigger( 'beforeAjaxBeforeSend.tribeEvents', [ jqXHR, settings ] );
 
 		if ( $loader.length ) {
 			$loader.removeClass( obj.selectors.hiddenElement.className() );
-			const $loaderText = $loader.find( obj.selectors.loaderText );
+			var $loaderText = $loader.find( obj.selectors.loaderText );
 			$loaderText.text( $loaderText.text() );
 		}
 		$container.attr( 'aria-busy', 'true' );
@@ -535,8 +535,8 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxComplete = function( jqXHR, textStatus ) {
-		const $container = this;
-		const $loader = $container.find( obj.selectors.loader );
+		var $container = this;
+		var $loader = $container.find( obj.selectors.loader );
 
 		$container.trigger( 'beforeAjaxComplete.tribeEvents', [ jqXHR, textStatus ] );
 
@@ -572,11 +572,11 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxSuccess = function( data, textStatus, jqXHR ) {
-		let $container = this;
+		var $container = this;
 
 		$container.trigger( 'beforeAjaxSuccess.tribeEvents', [ data, textStatus, jqXHR ] );
 
-		const $html = $( data );
+		var $html = $( data );
 
 		// Clean up the container and event listeners
 		obj.cleanup( $container );
@@ -617,7 +617,7 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxError = function( jqXHR, settings ) {
-		const $container = this;
+		var $container = this;
 
 		$container.trigger( 'beforeAjaxError.tribeEvents', [ jqXHR, settings ] );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -30,8 +30,7 @@ tribe.events.views.manager = {};
  * @return {void}
  */
 ( function( $, _, obj ) {
-	'use strict';
-	var $window = $( window );
+	const $window = $( window );
 
 	/**
 	 * Selectors used for configuration and setup
@@ -99,10 +98,10 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.cleanup = function( container ) {
-		var $container = $( container );
-		var $form = $container.find( obj.selectors.form );
-		var $data = $container.find( obj.selectors.dataScript );
-		var data  = {};
+		const $container = $( container );
+		const $form = $container.find( obj.selectors.form );
+		const $data = $container.find( obj.selectors.dataScript );
+		let data  = {};
 
 		// If we have data element set it up.
 		if ( $data.length ) {
@@ -133,10 +132,10 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.setup = function( index, container ) {
-		var $container = $( container );
-		var $form = $container.find( obj.selectors.form );
-		var $data = $container.find( obj.selectors.dataScript );
-		var data  = {};
+		const $container = $( container );
+		const $form = $container.find( obj.selectors.form );
+		const $data = $container.find( obj.selectors.dataScript );
+		let data  = {};
 
 		// If we have data element set it up.
 		if ( $data.length ) {
@@ -165,7 +164,7 @@ tribe.events.views.manager = {};
 	 * @return {jQuery}
 	 */
 	obj.getContainer = function( element ) {
-		var $element = $( element );
+		const $element = $( element );
 
 		if ( ! $element.is( obj.selectors.container ) ) {
 			return $element.parents( obj.selectors.container ).eq( 0 );
@@ -184,14 +183,14 @@ tribe.events.views.manager = {};
 	 * @return {mixed}
 	 */
 	obj.getContainerData = function( $container ) {
-		var $data = $container.find( obj.selectors.dataScript );
+		const $data = $container.find( obj.selectors.dataScript );
 
 		// Bail in case we dont find data script.
 		if ( ! $data.length ) {
 			return;
 		}
 
-		var data = JSON.parse( $data.text().trim() );
+		const data = JSON.parse( $data.text().trim() );
 
 		return data;
 	};
@@ -206,8 +205,8 @@ tribe.events.views.manager = {};
 	 * @return {Boolean}
 	 */
 	obj.shouldManageUrl = function( $container ) {
-		var shouldManageUrl = $container.data( 'view-manage-url' );
-		var tribeIsTruthy   = /^(true|1|on|yes)$/;
+		let shouldManageUrl = $container.data( 'view-manage-url' );
+		const tribeIsTruthy   = /^(true|1|on|yes)$/;
 
 		// When undefined we use true as the default.
 		if ( typeof shouldManageUrl === typeof undefined ) {
@@ -244,14 +243,14 @@ tribe.events.views.manager = {};
 			return;
 		}
 
-		var $data = $container.find( obj.selectors.dataScript );
+		const $data = $container.find( obj.selectors.dataScript );
 
 		// Bail in case we dont find data script.
 		if ( ! $data.length ) {
 			return;
 		}
 
-		var data = JSON.parse( $data.text().trim() );
+		const data = JSON.parse( $data.text().trim() );
 
 		// Bail when the data is not a valid object
 		if ( ! _.isObject( data ) ) {
@@ -287,27 +286,27 @@ tribe.events.views.manager = {};
 	 * @return {boolean}
 	 */
 	obj.onLinkClick = function( event ) {
-		var $container = obj.getContainer( this );
+		const $container = obj.getContainer( this );
 
 		$container.trigger( 'beforeOnLinkClick.tribeEvents', event );
 
 		event.preventDefault();
 
-		var containerData = obj.getContainerData( $container );
+		const containerData = obj.getContainerData( $container );
 
-		var $link = $( this );
-		var url = $link.attr( 'href' );
-		var currentUrl = containerData.prev_url;
-		var nonce = $link.data( 'view-rest-nonce' );
-		var shouldManageUrl = obj.shouldManageUrl( $container );
-		var shortcodeId = $container.data( 'view-shortcode' );
+		const $link = $( this );
+		const url = $link.attr( 'href' );
+		const currentUrl = containerData.prev_url;
+		let nonce = $link.data( 'view-rest-nonce' );
+		const shouldManageUrl = obj.shouldManageUrl( $container );
+		const shortcodeId = $container.data( 'view-shortcode' );
 
 		// Fetch nonce from container if the link doesn't have any
 		if ( ! nonce ) {
 			nonce = $container.data( 'view-rest-nonce' );
 		}
 
-		var data = {
+		const data = {
 			prev_url: encodeURI( decodeURI( currentUrl ) ),
 			url: encodeURI( decodeURI( url ) ),
 			should_manage_url: shouldManageUrl,
@@ -315,7 +314,7 @@ tribe.events.views.manager = {};
 		};
 
 		if ( shortcodeId ) {
-			data[ 'shortcode' ] = shortcodeId;
+			data.shortcode = shortcodeId;
 		}
 
 		obj.request( data, $container );
@@ -337,18 +336,18 @@ tribe.events.views.manager = {};
 	 * @return {boolean}
 	 */
 	obj.onSubmit = function( event ) {
-		var $container = obj.getContainer( this );
+		const $container = obj.getContainer( this );
 		$container.trigger( 'beforeOnSubmit.tribeEvents', event );
 
 		event.preventDefault();
 
 		// The submit event is triggered on the form, not the container.
-		var $form = $( this );
-		var nonce = $container.data( 'view-rest-nonce' );
+		const $form = $( this );
+		const nonce = $container.data( 'view-rest-nonce' );
 
-		var formData = Qs.parse( $form.serialize() );
+		const formData = Qs.parse( $form.serialize() );
 
-		var data = {
+		const data = {
 			view_data: formData[ 'tribe-events-views' ],
 			_wpnonce: nonce,
 		};
@@ -373,9 +372,14 @@ tribe.events.views.manager = {};
 	 * @return {boolean}     Will always return false on this one.
 	 */
 	obj.onPopState = function( event ) {
-		var target = event.originalEvent.target;
-		var url = target.location.href;
-		var $container = obj.getLastContainer();
+		const target = event.originalEvent.target;
+		const url = target.location.href;
+		const $container = obj.getLastContainer();
+
+		// A pop state from a hash inside of the same URL has been trigger like #content  so no request is required.
+		if ( url && url.split( '#' ).length >= 2 ) {
+			return false;
+		}
 
 		if ( ! $container ) {
 			return false;
@@ -390,9 +394,9 @@ tribe.events.views.manager = {};
 
 		$container.trigger( 'beforePopState.tribeEvents', event );
 
-		var nonce = $container.data( 'view-rest-nonce' );
+		const nonce = $container.data( 'view-rest-nonce' );
 
-		var data = {
+		const data = {
 			url: url,
 			_wpnonce: nonce,
 		};
@@ -413,8 +417,8 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.setupRequestData = function( data, $container ) {
-		var shouldManageUrl = obj.shouldManageUrl( $container );
-		var containerData = obj.getContainerData( $container );
+		const shouldManageUrl = obj.shouldManageUrl( $container );
+		const containerData = obj.getContainerData( $container );
 
 		if ( ! data.url ) {
 			data.url = containerData.url;
@@ -427,7 +431,7 @@ tribe.events.views.manager = {};
 		data.should_manage_url = shouldManageUrl;
 
 		// Allow other values to be passed to request from container data.
-		var requestData = $container.data( 'tribeRequestData' );
+		const requestData = $container.data( 'tribeRequestData' );
 
 		if ( ! $.isPlainObject( requestData ) ) {
 			return data;
@@ -450,7 +454,7 @@ tribe.events.views.manager = {};
 	obj.request = function( data, $container ) {
 		$container.trigger( 'beforeRequest.tribeEvents', [ data, $container ] );
 
-		var settings = obj.getAjaxSettings( $container );
+		const settings = obj.getAjaxSettings( $container );
 
 		// Pass the data setup to the $.ajax settings
 		settings.data = obj.setupRequestData( data, $container );
@@ -470,12 +474,12 @@ tribe.events.views.manager = {};
 	 * @return {Object}
 	 */
 	obj.getAjaxSettings = function( $container ) {
-		var ajaxSettings = {
+		const ajaxSettings = {
 			url: $container.data( 'view-rest-url' ),
 			accepts: 'html',
 			dataType: 'html',
 			method: $container.data( 'view-rest-method' ) || 'POST',
-			'async': true, // async is keyword
+			async: true, // async is keyword
 			beforeSend: obj.ajaxBeforeSend,
 			complete: obj.ajaxComplete,
 			success: obj.ajaxSuccess,
@@ -501,14 +505,14 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxBeforeSend = function( jqXHR, settings ) {
-		var $container = this;
-		var $loader = $container.find( obj.selectors.loader );
+		const $container = this;
+		const $loader = $container.find( obj.selectors.loader );
 
 		$container.trigger( 'beforeAjaxBeforeSend.tribeEvents', [ jqXHR, settings ] );
 
 		if ( $loader.length ) {
 			$loader.removeClass( obj.selectors.hiddenElement.className() );
-			var $loaderText = $loader.find( obj.selectors.loaderText );
+			const $loaderText = $loader.find( obj.selectors.loaderText );
 			$loaderText.text( $loaderText.text() );
 		}
 		$container.attr( 'aria-busy', 'true' );
@@ -531,8 +535,8 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxComplete = function( jqXHR, textStatus ) {
-		var $container = this;
-		var $loader = $container.find( obj.selectors.loader );
+		const $container = this;
+		const $loader = $container.find( obj.selectors.loader );
 
 		$container.trigger( 'beforeAjaxComplete.tribeEvents', [ jqXHR, textStatus ] );
 
@@ -568,11 +572,11 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxSuccess = function( data, textStatus, jqXHR ) {
-		var $container = this;
+		let $container = this;
 
 		$container.trigger( 'beforeAjaxSuccess.tribeEvents', [ data, textStatus, jqXHR ] );
 
-		var $html = $( data );
+		const $html = $( data );
 
 		// Clean up the container and event listeners
 		obj.cleanup( $container );
@@ -613,7 +617,7 @@ tribe.events.views.manager = {};
 	 * @return {void}
 	 */
 	obj.ajaxError = function( jqXHR, settings ) {
-		var $container = this;
+		const $container = this;
 
 		$container.trigger( 'beforeAjaxError.tribeEvents', [ jqXHR, settings ] );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -8,6 +8,7 @@
  */
 tribe.events = tribe.events || {};
 tribe.events.views = tribe.events.views || {};
+tribe.state = tribe.state || {};
 
 /**
  * Configures Views Object in the Global Tribe variable
@@ -378,7 +379,12 @@ tribe.events.views.manager = {};
 		var $container = obj.getLastContainer();
 
 		// A pop state from a hash inside of the same URL has been trigger like #content  so no request is required.
-		if ( url && url.split( '#' ).length >= 2 ) {
+		if ( target.location.hash ) {
+			return false;
+		}
+
+		// We no longer have the hash in place, and the URLs are the same so no need for a new request.
+		if ( tribe.state.initial_location && target.location.href === tribe.state.initial_location.href ) {
 			return false;
 		}
 
@@ -675,4 +681,5 @@ tribe.events.views.manager = {};
 
 	// Attaches the popstate method to the window object.
 	$window.on( 'popstate', obj.onPopState );
+	tribe.state.initial_location = document.location || '';
 } )( jQuery, window.underscore || window._, tribe.events.views.manager );

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -30,6 +30,7 @@ tribe.events.views.manager = {};
  * @return {void}
  */
 ( function( $, _, obj ) {
+	'use strict';
 	var $window = $( window );
 
 	/**
@@ -479,7 +480,7 @@ tribe.events.views.manager = {};
 			accepts: 'html',
 			dataType: 'html',
 			method: $container.data( 'view-rest-method' ) || 'POST',
-			async: true, // async is keyword
+			'async': true, // async is keyword
 			beforeSend: obj.ajaxBeforeSend,
 			complete: obj.ajaxComplete,
 			success: obj.ajaxSuccess,


### PR DESCRIPTION
Make sure hash changes on the URL are just to move the viewport to
the correct section of the page but on the same URL, for that
scenario we don't need to request a new request as the URL
didn't change.

Artifact: https://d.pr/v/5GeZUb
Ticket: TEC-3890