### PR TITLE
Added the organizer URL to the JSON-LD for Google Search

### DIFF
--- a/src/Tribe/JSON_LD/Organizer.php
+++ b/src/Tribe/JSON_LD/Organizer.php
@@ -55,6 +55,7 @@ class Tribe__Events__JSON_LD__Organizer extends Tribe__JSON_LD__Abstract {
 		$data->telephone = tribe_get_organizer_phone( $post_id );
 		$data->email = tribe_get_organizer_email( $post_id );
 		$data->sameAs = tribe_get_organizer_website_url( $post_id );
+		$data->url = tribe_get_organizer_website_url( $post_id );
 
 		$data = $this->apply_object_data_filter( $data, $args, $post );
 


### PR DESCRIPTION
Added the `url` property with the organizer website URL to the event organizer's JSON-LD.

- When the `organizer` of an event is present, [Google Search docs recommend](https://developers.google.com/search/docs/advanced/structured-data/event#organizer) that the `organizer.url` property is also present.
- Without this, Google Search console flags up the missing URL from the event organizer as a warning.
- The URL is also in the `organizer.sameAs` property, but this isn't used by Google Search.