### PR TITLE
Make sure classic editor loads by default on events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Properly recalculate event cost when creating events via the Block Editor. [TEC-3141]
 * Fix - Resolve a compatibility issue with the new single view and the tickets block when using the `twentynineteen` theme. [TEC-3937]
 * Fix - Ensure that `view_data` is an array when fetching values from the request. [TEC-3946]
+* Fix - Ensure that the events block editor is disabled when "Activate Block Editor for Events" is unchecked. [TEC-3964]
 * Tweak - Make custom post types available from the REST API so they can be compatible with the Navigation block. [TEC-3907]
 * Tweak - Remove aria-labeled attribute from featured icons. [TEC-3396]
 

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -51,6 +51,7 @@ class Tribe__Events__Editor extends Tribe__Editor {
 		 */
 		add_filter( 'use_block_editor_for_post_type', [ $this, 'deactivate_blocks_editor_venue' ], 10, 2 );
 		add_filter( 'use_block_editor_for_post_type', [ $this, 'deactivate_blocks_editor_organizer' ], 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'deactivate_blocks_editor_event' ], 10, 2 );
 	}
 
 	/**
@@ -91,6 +92,29 @@ class Tribe__Events__Editor extends Tribe__Editor {
 		}
 
 		return $is_enabled;
+	}
+
+	/**
+	 * Deactivate the blocks editor from the events post type unless explicitly enabled by the user via the settings
+	 * on the events tab.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool   $is_enabled If blocks editor is enabled or not.
+	 * @param string $post_type  The current post type.
+	 *
+	 * @return false
+	 */
+	public function deactivate_blocks_editor_event( $is_enabled, $post_type ) {
+		if ( Tribe__Events__Main::POSTTYPE !== $post_type ) {
+			return $is_enabled;
+		}
+
+		if ( tribe( 'events.editor.compatibility' )->is_blocks_editor_toggled_on() ) {
+			return $is_enabled;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -13,6 +13,8 @@ class Tribe__Events__Editor__Provider extends tad_DI52_ServiceProvider {
 		$this->container->singleton( 'events.editor', 'Tribe__Events__Editor' );
 		$this->container->singleton( 'events.editor.compatibility', 'Tribe__Events__Editor__Compatibility', [ 'hook' ] );
 
+		tribe( 'events.editor' )->hook();
+
 		if (
 			! tribe( 'editor' )->should_load_blocks()
 			|| ! tribe( 'events.editor.compatibility' )->is_blocks_editor_toggled_on()
@@ -65,8 +67,6 @@ class Tribe__Events__Editor__Provider extends tad_DI52_ServiceProvider {
 
 		// Setup the Meta registration
 		add_action( 'init', tribe_callback( 'events.editor.meta', 'register' ), 15 );
-
-		tribe( 'events.editor' )->hook();
 
 		// Register blocks to own own action
 		add_action( 'tribe_editor_register_blocks', tribe_callback( 'events.editor.blocks.classic-event-details', 'register' ) );

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/__snapshots__/Google_Map_LinkTest__test_render__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/__snapshots__/Google_Map_LinkTest__test_render__1.php
@@ -1,1 +1,1 @@
-<?php return '<a class="tribe-events-gmap" href="https://maps.google.com/maps?f=q&#038;source=s_q&#038;hl=en&#038;geocode=&#038;q=939+Lexington+Ave+New+York+NY+10065+United+States" title="Click to view a Google Map" target="_blank" rel="noreferrer noopener">+ Google Map</a>';
+<?php return '';


### PR DESCRIPTION
Only load the blocks editor if explicitly enabled from the events
settings.

[TEC-3964]

[TEC-3964]: https://theeventscalendar.atlassian.net/browse/TEC-3964