### PR TITLE
Inno/view labels filter

### DIFF
--- a/src/views/v2/components/events-bar/views.php
+++ b/src/views/v2/components/events-bar/views.php
@@ -23,6 +23,15 @@ $view_selector_classes = [
 	'tribe-events-c-view-selector--labels' => empty( $disable_event_search ),
 	'tribe-events-c-view-selector--tabs'   => $is_tabs_style,
 ];
+
+/**
+ * Filters the labels for the views.
+ *
+ * @since TBD
+ *
+ * @param string $view_label  Current label of the view.
+ */
+$view_label = apply_filters( 'tribe_events_views_v2_view_label', $view_label );
 ?>
 <div class="tribe-events-c-events-bar__views">
 	<h3 class="tribe-common-a11y-visual-hide">

--- a/src/views/v2/components/events-bar/views/list/item.php
+++ b/src/views/v2/components/events-bar/views/list/item.php
@@ -20,6 +20,15 @@ $list_item_classes = [ 'tribe-events-c-view-selector__list-item', "tribe-events-
 if ( $view_slug === $public_view_slug ) {
 	$list_item_classes[] = 'tribe-events-c-view-selector__list-item--active';
 }
+
+/**
+ * Filters the labels for the views.
+ *
+ * @since TBD
+ *
+ * @param string $view_label  Current label of the view.
+ */
+$view_label = apply_filters( 'tribe_events_views_v2_view_label', $public_view_data->view_label );
 ?>
 <li class="<?php echo esc_attr( implode( ' ', $list_item_classes ) ); ?>">
 	<a
@@ -31,7 +40,7 @@ if ( $view_slug === $public_view_slug ) {
 			<?php $this->template( 'components/icons/' . esc_attr( $public_view_slug ), [ 'classes' => [ 'tribe-events-c-view-selector__list-item-icon-svg' ] ] ); ?>
 		</span>
 		<span class="tribe-events-c-view-selector__list-item-text">
-			<?php echo esc_html( $public_view_data->view_label ); ?>
+			<?php echo esc_html( $view_label ); ?>
 		</span>
 	</a>
 </li>

--- a/src/views/v2/components/events-bar/views/list/item.php
+++ b/src/views/v2/components/events-bar/views/list/item.php
@@ -26,7 +26,7 @@ if ( $view_slug === $public_view_slug ) {
  *
  * @since TBD
  *
- * @param string $view_label  Current label of the view.
+ * @param string $public_view_data->view_label  Current label of the view.
  */
 $view_label = apply_filters( 'tribe_events_views_v2_view_label', $public_view_data->view_label );
 ?>


### PR DESCRIPTION
The added filter(s) should allow the user to change the view Labels to anything they like easily, with the following snippet:

```add_filter( 'tribe_events_views_v2_view_label', 'my_custom_view_labels' );

function my_custom_view_labels( $view_label ) {
	$new_labels = [
		'Month'   => 'Grid',
		'List'    => 'Listed',
		'Day'     => 'One day',
		'Week'    => '7 days',
		'Photo'   => 'Masonry',
		'Map'     => 'Location',
		'Summary' => 'Condensed',
	];

	if ( array_key_exists( $view_label, $new_labels ) ) {
		$view_label = $new_labels[ $view_label ];
	}

	return $view_label;
}
```

Works in any language, even on multilingual sites.
Though for non-English languages the user can just change the translation itself, they can also do it with the snippet.
Changing labels in multiple languages only requires the addition of all variants. For example for month view in English and Spanish the snippet would need to be adjusted like:

```
	$new_labels = [
		'Month'   => 'Grid',
		'Mes'      => 'Red',
		...
	];
```