### PR TITLE
Fix Day View time separator time

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Correctly handle start and end of day cutoff in Day View when the server timezone is not the same as the site (thanks @therealgilles). [TEC-3877]
 * Fix - Do not remove the `archive` body class from post tag and category pages when using Page as Event Template. [TEC-3846]
 * Fix - Correctly translate calendar view in WPML language switcher (thanks @dgwatkins). [TEC-3810]
+* Fix - Use the correct date and time in the Day View time separator when Timezone Mode is set to "Manual time zones for each event". [TEC-3877]
 * Tweak - Reduced the usage of the word "onwards" on list-style view date range headings where simpler headings are better suited. [TEC-3831]
 * Tweak - Move messages below the calendar grid in the mobile version of Month View. [TEC-3793]
 * Tweak - Display a message to let visitors know the selected Month View day has no events in mobile. [TEC-3812]

--- a/src/views/v2/day/time-separator.php
+++ b/src/views/v2/day/time-separator.php
@@ -22,7 +22,7 @@ if ( ! $should_have_time_separator || ! empty( $event->timeslot ) ) {
 	return;
 }
 
-$event_start_hour = strtotime( Dates::round_nearest_half_hour( $event->dates->start->format( Dates::DBDATETIMEFORMAT ) ) );
+$event_start_hour = strtotime( Dates::round_nearest_half_hour( $event->dates->start_display->format( Dates::DBDATETIMEFORMAT ) ) );
 
 // Format to WP format
 $separator_text = date_i18n( tribe_get_time_format(), $event_start_hour );


### PR DESCRIPTION
Issue: https://theeventscalendar.atlassian.net/browse/TEC-3877

This fixes an issue where the Day View time separator HTML would use the
event start time, without consideration of the Event Timezone and of the
site timezone settings (Events > Settings > "Timezone Settings" >
"Timezone Mode".

The fix consists in using the already available
`$event->dates->display_date` object that will be set, depending on the
site timezone mode settings, to the correct date and timezone to use
when the event details require, as the name implies, displaying.

[Screencap](https://www.dropbox.com/s/h99d1bd3ajyc9cq/TEC-3867-self-qa-2.mov?dl=0)
