### PR TITLE
Make sure not found messages are render on mobile

### DIFF
--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -53,6 +53,7 @@ if ( empty( $disable_event_search ) ) {
 
 		<header <?php tribe_classes( $header_classes ); ?>>
 			<?php $this->template( 'components/messages' ); ?>
+			<?php $this->template( 'components/messages', [ 'classes' => [ 'tribe-events-header__messages--mobile' ] ] ); ?>
 
 			<?php $this->template( 'components/breadcrumbs' ); ?>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
@@ -40,6 +40,16 @@
 							</ul>
 		</div>
 	</div>
+			<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile"  >
+			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
+						<ul class="tribe-events-c-messages__message-list">
+									<li
+						class="tribe-events-c-messages__message-list-item"
+						 data-key="0" 					>
+					There are no upcoming events.					</li>
+							</ul>
+		</div>
+	</div>
 
 			
 			<div

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
@@ -40,6 +40,17 @@
 							</ul>
 		</div>
 	</div>
+			<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile"  >
+			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
+			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+			<ul class="tribe-events-c-messages__message-list">
+									<li
+						class="tribe-events-c-messages__message-list-item"
+						 data-key="0" 					>
+					There are no upcoming events.					</li>
+							</ul>
+		</div>
+	</div>
 
 			
 			<div

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -31,7 +31,7 @@
 	<div id="tribe-events" class="tribe-no-js" data-live_ajax="1" data-datepicker_format="1" data-category="" data-featured=""></div>
 
 		<header  class="tribe-events-header tribe-events-header--has-event-search" >
-			
+						
 			
 			<div
 	 class="tribe-events-header__events-bar tribe-events-c-events-bar tribe-events-c-events-bar--border" 	data-js="tribe-events-events-bar"

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
@@ -40,6 +40,17 @@
 							</ul>
 		</div>
 	</div>
+			<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile"  >
+			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
+			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+			<ul class="tribe-events-c-messages__message-list">
+									<li
+						class="tribe-events-c-messages__message-list-item"
+						 data-key="0" 					>
+					There are no upcoming events.					</li>
+							</ul>
+		</div>
+	</div>
 
 			
 			<div


### PR DESCRIPTION
Make sure the list view on mobile displays the not found message when no
events are present on mobile layout.

Ticket: TEC-3812

This is done on top of https://github.com/the-events-calendar/the-events-calendar/pull/3514 to make sure this is not a regressive issue. 