### PR TITLE
TEC-3143: Use the timezone accordingly with the settings on export link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -240,6 +240,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Filter the type of files allowed to upload into the EA Client. [TEC-3882]
 * Tweak - Updating lodash to 4.17.21. [TEC-3885]
 * Tweak - Prevent to list changes of hash on URL changes like `#content` [TEC-3890]
+* Tweak - Update Google Calendar link to use the timezone based on the Timezone Settings from the Calendar [TEC-3143]
 
 = [5.6.0] 2021-04-29 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3033,7 +3033,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$timezone = Tribe__Timezones::build_timezone_object();
 			} else {
 				$timezone = Tribe__Events__Timezones::get_timezone(
-						Tribe__Events__Timezones::get_event_timezone_string( $post->ID )
+					Tribe__Events__Timezones::get_event_timezone_string( $post->ID )
 				);
 			}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3029,12 +3029,17 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				'sprop'    => 'website:' . home_url(),
 			];
 
-			$timezone = Tribe__Events__Timezones::get_event_timezone_string( $post->ID );
-			$timezone = Tribe__Events__Timezones::maybe_get_tz_name( $timezone );
+			if ( Tribe__Timezones::is_mode( Tribe__Timezones::SITE_TIMEZONE ) ) {
+				$timezone = Tribe__Timezones::build_timezone_object();
+			} else {
+				$timezone = Tribe__Events__Timezones::get_timezone(
+						Tribe__Events__Timezones::get_event_timezone_string( $post->ID )
+				);
+			}
 
 			// If we have a good timezone string we setup it; UTC doesn't work on Google
-			if ( false !== $timezone ) {
-				$params['ctz'] = urlencode( $timezone );
+			if ( $timezone instanceof DateTimeZone) {
+				$params['ctz'] = urlencode( $timezone->getName() );
 			}
 
 			/**

--- a/tests/wpunit/functions/template-tags/GoogleCalendarTest.php
+++ b/tests/wpunit/functions/template-tags/GoogleCalendarTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace TEC\Test\functions\template_tags;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Events\Test\Factories\Event;
+use Tribe__Timezones as Timezones;
+
+class GoogleCalendarTest extends WPTestCase {
+	private $mode = '';
+	private $initial_tz;
+
+	public function setUp() {
+		parent::setUp();
+		$this->mode       = Timezones::mode();
+		$this->initial_tz = Timezones::build_timezone_object();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		tribe_update_option( 'tribe_events_timezone_mode', $this->mode );
+		update_option( 'timezone_string', $this->initial_tz );
+	}
+
+	/**
+	 * should generate the event with the event timezone when timezone mode is event
+	 *
+	 * @test
+	 */
+	public function should_generate_the_event_with_the_event_timezone_when_timezone_mode_is_event() {
+		tribe_update_option( 'tribe_events_timezone_mode', Timezones::EVENT_TIMEZONE );
+		update_option( 'timezone_string', 'America/Los_Angeles' );
+
+		$event_id = ( new Event() )->create_object( [ 'timezone' => 'America/Mexico_City' ] );
+
+		$this->assertSame(
+			'America/Mexico_City',
+			$this->get_property_from_google_calendar_link( $event_id, 'ctz' )
+		);
+	}
+
+	/**
+	 * should generate the event with the global timezone when the timezone mode is site
+	 *
+	 * @test
+	 */
+	public function should_generate_the_event_with_the_global_timezone_when_the_timezone_mode_is_site() {
+		tribe_update_option( 'tribe_events_timezone_mode', Timezones::SITE_TIMEZONE );
+		update_option( 'timezone_string', 'America/Los_Angeles' );
+
+		$event_id = ( new Event() )->create_object( [ 'timezone' => 'America/Mexico_City' ] );
+
+		$this->assertSame(
+			'America/Los_Angeles',
+			$this->get_property_from_google_calendar_link( $event_id, 'ctz' )
+		);
+	}
+
+	/**
+	 * Extract the timezone from the generated gcal link.
+	 *
+	 * @since TBD
+	 *
+	 * @param $event_id
+	 *
+	 * @return mixed
+	 */
+	private function get_property_from_google_calendar_link( $event_id, string $property ) {
+		$url = wp_parse_url( tribe_get_gcal_link( $event_id ) );
+
+		$this->assertIsArray( $url );
+		$this->assertArrayHasKey( 'query', $url );
+
+		parse_str( $url['query'], $result );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( $property, $result );
+
+		return $result[ $property ];
+	}
+}


### PR DESCRIPTION
For the google calendar link use the timezone value according to the
settings specified on the settings of the calendar to make sure
behavior is consistent with the rest of the page.

Ticket: TEC-3143
Artifact: https://d.pr/v/VaYWQc