### PR TITLE
Corrects our include_all_languages() function to use the meta query

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure WPML translated event posts show up on translated venue and organizer pages. (props @dgwatkins)  [TEC-4036]
+
 = [5.8.1] 2021-07-20 =
 
 * Tweak - Remove some CSS on the single events page that was causing a random border to appear on avada theme [TEC-3952]

--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -151,9 +151,7 @@ class Tribe__Events__Integrations__WPML__Meta {
 				$result = array_merge( $result, wp_list_pluck( (array) $translations, 'element_id' ) );
 			}
 
-			if ( empty( $result ) ) {
-				continue;
-			}
+			// Don't bail here on empty $result!
 
 			$meta_query[ $key ]['value'] = $result;
 			$q->set( 'meta_query', $meta_query );


### PR DESCRIPTION
as WPML changed their algorithm and it does not include the correct venue ID (it's always English).

🎥 https://d.pr/v/fr19qz

[TEC-4036]

From original PR:
The query changed from arguments like venue=xxx to using the meta_query array.
This pull request caters for those changes.

https://wpml.org/forums/topic/events-not-showing-in-all-translated-venue-pages/

[TEC-4036]: https://theeventscalendar.atlassian.net/browse/TEC-4036