### PR TITLE
Fix single event iCalendar export

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Correctly handle start and end of day cutoff in Day View when the server timezone is not the same as the site (thanks @therealgilles). [TEC-3877]
 * Fix - Do not remove the `archive` body class from post tag and category pages when using Page as Event Template. [TEC-3846]
 * Fix - Correctly translate calendar view in WPML language switcher (thanks @dgwatkins). [TEC-3810]
+* Fix - Single event iCalendar export will correctly export only that event information. [TEC-3886]
 * Tweak - Reduced the usage of the word "onwards" on list-style view date range headings where simpler headings are better suited. [TEC-3831]
 * Tweak - Move messages below the calendar grid in the mobile version of Month View. [TEC-3793]
 * Tweak - Display a message to let visitors know the selected Month View day has no events in mobile. [TEC-3812]

--- a/src/Tribe/Views/V2/iCalendar/Request.php
+++ b/src/Tribe/Views/V2/iCalendar/Request.php
@@ -64,10 +64,15 @@ class Request {
 	 *                    iCalendar export request.
 	 */
 	public function get_event_ids() {
-		$view = View::make( $this->context->get( 'view', 'default' ), $this->context );
+		$view_slug = $this->context->get( 'view', 'default' );
 
-		// @todo @bordoni test this method for each View. w/ and w/o date set, with some filtering args.
-		$event_ids = $view->get_ical_ids( $this->ical->feed_posts_per_page() );
+		if ( 'single-event' !== $view_slug ) {
+			$view      = View::make( $view_slug, $this->context );
+			$event_ids = $view->get_ical_ids( $this->ical->feed_posts_per_page() );
+		} else {
+			$event_ids = [ $this->context->get( 'post_id' ) ];
+		}
+
 
 		return $event_ids;
 	}

--- a/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Events\Views\V2\iCalendar;
 
+use Tribe\Events\Test\Factories\Event;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
 use Tribe\Test\Products\Traits\With_Context;
 
@@ -299,5 +300,23 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		}
 
 		$this->assertEquals( $expected_events, $event_ids );
+	}
+
+	/**
+	 * It should return the single event request ID when creating expor for single-event
+	 *
+	 * @test
+	 */
+	public function should_return_the_single_event_request_id_when_creating_expor_for_single_event() {
+		$post_id = ( new Event() )->create();
+		$context = tribe_context()->alter( [
+			'view'    => 'single-event',
+			'post_id' => $post_id,
+		] );
+
+		$request   = $this->make_instance( $context );
+		$event_ids = $request->get_event_ids();
+
+		$this->assertEquals( [ $post_id ], $event_ids );
 	}
 }


### PR DESCRIPTION
Issue: https://theeventscalendar.atlassian.net/browse/TEC-3886

Fix the single event export by taking into account the request for the
single event.

Before we would build the View directly on the `view` context location
return value, when looking at single events, that return value would be
`single-event` that, not resolving to any View, would default to the
current default View (usually List).

This fix specially handles the iCalendar export request coming from
single event to return that single event ID only.

[Screencap](https://www.dropbox.com/s/dktmrh3con0bl1z/TEC-3886-self-qa.mov?dl=0)
