### PR TITLE
[TEC-3937] Fix for single view and Event Tickets compatibility when using `twentynineteen`.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.7.1] TBD =
 
-* Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3935]
+* Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3937]
 
 = [5.7.0] 2021-05-27 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.7.1] TBD =
 
+* Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3935]
+
 = [5.7.0] 2021-05-27 =
 
 * Feature - Add new Month View section to the Customizer for v2 views. [TEC-3836]

--- a/src/resources/postcss/tribe-events-full.pcss
+++ b/src/resources/postcss/tribe-events-full.pcss
@@ -2435,7 +2435,7 @@ input[name*='tribe-bar-']:-moz-placeholder {
 			padding-right: calc(10% + 60px);
 		}
 
-		.entry {
+		.tribe-events-single > .entry {
 			margin-top: 2rem;
 		}
 	}


### PR DESCRIPTION
🎫  [TEC-3937]

The styles that we're applying for the 2019 overrides are taking over the `entry` of any other thing that's used in that page. In our case (Event Tickets) it's adding a margin top on every item of the tickets block. I assume for WooCommerce or any other thing that uses the post classes it'll happen the same.

On hold until is ticketed and assigned for a given sprint.

https://www.loom.com/share/e9dc59b71ef94f2382edb3af72cbdbb1

[TEC-3937]: https://theeventscalendar.atlassian.net/browse/TEC-3937