### PR TITLE
Add check for incorrect context

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = TBD [TBD] =
 
+* Fix - Ensure that when viewing a single event we load the correct template when tribe_context is "confused". [TEC-3975]
 * Tweak - Add CSS class to the event tags label on the event details section on the single event page. [TEC-3951]
 * Tweak - Correct hte messaging and link for the v1 deprecation notice. [TEC-3958]
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2592,7 +2592,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		}
 
 		/**
-		 * Returns the default view, providing a fallback if the default is no longer availble.
+		 * Returns the default view, providing a fallback if the default is no longer available.
 		 *
 		 * This can be useful is for instance a view added by another plugin (such as PRO) is
 		 * stored as the default but can no longer be generated due to the plugin being deactivated.

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 
 			$types = ( ! empty( $query->query_vars['post_type'] ) ? (array) $query->query_vars['post_type'] : [] );
 
-			// check if any possiblity of this being an event query
+			// check if any possibility of this being an event query
 			$query->tribe_is_event = ( in_array( Tribe__Events__Main::POSTTYPE, $types ) && count( $types ) < 2 )
 				? true // it was an event query
 				: false;
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Tribe__Events__Query' ) ) {
 				$query->set( 'eventDisplay', Tribe__Events__Main::instance()->default_view() );
 			}
 
-			// check if any possiblity of this being an event category
+			// check if any possibility of this being an event category
 			$query->tribe_is_event_category = ! empty ( $query->query_vars[ Tribe__Events__Main::TAXONOMY ] )
 				? true // it was an event category
 				: false;

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -210,8 +210,10 @@ class Template_Bootstrap {
 			return $pre_html;
 		}
 
+		$is_single_event = 'single-event' === $view_slug || ( $query->is_singular && $query->tribe_is_event_query );
+
 		$should_display_single = (
-			'single-event' === $view_slug
+			$is_single_event
 			&& ! tribe_is_showing_all()
 			&& ! V1_Templates::is_embed()
 		);


### PR DESCRIPTION
 Add an additional check in get_view_html() to ensure that we still show the single event when the context is wrong.

Need to explore further _why_ the context is wrong :/

[TEC-3975]



[TEC-3975]: https://theeventscalendar.atlassian.net/browse/TEC-3975