### PR TITLE
Set the correct `content-type` header for views | TEC-4087

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Tweak - Improve the look and feel of the single events page when using the block editor. [TEC-3979]
+* Tweak - Set the appropriate Content-Type for REST responses that return just HTML during view partial requests. [TEC-4087]
 
 = [5.9.1] 2021-09-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Improve the look and feel of the single events page when using the block editor. [TEC-3979]
+
 = [5.9.1] 2021-09-14 =
 
 * Fix - Initialize $local_time_zone to ensure we don't have notices displayed in the frontend. [TEC-3791]

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -437,6 +437,24 @@ class Assets extends \tad_DI52_ServiceProvider {
 				],
 			]
 		);
+
+		tribe_asset(
+			$plugin,
+			'tribe-events-v2-single-blocks',
+			'tribe-events-single-blocks.css',
+			[
+				'tec-variables-full',
+				'tec-variables-skeleton',
+			],
+			'wp_enqueue_scripts',
+			[
+				'priority'     => 15,
+				'groups'       => [ static::$single_group_key ],
+				'conditionals' => [
+					[ $this, 'should_enqueue_single_event_block_editor_styles' ],
+				],
+			]
+		);
 	}
 
 	/**
@@ -560,6 +578,32 @@ class Assets extends \tad_DI52_ServiceProvider {
 			tribe( 'editor' )->is_events_using_blocks()
 			&& has_blocks( get_queried_object_id() )
 		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if we are on V2, on Event Single and if we are using the Block Editor in order to enqueue the block editor reskin styles for Single Event.
+	 *
+	 * @since TBD
+	 *
+	 * @return boolean
+	 */
+	public function should_enqueue_single_event_block_editor_styles() {
+		// Bail if not Single Event V2.
+		if ( ! tribe_events_single_view_v2_is_enabled() ) {
+			return false;
+		}
+
+		// Bail if not Single Event.
+		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
+			return false;
+		}
+
+		// Bail if not Block Editor.
+		if ( ! tribe( 'editor' )->is_events_using_blocks() && ! has_blocks( get_queried_object_id() ) ) {
 			return false;
 		}
 

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -184,6 +184,9 @@ class Rest_Endpoint {
 				       && wp_verify_nonce( $request->get_param( '_wpnonce' ), 'wp_rest' );
 			},
 			'callback'            => static function ( Request $request ) {
+				if ( ! headers_sent() ) {
+					header( 'Content-Type: text/html; charset=' . esc_attr( get_bloginfo( 'charset' ) ) );
+				}
 				View::make_for_rest( $request )->send_html();
 			},
 			'args'                => $this->get_request_arguments(),

--- a/src/modules/blocks/event-organizer/details/style.pcss
+++ b/src/modules/blocks/event-organizer/details/style.pcss
@@ -2,6 +2,9 @@
 	position: relative;
 
 	h3.tribe-editor__organizer__title-heading {
+		font-family: 'Helvetica', 'sans-serif';
+		font-size: 1.3125rem;
+		font-weight: bold;
 
 		.edit-post-visual-editor .editor-block-list__block & {
 			font-family: 'Helvetica', 'sans-serif';

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -1,0 +1,410 @@
+/**
+ * Block editor event single v2 reskin
+ *
+ * @since TBD
+ */
+
+/* = Event title
+============================================= */
+.single-tribe_events .tribe-blocks-editor .tribe-events-single-event-title {
+	font-size: revert;
+	line-height: revert;
+}
+
+/* = Website block view styles
+============================================= */
+.tribe-block__event-website {
+	padding: 20px 0;
+
+	a {
+		background-color: var(--tec-color-accent-primary);
+		border: none;
+		border-radius: 4px;
+		font-size: 1.125rem;
+		font-weight: var(--tec-font-weight-bold);
+		min-height: 40px;
+		padding: 0 20px;
+
+		#tribe-events-content & {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				color: var(--tec-color-background);
+			}
+		}
+	}
+}
+
+/* = Venue block view styles
+============================================= */
+.tribe-block__venue {
+	border-top: 1px solid var(--tec-color-border-default);
+	flex-direction: column-reverse;
+	justify-content: flex-start;
+	padding: 22.5px 0;
+
+	@media screen and (min-width: 768px) {
+		flex-direction: row;
+		padding: 32px 0;
+	}
+
+	&.tribe-block__venue--has-map {
+
+		.tribe-block__venue__meta,
+		.tribe-block__venue__map {
+			flex: none;
+			width: 100%;
+
+			@media screen and (min-width: 768px) {
+				width: 50%;
+			}
+		}
+
+		.tribe-block__venue__meta {
+			@media screen and (min-width: 1200px) {
+				width: 35%;
+			}
+		}
+	}
+
+	.tribe-block__venue__meta {
+		margin-top: 24px;
+
+		@media screen and (min-width: 768px) {
+			margin-top: 0;
+		}
+
+		.tribe-block__venue__name {
+
+			h3 {
+				font-size: 1rem;
+				font-weight: normal;
+				letter-spacing: normal;
+				line-height: 1.64;
+			}
+		}
+
+		.tribe-block__venue__address {
+			margin-bottom: 0;
+
+			a {
+				color: var(--tec-color-link-accent);
+				margin-top: 17px;
+			}
+
+			.tribe-region.tribe-events-abbr {
+				text-decoration: none;
+			}
+		}
+
+		.tribe-block__venue__phone {
+			margin-bottom: 0;
+		}
+
+		.tribe-block__venue__address,
+		.tribe-block__venue__phone,
+		.tribe-block__venue__website {
+			color: var(--tec-color-text-primary);
+			font-weight: normal;
+			letter-spacing: normal;
+			line-height: 1.64;
+		}
+	}
+}
+
+/* = Organizer block view styles
+============================================= */
+.tribe-block__organizer__details {
+	border-top: 1px solid var(--tec-color-border-default);
+	padding: 22.5px 0;
+
+	@media screen and (min-width: 768px) {
+		padding: 32px 0;
+	}
+
+	h3 {
+		font-size: 1rem;
+		font-weight: normal;
+		letter-spacing: normal;
+		line-height: 1.64;
+
+		a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	p {
+		color: var(--tec-color-text-primary);
+		font-size: 1rem;
+		letter-spacing: normal;
+		line-height: 1.64;
+	}
+}
+
+/* = Sharing block view styles
+============================================= */
+.tribe-block__events-link {
+	padding: 20px 0;
+
+	.tribe-block__btn--link {
+
+		&:before {
+			content: url("data:image/svg+xml,%3Csvg width='25' height='19' viewBox='0 0 25 19' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M0 0.431057V17.5689C0 17.807 0.162753 18 0.363518 18H17.6365C17.8372 18 18 17.807 18 17.5689V13.0039H18.0005V8.01562H18V0.431057C18 0.192991 17.8372 0 17.6365 0H0.363518C0.162753 0 0 0.192991 0 0.431057ZM18 8.01562H16.9855V4.6875H0.990723V16.7571H16.9855V13.0039H18V8.01562ZM0.990723 1.23926H16.9855V3.55366H0.990723V1.23926Z' fill='%23141827'/%3E%3Cpath d='M22.918 10.5003L9.2067 10.5002' stroke='%23141827' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M20.6947 7.24467L23.9466 10.5174L20.7341 13.73' stroke='%23141827' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");
+			margin: 5px 5px 0 0;
+		}
+
+		a {
+			background-color: transparent;
+			border: none;
+			color: var(--tec-color-link-accent);
+			display: block;
+			font-weight: normal;
+			margin: 10px 15px 10px 0;
+			min-height: revert;
+			padding: 0;
+
+			&:before {
+				color: var(--tec-color-link-accent);
+				content: '+';
+				margin-right: 3px;
+			}
+		}
+
+		img {
+			display: none;
+		}
+	}
+}
+
+/* = Price block view styles
+============================================= */
+.tribe-block__event-price {
+	padding: 20px 0 10px;
+}
+
+/* = Recurring event label
+============================================= */
+.single-tribe_events .tribe-blocks-editor .tribe-events-single-event-recurrence-description {
+	background-color: var(--tec-color-background-secondary);
+	border-radius: 40px;
+	display: inline-flex;
+	min-height: 40px;
+	padding: 0 13px 0 10px;
+	position: relative;
+
+	&:before {
+		background: url("data:image/svg+xml;charset=utf-8,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M13.333 3.826c0 .065 0 .13-.02.174 0 .022-.02.065-.02.087a.9.9 0 0 1-.197.37L10.45 7.37a.797.797 0 0 1-.592.26.797.797 0 0 1-.593-.26c-.316-.348-.316-.935 0-1.305l1.225-1.348H6.3c-2.547 0-4.64 2.283-4.64 5.11 0 1.369.474 2.651 1.363 3.608.316.348.316.935 0 1.304A.797.797 0 0 1 2.43 15a.797.797 0 0 1-.593-.26C.652 13.434 0 11.695 0 9.847c0-3.826 2.825-6.935 6.301-6.935h4.208L9.284 1.565c-.316-.348-.316-.935 0-1.304.316-.348.85-.348 1.185 0l2.647 2.913a.952.952 0 0 1 .198.37c0 .021.02.065.02.086v.196zM20 10.152c0 3.826-2.825 6.935-6.301 6.935H9.49l1.225 1.348c.336.348.336.935 0 1.304a.797.797 0 0 1-.593.261.83.83 0 0 1-.592-.26l-2.627-2.936a.948.948 0 0 1-.198-.37c0-.021-.02-.064-.02-.086-.02-.065-.02-.109-.02-.174 0-.065 0-.13.02-.174 0-.022.02-.065.02-.087a.9.9 0 0 1 .198-.37L9.55 12.63c.316-.347.849-.347 1.185 0 .336.348.336.935 0 1.305L9.51 15.283h4.208c2.548 0 4.641-2.283 4.641-5.11 0-1.369-.474-2.651-1.362-3.608a.97.97 0 0 1 0-1.304c.316-.348.849-.348 1.185 0C19.348 6.543 20 8.283 20 10.152z'/%3E%3C/svg%3E") 0/12px no-repeat;
+		content: '';
+		height: 20px;
+		left: 20px;
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 20px;
+	}
+
+	img {
+		display: none;
+	}
+
+	span {
+		color: var(--tec-color-text-primary);
+		font-size: 1rem;
+		font-weight: 700;
+		padding-left: 30px;
+	}
+
+	a {
+		color: var(--tec-color-link-accent);
+		font-size: 1rem;
+	}
+}
+
+/* = Theme specific overrides
+============================================= */
+
+/* Twenty-twenty-one theme */
+.tribe-theme-twentytwentyone {
+	/* Website block view styles */
+	.tribe-block__event-website a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
+		background-color: var(--tec-color-link-accent);
+	}
+
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta .tribe-block__venue__website a {
+		color: var(--tec-color-link-accent);
+	}
+
+	/* Sharing block view styles */
+	.tribe-block__events-link .tribe-block__btn--link a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
+		background-color: transparent;
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price .tribe-block__event-price__description {
+		font-size: 1.2rem;
+	}
+}
+
+/* Twenty-twenty theme */
+.tribe-theme-twentytwenty {
+	/* Website block view styles */
+	.tribe-block__event-website a {
+		font-size: 1.65rem;
+	}
+
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__address,
+		.tribe-block__venue__address a,
+		.tribe-block__venue__phone,
+		.tribe-block__venue__website {
+			font-size: 1.65rem;
+		}
+
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	/* Organizer block view styles */
+	.tribe-block__organizer__details {
+		h3,
+		p {
+			font-size: 1.65rem;
+		}
+	}
+
+	/* Sharing block view styles */
+	.tribe-block__events-link .tribe-block__btn--link a {
+		font-size: 1.65rem;
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price {
+		.tribe-block__event-price__cost {
+			font-size: 1.65rem;
+		}
+
+		.tribe-block__event-price__description {
+			font-size: 1.65rem;
+		}
+	}
+
+	/* Recurring event label */
+	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
+		span,
+		a {
+			font-size: 1.65rem;
+		}
+	}
+}
+
+/* Twenty-seventeen theme */
+.tribe-theme-twentyseventeen {
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+}
+
+/* Genesis theme */
+.tribe-theme-genesis {
+	/* Website block view styles */
+	.tribe-block__event-website a {
+		font-size: 1.65rem;
+	}
+
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__address,
+		.tribe-block__venue__phone,
+		.tribe-block__venue__website {
+			font-size: 1.65rem;
+		}
+
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	/* Organizer block view styles */
+	.tribe-block__organizer__details {
+		h3,
+		p {
+			font-size: 1.65rem;
+		}
+	}
+
+	/* Sharing block view styles */
+	.tribe-block__events-link .tribe-block__btn--link a {
+		font-size: 1.65rem;
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price {
+
+		.tribe-block__event-price__cost {
+			font-size: 1.65rem;
+		}
+
+		.tribe-block__event-price__description {
+			font-size: 1.65rem;
+		}
+	}
+
+	/* Recurring event label */
+	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
+		span,
+		a {
+			font-size: 1.65rem;
+		}
+	}
+}
+
+/* Divi theme */
+.tribe-theme-divi {
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__address,
+		.tribe-block__venue__phone,
+		.tribe-block__venue__website {
+			padding-bottom: 0;
+		}
+
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	/* Organizer block view styles */
+	.tribe-block__organizer__details {
+		h3,
+		p {
+			padding-bottom: 0;
+		}
+	}
+}
+
+/* Enfold */
+.tribe-theme-enfold {
+	/* Venue block view styles */
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	/* Organizer block view styles */
+	.tribe-block__organizer__details h3 {
+		color: var(--tec-color-accent-primary);
+	}
+}


### PR DESCRIPTION
When the view endpoint is used to fetch new partials `application/json`
header is used when deliver the view to the clients.

Instead `text/html` is used to deliver the views with the charset from
the site.

Screencast: https://d.pr/v/zyib6Z
:ticket: [TEC-4087]

[TEC-4087]: https://theeventscalendar.atlassian.net/browse/TEC-4087