### PR TITLE
Cast tribe_get_request_var to array.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,7 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Properly recalculate event cost when creating events via the Block Editor. [TEC-3141]
 * Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3937]
-* Fix - Resolve a compatibility issue with the Analytify dashboard. [TEC-3946]
+* Fix - Ensure that `view_data` is an array when fetching values from the request. [TEC-3946]
 * Tweak - Make custom post types available from the REST API so they can be compatible with the Navigation block. [TEC-3907]
 * Tweak - Remove aria-labeled attribute from featured icons. [TEC-3396]
 

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Properly recalculate event cost when creating events via the Block Editor. [TEC-3141]
 * Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3937]
+* Fix - Resolve a compatibility issue with the Analytify dashboard. [TEC-3946]
 * Tweak - Make custom post types available from the REST API so they can be compatible with the Navigation block. [TEC-3907]
 * Tweak - Remove aria-labeled attribute from featured icons. [TEC-3396]
 

--- a/src/Tribe/Views/V2/Utils/View.php
+++ b/src/Tribe/Views/V2/Utils/View.php
@@ -27,7 +27,7 @@ class View {
 	 */
 	public static function get_data( $indexes, $default = null ) {
 		$found = Arr::get_first_set(
-			tribe_get_request_var( 'view_data', [] ),
+			(array) tribe_get_request_var( 'view_data', [] ),
 			(array) $indexes,
 			$default
 		);


### PR DESCRIPTION
Since the URL param is not namespaced, we cannot assume we will get back _our_ info.

This caused a plugin conflict and fatal here as Analytify also uses the `view_data` param - and it's a simple string.

Possibly a larger question here as to how/why the function is being called in the first place on an admin page that isn't ours?

[TEC-3946]

[TEC-3946]: https://theeventscalendar.atlassian.net/browse/TEC-3946