### PR TITLE
Set the correct content-type header for views | TEC-4087

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Set the appropriate Content-Type for REST responses that return just HTML during view partial requests. [TEC-4087]
+
 = [5.9.1] 2021-09-14 =
 
 * Fix - Initialize $local_time_zone to ensure we don't have notices displayed in the frontend. [TEC-3791]

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -184,6 +184,9 @@ class Rest_Endpoint {
 				       && wp_verify_nonce( $request->get_param( '_wpnonce' ), 'wp_rest' );
 			},
 			'callback'            => static function ( Request $request ) {
+				if ( ! headers_sent() ) {
+					header( 'Content-Type: text/html; charset=' . esc_attr( get_bloginfo( 'charset' ) ) );
+				}
 				View::make_for_rest( $request )->send_html();
 			},
 			'args'                => $this->get_request_arguments(),


### PR DESCRIPTION
When the view endpoint is used to fetch new partials `application/json`
header is used when deliver the view to the clients.

Instead `text/html` is used to deliver the views with the charset from
the site.

Screencast: https://d.pr/v/zyib6Z
:ticket: [TEC-4087]

[TEC-4087]: https://theeventscalendar.atlassian.net/browse/TEC-4087