### PR TITLE
Apply date passed from Event Manager to event start date. [ECP-954]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+== TBD ==
+
+* Fix - Ensure the date selected when creating a new event from the Event Manager is applied on the block editor. [ECP-954]
+
 = [5.11.0] 2021-11-17 =
 
 * Feature - Add an `Events List` block that is based on the `Events List` widget to the block editor which users can drag around to any position they want it to appear. [ECP-989]

--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 == TBD ==
 
-* Fix - Ensure the date selected when creating a new event from the Event Manager is applied on the block editor. [ECP-954]
+* Fix - Ensure the date selected when creating a new event from the Event Manager is applied to the block editor. [ECP-954]
 
 = [5.11.0] 2021-11-17 =
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -59,14 +59,16 @@ class Event implements Editor_Object_Interface {
 				'is_new_post' => true,
 			];
 
+		$startDate = tribe_get_request_var( 'tribe-start-date' );
+
 			/**
 			 * Grabs the tribe-start-date query param from the url 
 			 * if it exists then adds it to the global window object.
 			 */
-			if ( tribe_get_request_var( 'tribe-start-date' ) && strtotime( tribe_get_request_var( 'tribe-start-date' ) ) ) {
+			if ( $startDate && strtotime( $startDate ) ) {
 				$this->data = [
 					'is_new_post'      => true,
-					'tribe_start_date' => tribe_get_request_var( 'tribe-start-date' ) . ' 08:00:00',
+					'tribe_start_date' => $startDate . ' 08:00:00',
 				];
 			}
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -63,7 +63,7 @@ class Event implements Editor_Object_Interface {
 			 * Grabs the tribe-start-date query param from the url 
 			 * if it exists then adds it to the global window object.
 			 */
-			if ( tribe_get_request_var( 'tribe-start-date' ) ) {
+			if ( tribe_get_request_var( 'tribe-start-date' ) && strtotime( tribe_get_request_var( 'tribe-start-date' ) ) ) {
 				$this->data = [
 					'is_new_post'      => true,
 					'tribe_start_date' => tribe_get_request_var( 'tribe-start-date' ),

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -11,6 +11,7 @@ namespace Tribe\Events\Editor\Objects;
 
 use Tribe__Events__Main as TEC;
 use Tribe__Utils__Array as Arr;
+use Tribe__Date_Utils as Dates;
 
 /**
  * Class Event
@@ -68,7 +69,7 @@ class Event implements Editor_Object_Interface {
 			if ( $startDate && strtotime( $startDate ) ) {
 				$this->data = [
 					'is_new_post'      => true,
-					'tribe_start_date' => $startDate . ' 08:00:00',
+					'tribe_start_date' => Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT ) . ' 08:00:00',
 				];
 			}
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -66,7 +66,7 @@ class Event implements Editor_Object_Interface {
 			 * Grabs the tribe-start-date query param from the url if it exists
 			 * and if its a valid date then adds it to the global window object.
 			 */
-			if ( $start_date ) {	
+			if ( $start_date ) {
 				$start_date = Dates::build_date_object( $start_date, null, false );
 
 				if ( $start_date ) {

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -59,6 +59,13 @@ class Event implements Editor_Object_Interface {
 				'is_new_post' => true,
 			];
 
+			if ( isset( $_GET['tribe-start-date'] ) ) {
+				$this->data = [
+					'is_new_post'      => true,
+					'tribe_start_date' => $_GET['tribe-start-date'],
+				];
+			}
+
 			if ( $this->post instanceof \WP_Post && TEC::POSTTYPE === $this->post->post_type ) {
 				$meta = Arr::flatten( (array) \get_post_meta( $this->post->ID ) );
 				$post_id = $this->post->ID;

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -67,7 +67,7 @@ class Event implements Editor_Object_Interface {
 			 * if it exists then adds it to the global window object.
 			 */
 			if ( $startDate && strtotime( $startDate ) ) {
-				$this->data['tribe_start_date'] = Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT ) . ' 08:00:00';
+				$this->data['tribe_start_date'] = Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT );
 			}
 
 			if ( $this->post instanceof \WP_Post && TEC::POSTTYPE === $this->post->post_type ) {

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -60,8 +60,8 @@ class Event implements Editor_Object_Interface {
 			];
 
 			/**
-			 * Grabs the tribe-start-date query param from the url if it exists 
-			 * then adds to to the global window object.
+			 * Grabs the tribe-start-date query param from the url 
+			 * if it exists then adds it to the global window object.
 			 */
 			if ( isset( $_GET['tribe-start-date'] ) ) {
 				$this->data = [

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -70,7 +70,7 @@ class Event implements Editor_Object_Interface {
 				$start_date = Dates::build_date_object( $start_date, null, false );
 
 				if ( $start_date ) {
-					$this->data['tribe_start_date'] = $start_date->format( Dates::DBDATETIMEFORMAT );
+					$this->data['tribe_start_date'] = $start_date->format( Dates::DBDATEFORMAT );
 				}
 			}
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -66,7 +66,7 @@ class Event implements Editor_Object_Interface {
 			if ( tribe_get_request_var( 'tribe-start-date' ) && strtotime( tribe_get_request_var( 'tribe-start-date' ) ) ) {
 				$this->data = [
 					'is_new_post'      => true,
-					'tribe_start_date' => tribe_get_request_var( 'tribe-start-date' ),
+					'tribe_start_date' => tribe_get_request_var( 'tribe-start-date' ) . ' 08:00:00',
 				];
 			}
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -67,10 +67,7 @@ class Event implements Editor_Object_Interface {
 			 * if it exists then adds it to the global window object.
 			 */
 			if ( $startDate && strtotime( $startDate ) ) {
-				$this->data = [
-					'is_new_post'      => true,
-					'tribe_start_date' => Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT ) . ' 08:00:00',
-				];
+				$this->data['tribe_start_date'] = Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT ) . ' 08:00:00';
 			}
 
 			if ( $this->post instanceof \WP_Post && TEC::POSTTYPE === $this->post->post_type ) {

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -59,7 +59,7 @@ class Event implements Editor_Object_Interface {
 				'is_new_post' => true,
 			];
 
-		$startDate = tribe_get_request_var( 'tribe-start-date' );
+			$startDate = tribe_get_request_var( 'tribe-start-date' );
 
 			/**
 			 * Grabs the tribe-start-date query param from the url 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -60,14 +60,18 @@ class Event implements Editor_Object_Interface {
 				'is_new_post' => true,
 			];
 
-			$startDate = tribe_get_request_var( 'tribe-start-date' );
+			$start_date = tribe_get_request_var( 'tribe-start-date' );
 
 			/**
-			 * Grabs the tribe-start-date query param from the url 
-			 * if it exists then adds it to the global window object.
+			 * Grabs the tribe-start-date query param from the url if it exists
+			 * and if its a valid date then adds it to the global window object.
 			 */
-			if ( $startDate && strtotime( $startDate ) ) {
-				$this->data['tribe_start_date'] = Dates::build_date_object( $startDate )->format( Dates::DBDATEFORMAT );
+			if ( $start_date ) {	
+				$start_date = Dates::build_date_object( $start_date, null, false );
+
+				if ( $start_date ) {
+					$this->data['tribe_start_date'] = $start_date->format( Dates::DBDATETIMEFORMAT );
+				}
 			}
 
 			if ( $this->post instanceof \WP_Post && TEC::POSTTYPE === $this->post->post_type ) {

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -63,10 +63,10 @@ class Event implements Editor_Object_Interface {
 			 * Grabs the tribe-start-date query param from the url 
 			 * if it exists then adds it to the global window object.
 			 */
-			if ( isset( $_GET['tribe-start-date'] ) ) {
+			if ( tribe_get_request_var( 'tribe-start-date' ) ) {
 				$this->data = [
 					'is_new_post'      => true,
-					'tribe_start_date' => $_GET['tribe-start-date'],
+					'tribe_start_date' => tribe_get_request_var( 'tribe-start-date' ),
 				];
 			}
 

--- a/src/Tribe/Editor/Objects/Event.php
+++ b/src/Tribe/Editor/Objects/Event.php
@@ -59,6 +59,10 @@ class Event implements Editor_Object_Interface {
 				'is_new_post' => true,
 			];
 
+			/**
+			 * Grabs the tribe-start-date query param from the url if it exists 
+			 * then adds to to the global window object.
+			 */
 			if ( isset( $_GET['tribe-start-date'] ) ) {
 				$this->data = [
 					'is_new_post'      => true,

--- a/src/modules/data/blocks/datetime/reducer.js
+++ b/src/modules/data/blocks/datetime/reducer.js
@@ -27,9 +27,10 @@ export const defaultEndMoment = moment().startOf( 'day' ).seconds( defaultEndTim
 
 const defaultStartDateTime = momentUtil.toDateTime( defaultStartMoment );
 const defaultEndDateTime = momentUtil.toDateTime( defaultEndMoment );
+const queryStartDate = globals.postObjects().tribe_events.tribe_start_date;
 
 export const DEFAULT_STATE = {
-	start: defaultStartDateTime,
+	start: queryStartDate ? queryStartDate : defaultStartDateTime,
 	end: defaultEndDateTime,
 	startTimeInput: momentUtil.toTime( defaultStartMoment ),
 	endTimeInput: momentUtil.toTime( defaultEndMoment ),

--- a/src/modules/data/blocks/datetime/reducer.js
+++ b/src/modules/data/blocks/datetime/reducer.js
@@ -23,7 +23,9 @@ const defaultStartTimeSeconds = time.toSeconds( defaultStartTime, time.TIME_FORM
 const defaultEndTimeSeconds = time.toSeconds( defaultEndTime, time.TIME_FORMAT_HH_MM_SS );
 const queryStartDate = globals.postObjects().tribe_events.tribe_start_date;
 
-export const defaultStartMoment = queryStartDate ? moment( queryStartDate ).seconds( defaultStartTimeSeconds ) : moment().startOf( 'day' ).seconds( defaultStartTimeSeconds ); // eslint-disable-line max-len
+export const defaultStartMoment = queryStartDate
+	? moment( queryStartDate ).seconds( defaultStartTimeSeconds )
+	: moment().startOf( 'day' ).seconds( defaultStartTimeSeconds );
 export const defaultEndMoment = moment().startOf( 'day' ).seconds( defaultEndTimeSeconds );
 
 const defaultStartDateTime = momentUtil.toDateTime( defaultStartMoment );

--- a/src/modules/data/blocks/datetime/reducer.js
+++ b/src/modules/data/blocks/datetime/reducer.js
@@ -28,9 +28,10 @@ export const defaultEndMoment = moment().startOf( 'day' ).seconds( defaultEndTim
 const defaultStartDateTime = momentUtil.toDateTime( defaultStartMoment );
 const defaultEndDateTime = momentUtil.toDateTime( defaultEndMoment );
 const queryStartDate = globals.postObjects().tribe_events.tribe_start_date;
+const queryStartDateTime = queryStartDate + ' ' + defaultStartTime;
 
 export const DEFAULT_STATE = {
-	start: queryStartDate ? queryStartDate : defaultStartDateTime,
+	start: queryStartDate ? queryStartDateTime : defaultStartDateTime,
 	end: defaultEndDateTime,
 	startTimeInput: momentUtil.toTime( defaultStartMoment ),
 	endTimeInput: momentUtil.toTime( defaultEndMoment ),

--- a/src/modules/data/blocks/datetime/reducer.js
+++ b/src/modules/data/blocks/datetime/reducer.js
@@ -21,17 +21,16 @@ const defaultStartTime = globals.defaultTimes().start ? globals.defaultTimes().s
 const defaultEndTime = globals.defaultTimes().end ? globals.defaultTimes().end : '17:00:00';
 const defaultStartTimeSeconds = time.toSeconds( defaultStartTime, time.TIME_FORMAT_HH_MM_SS );
 const defaultEndTimeSeconds = time.toSeconds( defaultEndTime, time.TIME_FORMAT_HH_MM_SS );
+const queryStartDate = globals.postObjects().tribe_events.tribe_start_date;
 
-export const defaultStartMoment = moment().startOf( 'day' ).seconds( defaultStartTimeSeconds );
+export const defaultStartMoment = queryStartDate ? moment( queryStartDate ).seconds( defaultStartTimeSeconds ) : moment().startOf( 'day' ).seconds( defaultStartTimeSeconds );
 export const defaultEndMoment = moment().startOf( 'day' ).seconds( defaultEndTimeSeconds );
 
 const defaultStartDateTime = momentUtil.toDateTime( defaultStartMoment );
 const defaultEndDateTime = momentUtil.toDateTime( defaultEndMoment );
-const queryStartDate = globals.postObjects().tribe_events.tribe_start_date;
-const queryStartDateTime = queryStartDate + ' ' + defaultStartTime;
 
 export const DEFAULT_STATE = {
-	start: queryStartDate ? queryStartDateTime : defaultStartDateTime,
+	start: defaultStartDateTime,
 	end: defaultEndDateTime,
 	startTimeInput: momentUtil.toTime( defaultStartMoment ),
 	endTimeInput: momentUtil.toTime( defaultEndMoment ),


### PR DESCRIPTION
This PR ensures the date selected when creating a new event from the Event Manager is applied to the block editor.

Ticket : https://theeventscalendar.atlassian.net/browse/ECP-954
Artifact : https://www.loom.com/share/59f795e3736c4f7ba12319ee73bdd685
Updated Artifact : https://www.loom.com/share/b2c7e4f13be74c42b3ab56a71c3f179b