### PR TITLE
Trigger update to _EventCost when updating events via the Block Editor | TEC-3141

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [5.7.1] TBD =
 
+* Fix - Properly recalculate event cost when creating events via the Block Editor. [TEC-3141]
+
 = [5.7.0] 2021-05-27 =
 
 * Feature - Add new Month View section to the Customizer for v2 views. [TEC-3836]

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -189,8 +189,7 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 	 * @param \stdClass        $post_data The post insertion/update payload.
 	 * @param \WP_REST_Request $request The current insertion or update request object.
 	 *
-	 * @return \stdClass The post insertion/update payload with an added `meta_input` entry if
-	 *                   the insertion/update of UTC dates is required.
+	 * @return \stdClass The post insertion/update payload.
 	 */
 	public function update_cost( $post_data, $request ) {
 		$post_id = $request->get_param( 'id' );

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -22,6 +22,7 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		$post_type = Tribe__Events__Main::POSTTYPE;
 		add_filter( "rest_prepare_{$post_type}", [ $this, 'meta_backwards_compatibility' ], 10, 3 );
 		add_filter( "rest_after_insert_{$post_type}", [ $this, 'add_utc_dates' ], 10, 2 );
+		add_filter( "rest_after_insert_{$post_type}", [ $this, 'update_cost' ], 10, 2 );
 		add_filter( 'delete_post_metadata', [ $this, 'filter_allow_meta_delete_non_existent_key' ], 15, 5 );
 
 		register_meta( 'post', '_EventAllDay', $this->boolean() );
@@ -178,6 +179,25 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Make sure we allow other plugins and customizations to filter the cost field.
+	 *
+	 * @since TBD
+	 *
+	 * @param \stdClass        $post_data The post insertion/update payload.
+	 * @param \WP_REST_Request $request The current insertion or update request object.
+	 *
+	 * @return \stdClass The post insertion/update payload with an added `meta_input` entry if
+	 *                   the insertion/update of UTC dates is required.
+	 */
+	public function update_cost( $post_data, $request ) {
+		$post_id = $request->get_param( 'id' );
+
+		\Tribe__Events__API::update_event_cost( $post_id );
+
+		return $post_data;
 	}
 
 	/**


### PR DESCRIPTION
Similar to the Event API call that is done on event additions/updates in the classic editor, we need to give the opportunity for ET/ET+ and other sources to influence the cost fields.

🎥 https://d.pr/v/tMH4z7
🎫 [TEC-3141]

[TEC-3141]: https://theeventscalendar.atlassian.net/browse/TEC-3141