### PR TITLE
Fix opacity on date colors.

### DIFF
--- a/src/Tribe/Views/V2/Customizer.php
+++ b/src/Tribe/Views/V2/Customizer.php
@@ -325,7 +325,7 @@ class Customizer {
 				$tribe_events .tribe-events-calendar-month__day--past .tribe-events-calendar-month__calendar-event-datetime,
 				$tribe_events .tribe-events-calendar-month__calendar-event-tooltip-datetime,
 				$tribe_events .tribe-events-calendar-month-mobile-events__mobile-event-datetime {
-					color: rgba($date_css_rgb, .88);
+					color: rgba({$date_css_rgb}, .88);
 				}
 			";
 		}

--- a/src/Tribe/Views/V2/Customizer.php
+++ b/src/Tribe/Views/V2/Customizer.php
@@ -307,17 +307,25 @@ class Customizer {
 		}
 
 		if ( $customizer->has_option( $section->ID, 'event_date_time_color' ) ) {
+			$color          = $section->get_option( 'event_date_time_color' );
+			$date_color     = new \Tribe__Utils__Color( $color );
+			$date_color_rgb = $date_color::hexToRgb( $color );
+			$date_css_rgb   = $date_color_rgb['R'] . ',' . $date_color_rgb['G'] . ',' . $date_color_rgb['B'];
+
 			// Event Date Time overrides.
 			$css_template .= "
 				.tribe-events-schedule h2,
 				$tribe_events .tribe-events-calendar-list__event-datetime,
 				$tribe_events .tribe-events-calendar-day__event-datetime,
+				$tribe_events .tribe-events-calendar-latest-past__event-datetime {
+					color: <%= global_elements.event_date_time_color %>;
+				}
+
 				$tribe_events .tribe-events-calendar-month__calendar-event-datetime,
 				$tribe_events .tribe-events-calendar-month__day--past .tribe-events-calendar-month__calendar-event-datetime,
 				$tribe_events .tribe-events-calendar-month__calendar-event-tooltip-datetime,
-				$tribe_events .tribe-events-calendar-month-mobile-events__mobile-event-datetime,
-				$tribe_events .tribe-events-calendar-latest-past__event-datetime {
-					color: <%= global_elements.event_date_time_color %>;
+				$tribe_events .tribe-events-calendar-month-mobile-events__mobile-event-datetime {
+					color: rgba($date_css_rgb, .88);
 				}
 			";
 		}

--- a/src/resources/postcss/views/full/month/_calendar-event.pcss
+++ b/src/resources/postcss/views/full/month/_calendar-event.pcss
@@ -11,7 +11,7 @@
 		}
 
 		.tribe-events-calendar-month__calendar-event-datetime {
-			color: var(--color-text-primary);
+			color: rgba(var(--color-text-primary), .88);
 			opacity: 0.94; /* This opacity is compounded with the calendar-event opacity above */
 		}
 
@@ -33,7 +33,7 @@
 	.tribe-events-calendar-month__calendar-event-datetime {
 		@mixin mobile-body-3;
 
-		color: var(--color-text-secondary);
+		color: rgba(var(--color-text-primary), .88);
 	}
 
 	.tribe-events-calendar-month__calendar-event--featured {


### PR DESCRIPTION
Switch default color to use the primary + opacity

Ensure the Customizer also incorporates the opacity.

[TEC-3709]

[TEC-3709]: https://theeventscalendar.atlassian.net/browse/TEC-3709