### PR TITLE
Ensure the _request_ respects the default limit too.

### DIFF
--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -950,7 +950,7 @@ class Tribe__Events__Aggregator__Service {
 		if ( $is_other_url ) {
 			$limit_type = 'range';
 		} else {
-			$limit_type = tribe_get_option( 'tribe_aggregator_default_import_limit_type', false );
+			$limit_type = tribe_get_option( 'tribe_aggregator_default_import_limit_type', 'count' );
 		}
 
 		/** @var \Tribe__Events__Aggregator__Settings $settings */

--- a/src/admin-views/aggregator/origins/limit.php
+++ b/src/admin-views/aggregator/origins/limit.php
@@ -1,24 +1,39 @@
 <?php
 /** @var \Tribe__Events__Aggregator__Settings $settings */
-$settings             = tribe( 'events-aggregator.settings' );
+$settings          = tribe( 'events-aggregator.settings' );
 $global_limit_type = tribe_get_option( 'tribe_aggregator_default_import_limit_type', 'count' );
 
 if ( 'no_limit' === $global_limit_type ) {
 	return;
 }
 
-$global_limit_option  = $global_limit_type === 'range'
-	? tribe_get_option( 'tribe_aggregator_default_import_limit_range', $settings->get_import_range_default() )
-	: tribe_get_option( 'tribe_aggregator_default_import_limit_number', $settings->get_import_limit_count_default() );
-$global_limit_strings = $global_limit_type === 'range'
-	? $settings->get_import_range_options( false )
-	: $settings->get_import_limit_count_options();
+$global_limit_strings = $settings->get_import_limit_count_options();
+$global_limit_option  = tribe_get_option( 'tribe_aggregator_default_import_limit_number', $settings->get_import_limit_count_default() );
+$global_limit_message = esc_html(
+	sprintf(
+		__(
+			'Event Aggregator will try to fetch %s events starting from the current date or the specified date;',
+			'the-events-calendar'
+		),
+		$global_limit_strings[ $global_limit_option ]
+	)
+);
 
-$global_limit_string  = $global_limit_strings[ $global_limit_option ];
-$global_limit_message = $global_limit_type === 'range'
-	? esc_html( sprintf( __( 'Event Aggregator will try to fetch events starting within the next %s from the current date or the specified date;', 'the-events-calendar' ), $global_limit_string ) )
-	: esc_html( sprintf( __( 'Event Aggregator will try to fetch %s events starting from the current date or the specified date;', 'the-events-calendar' ), $global_limit_string ) );
-$import_limit_link     = esc_attr( admin_url( '/edit.php?post_type=tribe_events&page=tribe-common&tab=imports#tribe-field-tribe_aggregator_default_import_limit_type' ) );
+if ( 'range' === $global_limit_type ) {
+	$global_limit_strings = $settings->get_import_range_options( false );
+	$global_limit_option  = tribe_get_option( 'tribe_aggregator_default_import_limit_range', $settings->get_import_range_default() );
+	$global_limit_message = esc_html(
+		sprintf(
+			__(
+				'Event Aggregator will try to fetch events starting within the next %s from the current date or the specified date;',
+				'the-events-calendar'
+			),
+			$global_limit_strings[ $global_limit_option ]
+		)
+	);
+}
+
+$import_limit_link    = esc_url( admin_url( '/edit.php?post_type=tribe_events&page=tribe-common&tab=imports#tribe-field-tribe_aggregator_default_import_limit_type' ) );
 $import_limit_message = $global_limit_message . ' ' . sprintf( '<a href="%s" target="_blank">%s</a> ', $import_limit_link, esc_html__( 'you can modify this setting here.', 'the-events-calendar' ) );
 ?>
 


### PR DESCRIPTION
Also, I "cleaned up" the template code.
While I am a HUGE fan of ternaries, it was hard to read and figure out what exactly was going on.
So shoot me :wink:

Desired result with test file: https://d.pr/i/iCztZI

[EA-423]

[EA-423]: https://theeventscalendar.atlassian.net/browse/EA-423