### PR TITLE
Force get_post_classes() to bypass the cache in tribe_get_events()

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Bypass caching of the event when dealing with the admin event list table. [BTRIA-1072]
+
 = [5.11.0] 2021-11-17 =
 
 * Feature - Add an `Events List` block that is based on the `Events List` widget to the block editor which users can drag around to any position they want it to appear. [ECP-989]

--- a/readme.txt
+++ b/readme.txt
@@ -223,7 +223,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Bypass caching of the event when dealing with the admin event list table. [BTRIA-1072]
+* Fix - Bypass caching of the event when dealing with the admin event list table. [TEC-4156]
 
 = [5.11.0] 2021-11-17 =
 

--- a/src/Tribe/Event_Status/Template_Modifications.php
+++ b/src/Tribe/Event_Status/Template_Modifications.php
@@ -70,7 +70,11 @@ class Template_Modifications {
 			return $classes;
 		}
 
-		$event = tribe_get_event( $event );
+		/**
+		 * We're specifically forcing here (last param) as otherwise
+		 * this runs into issues with the event list table in the admin.
+		 */
+		$event = tribe_get_event( $event, OBJECT, 'raw', true );
 
 		if ( $event->event_status ) {
 			$classes[] = 'tribe-events-status__list-event-' . sanitize_html_class( $event->event_status );


### PR DESCRIPTION
...to avoid issues with duplicated titles in the admin list table.

In the list table, the title is acquired via  [_draft_or_post_title() ](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/class-wp-posts-list-table.php#L1089) which does not carry the post ID.

Since the ID is not passed, it defaults to 0 and I think our caching is running afoul of this somewhere along the path. (or the key fields need to be corrected?)

📷 Bad: https://d.pr/i/KmobuT
📸 Good: https://d.pr/i/thGNlK

[TEC-4156]

[TEC-4156]: https://theeventscalendar.atlassian.net/browse/TEC-4156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ