### PR TITLE
[TEC-3791] Ensure the correct timezone label is being displayed on the Classic editor when site-wide timezone is set.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Ensure the correct timezone label is being displayed on the Block editor when site-wide timezone is set. [TEC-3791]
+* Fix - Ensure the correct timezone label is being displayed on the Classic and Block editors when site-wide timezone is set. [TEC-3791]
 * Fix - Ensure that venue state or province are displayed next to the city in list view. [TEC-3332]
 * Fix - Ensure the category archive event breadcrumb links to the main events page. [TEC-3330]
 * Fix - Ensure that the page title does not encode (em)dashes before passing it on. [TEC-4049]

--- a/src/views/blocks/event-datetime.php
+++ b/src/views/blocks/event-datetime.php
@@ -46,7 +46,7 @@ if ( is_null( $show_time_zone ) ) {
 $time_zone_label = $this->attr( 'timeZoneLabel' );
 
 if ( is_null( $time_zone_label ) ) {
-	$time_zone_label = Tribe__Events__Timezones::is_mode( 'site' ) ? $time_zone_label = Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
+	$time_zone_label = Tribe__Events__Timezones::is_mode( 'site' ) ? Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
 }
 
 

--- a/src/views/blocks/parts/details.php
+++ b/src/views/blocks/parts/details.php
@@ -17,7 +17,7 @@ $event_id             = Tribe__Main::post_id_helper();
 $time_format          = get_option( 'time_format', Tribe__Date_Utils::TIMEFORMAT );
 $time_range_separator = tribe_get_option( 'timeRangeSeparator', ' - ' );
 $show_time_zone       = tribe_get_option( 'tribe_events_timezones_show_zone', false );
-$time_zone_label      = Tribe__Events__Timezones::is_mode( 'site' ) ? $time_zone_label = Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
+$time_zone_label      = Tribe__Events__Timezones::is_mode( 'site' ) ? Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
 
 $start_datetime = tribe_get_start_date();
 $start_date = tribe_get_start_date( null, false );

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -17,7 +17,7 @@ $event_id             = Tribe__Main::post_id_helper();
 $time_format          = get_option( 'time_format', Tribe__Date_Utils::TIMEFORMAT );
 $time_range_separator = tribe_get_option( 'timeRangeSeparator', ' - ' );
 $show_time_zone       = tribe_get_option( 'tribe_events_timezones_show_zone', false );
-$time_zone_label      = Tribe__Events__Timezones::is_mode( 'site' ) ? $time_zone_label = Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
+$time_zone_label      = Tribe__Events__Timezones::is_mode( 'site' ) ? Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
 
 $start_datetime = tribe_get_start_date();
 $start_date = tribe_get_start_date( null, false );

--- a/src/views/modules/meta/details.php
+++ b/src/views/modules/meta/details.php
@@ -17,7 +17,7 @@ $event_id             = Tribe__Main::post_id_helper();
 $time_format          = get_option( 'time_format', Tribe__Date_Utils::TIMEFORMAT );
 $time_range_separator = tribe_get_option( 'timeRangeSeparator', ' - ' );
 $show_time_zone       = tribe_get_option( 'tribe_events_timezones_show_zone', false );
-$time_zone_label      = Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
+$time_zone_label      = Tribe__Events__Timezones::is_mode( 'site' ) ? $time_zone_label = Tribe__Events__Timezones::wp_timezone_abbr( $local_start_time ) : Tribe__Events__Timezones::get_event_timezone_abbr( $event_id );
 
 $start_datetime = tribe_get_start_date();
 $start_date = tribe_get_start_date( null, false );


### PR DESCRIPTION
This PR ensures that the correct timezone label is displayed when we have the `use site-wide timezone everywhere` setting enabled.

It resolves the same issue as on this [other one](https://github.com/the-events-calendar/the-events-calendar/pull/3629) but focuses on the classic editor. 

It also cleans up the ternary operator used on the block editor. 

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-3791
Artifact : 
![artifact](https://user-images.githubusercontent.com/22029087/132195038-0401564f-380d-4eb6-af60-b53aabc2d9a1.jpg)
