### PR TITLE
Only run Codeception tests when changing files that require it

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -1,5 +1,13 @@
 name: 'Codeception Tests'
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'src/**.php'
+      - 'tests/**',
+      - '*.php'
+      - 'composer.json'
+      - 'codeception.*.yml'
+      - '.github/workflows/tests-php.yml'
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This is an optimization in workflow shenanigans so that we don't run the automated tests when we don't have to.

THREE CHEERS FOR INNOVATION DAY!