### PR TITLE
Target a body class only added when in the Customizer preview.

### DIFF
--- a/src/Tribe/Views/V2/Customizer/Configuration.php
+++ b/src/Tribe/Views/V2/Customizer/Configuration.php
@@ -41,7 +41,7 @@ class Configuration {
 	 * @return string The selector string.
 	 */
 	public static function get_selector() {
-		$tribe_events = 'body.customizer-preview, #tribe-events-pg-template, .tribe-events, .tribe-common';
+		$tribe_events = '.tec-customizer, #tribe-events-pg-template, .tribe-events, .tribe-common';
 
 		/**
 		 * Allows filtering to enforce applying Customizer styles to shortcode views.

--- a/src/Tribe/Views/V2/Customizer/Hooks.php
+++ b/src/Tribe/Views/V2/Customizer/Hooks.php
@@ -89,6 +89,16 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		// Register assets for Customizer styles.
 		add_filter( 'tribe_customizer_inline_stylesheets', [ $this, 'customizer_inline_stylesheets' ], 12, 2 );
 		add_filter( 'tribe_customizer_print_styles_action', [ $this, 'print_inline_styles_in_footer' ] );
+
+		add_filter( 'body_class', [ $this, 'body_class' ] );
+	}
+
+	public function body_class( $classes ) {
+		if ( is_customize_preview() ) {
+			$classes[] = 'tec-customizer';
+		}
+
+		return $classes;
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Customizer/Hooks.php
+++ b/src/Tribe/Views/V2/Customizer/Hooks.php
@@ -93,6 +93,15 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'body_class', [ $this, 'body_class' ] );
 	}
 
+	/**
+	 * Add an identifying class to the body - but only when inside the Customizer preview.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string> $classes The list of body classes to be applied.
+	 *
+	 * @return array<string> $classes The modified list of body classes to be applied.
+	 */
 	public function body_class( $classes ) {
 		if ( is_customize_preview() ) {
 			$classes[] = 'tec-customizer';


### PR DESCRIPTION
Stop relying on targets that are only present at the whim of themes and filters 😉 

[TEC-4055]

Instead of relying on classes added by themes, or core (and removable via a filter) let's add our own.

[TEC-4055]: https://theeventscalendar.atlassian.net/browse/TEC-4055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ