### PR TITLE
Integrate WPML team language handling snippet

### DIFF
--- a/src/Tribe/I18n.php
+++ b/src/Tribe/I18n.php
@@ -188,6 +188,20 @@ class I18n {
 		$result = $do( ...$args );
 		remove_filter( 'locale', $force_locale );
 
+		$domains = isset( $args[1] ) ? (array) $args[1] : false;
+		if ( false !== $domains ) {
+			foreach ( $domains as $domain => $file ) {
+				// Reload it with the correct language.
+				unload_textdomain( $domain );
+
+				if ( 'default' === $domain ) {
+					load_default_textdomain();
+				} elseif ( is_string( $file ) ) {
+					Common::instance()->load_text_domain( $domain, $file );
+				}
+			}
+		}
+
 		// Restore the `locale` filtering functions.
 		$wp_filter['locale'] = $locale_filters_backup;
 


### PR DESCRIPTION
Issue: https://theeventscalendar.atlassian.net/browse/TEC-3810

This further PR on the work done in the first PR for the issue
integrates the snippet of code [shared by the WPML
team](https://wpml.org/errata/the-events-calendar-issues-with-string-translation/
) to fix more issues found during the first QA pass.

[Screencap](https://www.dropbox.com/s/o5gn2pqkar08lmm/TEC-3810-pass-2-self-qa.mov?dl=0)
