### PR TITLE
Wrong rel value causing HTML 5 and WCAG 2.1 compliance error [TEC-4129]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = TBD =
 
+* Fix - Add a valid rel value to the link tag for TEC REST API support in order to improve HTML 5 and WCAG 2.1 compliance. [TEC-4129]
 * Tweak - Ensure the `related events title` and `event titles` within the single event page for the block editor make use the customizer font settings. [TEC-4125]
 
 = [5.11.0] 2021-11-17 =

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -329,7 +329,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 * @return string
 	 */
 	public function get_reference_url() {
-		return esc_attr( 'https://theeventscalendar.com/' );
+		return esc_html( 'alternate' );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a valid rel value to the link tag for TEC REST API support in order to improve HTML 5 and WCAG 2.1 compliance.

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-4129
Artifacts : 
Before Fix;
![image](https://user-images.githubusercontent.com/22029087/143275217-13a7e56a-fda7-4463-9efd-e39b7437e0f1.png)
After Fix; 
![image](https://user-images.githubusercontent.com/22029087/143275345-c9439483-2598-4b28-b256-b35bb3c60724.png)


