### PR TITLE
[TEC-4071] Match the font titles for venue and organizer blocks. 

### DIFF
--- a/src/modules/blocks/event-organizer/details/style.pcss
+++ b/src/modules/blocks/event-organizer/details/style.pcss
@@ -2,6 +2,9 @@
 	position: relative;
 
 	h3.tribe-editor__organizer__title-heading {
+		font-family: 'Helvetica', 'sans-serif';
+		font-size: 1.3125rem;
+		font-weight: bold;
 
 		.edit-post-visual-editor .editor-block-list__block & {
 			font-family: 'Helvetica', 'sans-serif';


### PR DESCRIPTION
This PR matches the fonts for the event venue and event organizer titles in the block editor. Below I'll attach some before and after screenshots. 

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-4071

Artifacts: 
Before: 
![image](https://user-images.githubusercontent.com/22029087/132504099-ceea11ca-18df-48b8-b299-57fb514c3940.png)

After: 
![image](https://user-images.githubusercontent.com/22029087/132503932-881f436c-6349-485a-9116-3e9025b93efc.png)
