### PR TITLE
[TEC-4071] Ensure customizer font control settings are applied to single events page.

### DIFF
--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -20,7 +20,7 @@
 		background-color: var(--tec-color-accent-primary);
 		border: none;
 		border-radius: 4px;
-		font-size: 1.125rem;
+		font-size: var(--tec-font-size-3);
 		font-weight: var(--tec-font-weight-bold);
 		min-height: 40px;
 		padding: 0 20px;
@@ -78,7 +78,7 @@
 		.tribe-block__venue__name {
 
 			h3 {
-				font-size: 1rem;
+				font-size: var(--tec-font-size-3);
 				font-weight: normal;
 				letter-spacing: normal;
 				line-height: 1.64;
@@ -124,7 +124,7 @@
 	}
 
 	h3 {
-		font-size: 1rem;
+		font-size: var(--tec-font-size-3);
 		font-weight: normal;
 		letter-spacing: normal;
 		line-height: 1.64;
@@ -136,7 +136,7 @@
 
 	p {
 		color: var(--tec-color-text-primary);
-		font-size: 1rem;
+		font-size: var(--tec-font-size-3);
 		letter-spacing: normal;
 		line-height: 1.64;
 	}
@@ -181,6 +181,10 @@
 ============================================= */
 .tribe-block__event-price {
 	padding: 20px 0 10px;
+
+	.tribe-block__event-price__cost {
+		font-size: var(--tec-font-size-4);
+	}
 }
 
 /* = Recurring event label
@@ -210,14 +214,14 @@
 
 	span {
 		color: var(--tec-color-text-primary);
-		font-size: 1rem;
+		font-size: var(--tec-font-size-3);
 		font-weight: 700;
 		padding-left: 30px;
 	}
 
 	a {
 		color: var(--tec-color-link-accent);
-		font-size: 1rem;
+		font-size: var(--tec-font-size-3);
 	}
 }
 
@@ -243,7 +247,7 @@
 
 	/* Price block view styles */
 	.tribe-block__event-price .tribe-block__event-price__description {
-		font-size: 1.2rem;
+		font-size: var(--tec-font-size-4);
 	}
 }
 
@@ -251,7 +255,7 @@
 .tribe-theme-twentytwenty {
 	/* Website block view styles */
 	.tribe-block__event-website a {
-		font-size: 1.65rem;
+		font-size: var(--tec-font-size-3);
 	}
 
 	/* Venue block view styles */
@@ -261,7 +265,7 @@
 		.tribe-block__venue__address a,
 		.tribe-block__venue__phone,
 		.tribe-block__venue__website {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 
 		.tribe-block__venue__website a {
@@ -273,23 +277,23 @@
 	.tribe-block__organizer__details {
 		h3,
 		p {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
-		font-size: 1.65rem;
+		font-size: var(--tec-font-size-3);
 	}
 
 	/* Price block view styles */
 	.tribe-block__event-price {
 		.tribe-block__event-price__cost {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 
 		.tribe-block__event-price__description {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 
@@ -297,7 +301,7 @@
 	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
 		span,
 		a {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 }
@@ -317,7 +321,7 @@
 .tribe-theme-genesis {
 	/* Website block view styles */
 	.tribe-block__event-website a {
-		font-size: 1.65rem;
+		font-size: var(--tec-font-size-3);
 	}
 
 	/* Venue block view styles */
@@ -326,7 +330,7 @@
 		.tribe-block__venue__address,
 		.tribe-block__venue__phone,
 		.tribe-block__venue__website {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 
 		.tribe-block__venue__website a {
@@ -338,24 +342,24 @@
 	.tribe-block__organizer__details {
 		h3,
 		p {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
-		font-size: 1.65rem;
+		font-size: var(--tec-font-size-3);
 	}
 
 	/* Price block view styles */
 	.tribe-block__event-price {
 
 		.tribe-block__event-price__cost {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 
 		.tribe-block__event-price__description {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 
@@ -363,7 +367,7 @@
 	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
 		span,
 		a {
-			font-size: 1.65rem;
+			font-size: var(--tec-font-size-3);
 		}
 	}
 }

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -14,6 +14,7 @@
 /* = Website block view styles
 ============================================= */
 .tribe-block__event-website {
+	font-family: var(--tec-font-family-sans-serif);
 	padding: 20px 0;
 
 	a {
@@ -41,6 +42,7 @@
 .tribe-block__venue {
 	border-top: 1px solid var(--tec-color-border-default);
 	flex-direction: column-reverse;
+	font-family: var(--tec-font-family-sans-serif);
 	justify-content: flex-start;
 	padding: 22.5px 0;
 
@@ -117,6 +119,7 @@
 ============================================= */
 .tribe-block__organizer__details {
 	border-top: 1px solid var(--tec-color-border-default);
+	font-family: var(--tec-font-family-sans-serif);
 	padding: 22.5px 0;
 
 	@media screen and (min-width: 768px) {
@@ -145,6 +148,7 @@
 /* = Sharing block view styles
 ============================================= */
 .tribe-block__events-link {
+	font-family: var(--tec-font-family-sans-serif);
 	padding: 20px 0;
 
 	.tribe-block__btn--link {
@@ -180,6 +184,7 @@
 /* = Price block view styles
 ============================================= */
 .tribe-block__event-price {
+	font-family: var(--tec-font-family-sans-serif);
 	padding: 20px 0 10px;
 
 	.tribe-block__event-price__cost {
@@ -197,6 +202,7 @@
 	background-color: var(--tec-color-background-secondary);
 	border-radius: 40px;
 	display: inline-flex;
+	font-family: var(--tec-font-family-sans-serif);
 	min-height: 40px;
 	padding: 0 13px 0 10px;
 	position: relative;

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -236,7 +236,7 @@
 .tribe-theme-twentytwentyone {
 	/* Website block view styles */
 	.tribe-block__event-website a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
-		background-color: var(--tec-color-link-accent);
+		background-color: var(--tec-color-accent-primary);
 	}
 
 	/* Venue block view styles */

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -183,7 +183,11 @@
 	padding: 20px 0 10px;
 
 	.tribe-block__event-price__cost {
-		font-size: var(--tec-font-size-4);
+		font-size: var(--tec-font-size-3);
+	}
+
+	.tribe-block__event-price__description {
+		font-size: var(--tec-font-size-3);
 	}
 }
 
@@ -244,11 +248,6 @@
 	.tribe-block__events-link .tribe-block__btn--link a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
 		background-color: transparent;
 	}
-
-	/* Price block view styles */
-	.tribe-block__event-price .tribe-block__event-price__description {
-		font-size: var(--tec-font-size-4);
-	}
 }
 
 /* Twenty-twenty theme */
@@ -284,17 +283,6 @@
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
 		font-size: var(--tec-font-size-3);
-	}
-
-	/* Price block view styles */
-	.tribe-block__event-price {
-		.tribe-block__event-price__cost {
-			font-size: var(--tec-font-size-3);
-		}
-
-		.tribe-block__event-price__description {
-			font-size: var(--tec-font-size-3);
-		}
 	}
 
 	/* Recurring event label */
@@ -349,18 +337,6 @@
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
 		font-size: var(--tec-font-size-3);
-	}
-
-	/* Price block view styles */
-	.tribe-block__event-price {
-
-		.tribe-block__event-price__cost {
-			font-size: var(--tec-font-size-3);
-		}
-
-		.tribe-block__event-price__description {
-			font-size: var(--tec-font-size-3);
-		}
 	}
 
 	/* Recurring event label */

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -65,6 +65,7 @@
 
 		.tribe-block__venue__meta {
 			@media screen and (min-width: 1200px) {
+				margin-right: 20px;
 				width: 35%;
 			}
 		}
@@ -241,18 +242,53 @@
 /* Twenty-twenty-one theme */
 .tribe-theme-twentytwentyone {
 	/* Website block view styles */
-	.tribe-block__event-website a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
-		background-color: var(--tec-color-accent-primary);
+	.tribe-block__event-website a {
+		font-size: var(--tec-font-size-4);
+
+		&:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
+			background-color: var(--tec-color-accent-primary);
+		}
 	}
 
 	/* Venue block view styles */
-	.tribe-block__venue .tribe-block__venue__meta .tribe-block__venue__website a {
-		color: var(--tec-color-link-accent);
+	.tribe-block__venue .tribe-block__venue__meta {
+		.tribe-block__venue__name h3,
+		.tribe-block__venue__address,
+		.tribe-block__venue__address a,
+		.tribe-block__venue__phone,
+		.tribe-block__venue__website {
+			font-size: var(--tec-font-size-4);
+		}
+
+		.tribe-block__venue__website a {
+			color: var(--tec-color-link-accent);
+		}
+	}
+
+	/* Organizer block view styles */
+	.tribe-block__organizer__details {
+		h3,
+		p {
+			font-size: var(--tec-font-size-4);
+		}
 	}
 
 	/* Sharing block view styles */
-	.tribe-block__events-link .tribe-block__btn--link a:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
-		background-color: transparent;
+	.tribe-block__events-link .tribe-block__btn--link a {
+		font-size: var(--tec-font-size-4);
+
+		&:focus:not(.wp-block-button__link):not(.wp-block-file__button) {
+			background-color: transparent;
+		}
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price__cost {
+		font-size: var(--tec-font-size-4);
+	}
+
+	.tribe-block__event-price__description {
+		font-size: var(--tec-font-size-4);
 	}
 }
 

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -335,14 +335,6 @@
 	.tribe-block__event-price__description {
 		font-size: var(--tec-font-size-4);
 	}
-
-	/* Recurring event label */
-	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
-		span,
-		a {
-			font-size: var(--tec-font-size-4);
-		}
-	}
 }
 
 /* Twenty-seventeen theme */
@@ -397,14 +389,6 @@
 
 	.tribe-block__event-price__description {
 		font-size: var(--tec-font-size-4);
-	}
-
-	/* Recurring event label */
-	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
-		span,
-		a {
-			font-size: var(--tec-font-size-4);
-		}
 	}
 }
 

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -260,7 +260,7 @@
 .tribe-theme-twentytwenty {
 	/* Website block view styles */
 	.tribe-block__event-website a {
-		font-size: var(--tec-font-size-3);
+		font-size: var(--tec-font-size-4);
 	}
 
 	/* Venue block view styles */
@@ -270,7 +270,7 @@
 		.tribe-block__venue__address a,
 		.tribe-block__venue__phone,
 		.tribe-block__venue__website {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 
 		.tribe-block__venue__website a {
@@ -282,20 +282,29 @@
 	.tribe-block__organizer__details {
 		h3,
 		p {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 	}
 
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
-		font-size: var(--tec-font-size-3);
+		font-size: var(--tec-font-size-4);
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price__cost {
+		font-size: var(--tec-font-size-4);
+	}
+
+	.tribe-block__event-price__description {
+		font-size: var(--tec-font-size-4);
 	}
 
 	/* Recurring event label */
 	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
 		span,
 		a {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 	}
 }
@@ -315,7 +324,7 @@
 .tribe-theme-genesis {
 	/* Website block view styles */
 	.tribe-block__event-website a {
-		font-size: var(--tec-font-size-3);
+		font-size: var(--tec-font-size-4);
 	}
 
 	/* Venue block view styles */
@@ -324,7 +333,7 @@
 		.tribe-block__venue__address,
 		.tribe-block__venue__phone,
 		.tribe-block__venue__website {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 
 		.tribe-block__venue__website a {
@@ -336,20 +345,29 @@
 	.tribe-block__organizer__details {
 		h3,
 		p {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 	}
 
 	/* Sharing block view styles */
 	.tribe-block__events-link .tribe-block__btn--link a {
-		font-size: var(--tec-font-size-3);
+		font-size: var(--tec-font-size-4);
+	}
+
+	/* Price block view styles */
+	.tribe-block__event-price__cost {
+		font-size: var(--tec-font-size-4);
+	}
+
+	.tribe-block__event-price__description {
+		font-size: var(--tec-font-size-4);
 	}
 
 	/* Recurring event label */
 	.tribe-blocks-editor .tribe-events-single-event-recurrence-description {
 		span,
 		a {
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-4);
 		}
 	}
 }


### PR DESCRIPTION
This PR updates that ensure the font customizer settings i.e. font size and font family settings are applied to the block editor single events page. 

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-4071 
Artifact : https://www.loom.com/share/dbe39362001a43f59f4f52712d5f0843

We don't need a change log since this is a patch addressing some QA feedback from an earlier ticket.