### PR TITLE
[TEC-3944]  Ensure the day view on mobile displays the not found message when no events are present.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Fix - Ensure the day view on mobile displays the not found message when no events are present. [TEC-3944]
 * Fix - Ensure a map preview is displayed on the venue block in the admin area when using TEC's default Google API Key. [TEC-3042]
 * Tweak - Set the appropriate Content-Type for REST responses that return just HTML during view partial requests. [TEC-4087]
 

--- a/src/resources/postcss/views/skeleton/_header.pcss
+++ b/src/resources/postcss/views/skeleton/_header.pcss
@@ -50,6 +50,10 @@
 		margin-bottom: var(--tec-spacer-3);
 		width: 100%;
 
+		&.tribe-events-header__messages--mobile {
+			margin-top: 10px;
+		}
+
 		&:not(.tribe-events-header__messages--mobile) {
 			display: none;
 		}

--- a/src/views/v2/day.php
+++ b/src/views/v2/day.php
@@ -59,6 +59,8 @@ if ( empty( $disable_event_search ) ) {
 			<?php $this->template( 'components/events-bar' ); ?>
 
 			<?php $this->template( 'day/top-bar' ); ?>
+
+			<?php $this->template( 'components/messages', [ 'classes' => [ 'tribe-events-header__messages--mobile' ] ] ); ?>
 		</header>
 
 		<?php $this->template( 'components/filter-bar' ); ?>


### PR DESCRIPTION
This PR ensures the day view on mobile displays the `not found` message when no events are present.

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-3944
Artifact : https://www.loom.com/share/0d3d22030ce3426288a6c4f009bc299d