### PR TITLE
display map preview on embed toggle

### DIFF
--- a/src/modules/elements/google-map/element.js
+++ b/src/modules/elements/google-map/element.js
@@ -334,6 +334,10 @@ export default class GoogleMap extends Component {
 			return this.renderInteractive();
 		}
 
+		if ( interactive ) {
+			return this.renderInteractive();
+		}
+
 		if ( ! interactive ) {
 			return this.renderIframe();
 		}


### PR DESCRIPTION
This PR is a patch of this [earlier one](https://github.com/the-events-calendar/the-events-calendar/pull/3657) and it addresses the map preview not being displayed correctly when the embed settings are toggled.

A change log was already provided added to the earlier PR.

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-3042
Artifact : https://www.loom.com/share/26c42cde62194a6d841053af1c91721b