### PR TITLE
Add body to selector so customizations carry through view refreshes.

### DIFF
--- a/src/Tribe/Views/V2/Customizer/Configuration.php
+++ b/src/Tribe/Views/V2/Customizer/Configuration.php
@@ -41,7 +41,7 @@ class Configuration {
 	 * @return string The selector string.
 	 */
 	public static function get_selector() {
-		$tribe_events = '#tribe-events-pg-template, .tribe-events, .tribe-common';
+		$tribe_events = 'body, #tribe-events-pg-template, .tribe-events, .tribe-common';
 
 		/**
 		 * Allows filtering to enforce applying Customizer styles to shortcode views.


### PR DESCRIPTION
The js targets get re-created on view change. This ensures we have at least one that will exist after a view change.

This might down the line require some fine tuning. We may be able to remove the other selectors, but for now I'd prefer to keep them.