### PR TITLE
Revert [src/Tribe/Editor/Blocks/Event_Datetime.php] to previous state

### DIFF
--- a/src/Tribe/Editor/Blocks/Event_Datetime.php
+++ b/src/Tribe/Editor/Blocks/Event_Datetime.php
@@ -55,12 +55,10 @@ extends Tribe__Editor__Blocks__Abstract {
 	 * Returns the block data for the block editor.
 	 *
 	 * @since 5.1.1
-	 * 
-	 * @param int $event_id The event post ID. Defaults to the current event.
 	 *
 	 * @return array<string,mixed> The block data for the editor.
 	 */
-	public function block_data( $event_id = null ) {
+	public function block_data() {
 		$block_data = [
 			'id'         => $this->slug(),
 			'attributes' => [
@@ -100,7 +98,7 @@ extends Tribe__Editor__Blocks__Abstract {
 				],
 				'timeZoneLabel' => [
 					'type'    => 'string',
-					'default' => class_exists( 'Tribe__Timezones' ) ? Tribe__Events__Timezones::get_event_timezone_abbr( $event_id ) : get_option( 'timezone_string', 'UTC' ),
+					'default' => class_exists( 'Tribe__Timezones' ) ? Tribe__Timezones::wp_timezone_string() : get_option( 'timezone_string', 'UTC' ),
 				],
 				// Only available for classic users.
 				'cost'          => [


### PR DESCRIPTION
This PR reverts the `src/Tribe/Editor/Blocks/Event_Datetime.php` file to its previous state before we merged this [PR](https://github.com/the-events-calendar/the-events-calendar/pull/3629). 

Reference : https://github.com/the-events-calendar/the-events-calendar/pull/3629#discussion_r703550154
Ticket : https://theeventscalendar.atlassian.net/browse/TEC-3791