### PR TITLE
Subscribe to Calendar - URL, text, and placement fixes

### DIFF
--- a/src/Tribe/Editor/Blocks/Event_Links.php
+++ b/src/Tribe/Editor/Blocks/Event_Links.php
@@ -22,8 +22,8 @@ extends Tribe__Editor__Blocks__Abstract {
 	 */
 	public function default_attributes() {
 		return [
-			'googleCalendarLabel' => esc_html__( 'Google Calendar', 'the-events-calendar' ),
-			'iCalLabel'           => esc_html__( 'iCal Export', 'the-events-calendar' ),
+			'googleCalendarLabel' => esc_html__( 'Add to Google Calendar', 'the-events-calendar' ),
+			'iCalLabel'           => esc_html__( 'Add to iCalendar', 'the-events-calendar' ),
 			'hasiCal'             => true,
 			'hasGoogleCalendar'   => true,
 		];

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -81,8 +81,8 @@ abstract class Link_Abstract implements Link_Interface {
 		$class = sanitize_html_class( 'tribe-events-' . static::get_slug() );
 		$links[] = '<a class="tribe-events-button ' . $class
 				. '" href="' . esc_url( $this->get_uri( $view ) )
-				. '" title="' . esc_attr( static::get_single_label( $view ) )
-				. '">+ ' . esc_html( static::get_single_label( $view ) ) . '</a>';
+				. '" title="' . esc_attr( $this->get_single_label( $view ) )
+				. '">+ ' . esc_html( $this->get_single_label( $view ) ) . '</a>';
 
 		return $links;
 	}
@@ -143,16 +143,16 @@ abstract class Link_Abstract implements Link_Interface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_uri( View $view ) {
+	public function get_uri( $view ) {
 		// If we're on a Single Event view, let's bypass the canonical function call and logic.
-		$feed_url = $view->get_context()->get( 'single_ical_link', false );
+		$feed_url = empty( $view ) ? tribe_get_single_ical_link() : $view->get_context()->get( 'single_ical_link', false );
 
-		if ( empty( $feed_url )  ) {
+		if ( empty( $feed_url ) && ! empty( $view ) ) {
 			$feed_url = $this->get_canonical_ics_feed_url( $view );
 		}
 
 		$feed_url = str_replace( [ 'http://', 'https://' ], 'webcal://', $feed_url );
-
+		bdump($feed_url);
 		return $feed_url;
 	}
 

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -152,7 +152,7 @@ abstract class Link_Abstract implements Link_Interface {
 		}
 
 		$feed_url = str_replace( [ 'http://', 'https://' ], 'webcal://', $feed_url );
-		bdump($feed_url);
+
 		return $feed_url;
 	}
 

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Interface.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Interface.php
@@ -22,12 +22,12 @@ interface Link_Interface {
 	 *
 	 * @since TBD
 	 *
-	 * @param array                       $template_vars The template variables.
-	 * @param \Tribe\Events\Views\V2\View $view          The current View object.
+	 * @param array                       $subscribe_links The list of subscribe links.
+	 * @param \Tribe\Events\Views\V2\View $view            The current View object.
 	 *
-	 * @return array $template_vars The modified vars.
+	 * @return array $subscribe_links The modified list of links.
 	 */
-	public function filter_tec_views_v2_subscribe_links( $template_vars, $view );
+	public function filter_tec_views_v2_subscribe_links( $subscribe_links, $view );
 
 	/**
 	 * Adds a link to those displayed on the single event view.
@@ -92,5 +92,5 @@ interface Link_Interface {
 	 *
 	 * @return string The url for the link calendar subscription "feed", or download.
 	 */
-	public function get_uri( View $view );
+	public function get_uri( $view );
 }

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -80,9 +80,16 @@ class iCalendar_Handler extends \tad_DI52_ServiceProvider {
 		tribe( iCal::class )->register();
 		tribe( iCalendar_Export::class )->register();
 
-		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'template_vars' ], 10, 2 );
+		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'filter_template_vars' ], 10, 2 );
 		add_filter( 'tribe_events_ical_single_event_links', [ $this, 'single_event_links' ], 20 );
 		add_filter( 'tribe_ical_properties', [ $this, 'ical_properties' ] );
+		add_filter( 'tribe_template_context:events/blocks/event-links', [ $this, 'filter_template_context' ], 10, 4 );
+	}
+
+	public function filter_template_context( $context, $file, $name, $template ) {
+		$context['subscribe_links'] = $this->get_subscribe_links();
+
+		return $context;
 	}
 
 	/**
@@ -99,8 +106,24 @@ class iCalendar_Handler extends \tad_DI52_ServiceProvider {
 	 *
 	 * @return array The filtered template variables.
 	 */
-	public function template_vars( $template_vars, View $view ) {
+	public function filter_template_vars( $template_vars, View $view ) {
 		// Set up the section of the $template vars for the links.
+		$subscribe_links                  = $this->get_subscribe_links( $view );
+		$template_vars['subscribe_links'] = $subscribe_links;
+
+		return $template_vars;
+	}
+
+	/**
+	 * Builds the subscribe links in a separate process.
+	 *
+	 * @since TBD
+	 *
+	 * @param Tribe\Events\Views\V2\View $view
+	 * @return void
+	 */
+	public function get_subscribe_links( $view = null ) {
+		// Set up the list of links.
 		$subscribe_links = [];
 
 		/**
@@ -112,10 +135,9 @@ class iCalendar_Handler extends \tad_DI52_ServiceProvider {
 		 * @param \Tribe\Events\Views\V2\View $view The View implementation.
 		 * @param array<string,mixed>         $template_vars The View template variables (for use in internal logic).
 		 */
-		$subscribe_links = apply_filters( 'tec_views_v2_subscribe_links', $subscribe_links, $view, $template_vars );
-		$template_vars['subscribe_links'] = $subscribe_links;
+		$subscribe_links = apply_filters( 'tec_views_v2_subscribe_links', $subscribe_links, $view );
 
-		return $template_vars;
+		return $subscribe_links;
 	}
 
 	/**

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -130,7 +130,7 @@ class Tribe__Events__iCal {
 		}
 		$calendar_links = '<div class="tribe-events-cal-links">';
 		$calendar_links .= '<a class="tribe-events-gcal tribe-events-button" href="' . Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() ) . '" target="_blank" rel="noopener noreferrer" title="' . esc_attr__( 'Add to Google Calendar', 'the-events-calendar' ) . '">+ ' . esc_html__( 'Google Calendar', 'the-events-calendar' ) . '</a>';
-		$calendar_links .= '<a class="tribe-events-ical tribe-events-button" href="' . esc_url( tribe_get_single_ical_link() ) . '" title="' . esc_attr__( 'Download .ics file', 'the-events-calendar' ) . '" >+ ' . esc_html__( 'iCal Export', 'the-events-calendar' ) . '</a>';
+		$calendar_links .= '<a class="tribe-events-ical tribe-events-button" href="' . esc_url( tribe_get_single_ical_link() ) . '" title="' . esc_attr__( 'Download .ics file', 'the-events-calendar' ) . '" >+ ' . esc_html__( 'Add to iCalendar', 'the-events-calendar' ) . '</a>';
 		$calendar_links .= '</div><!-- .tribe-events-cal-links -->';
 
 		/**

--- a/src/modules/blocks/event-links/index.js
+++ b/src/modules/blocks/event-links/index.js
@@ -35,11 +35,11 @@ export default {
 	attributes: {
 		googleCalendarLabel: {
 			type: 'html',
-			default: __( 'Google Calendar', 'the-events-calendar' ),
+			default: __( 'Add to Google Calendar', 'the-events-calendar' ),
 		},
 		iCalLabel: {
 			type: 'html',
-			default: __( 'iCal Export', 'the-events-calendar' ),
+			default: __( 'Add to iCalendar', 'the-events-calendar' ),
 		},
 		hasiCal: {
 			type: 'html',
@@ -56,4 +56,3 @@ export default {
 		return null;
 	},
 };
-

--- a/src/modules/blocks/event-links/template.js
+++ b/src/modules/blocks/event-links/template.js
@@ -107,7 +107,7 @@ const renderControls = ( {
 						onChange={ toggleGoogleCalendar }
 					/>
 					<ToggleControl
-						label={ __( 'iCal', 'the-events-calendar' ) }
+						label={ __( 'iCalendar', 'the-events-calendar' ) }
 						checked={ hasiCal }
 						onChange={ toggleIcalLabel }
 					/>

--- a/src/modules/blocks/event-links/template.js
+++ b/src/modules/blocks/event-links/template.js
@@ -23,8 +23,8 @@ const { InspectorControls } = wpEditor;
  * Module Code
  */
 
-const googleCalendarPlaceholder = __( 'Google Calendar', 'the-events-calendar' );
-const iCalExportPlaceholder = __( 'iCal Export', 'the-events-calendar' );
+const googleCalendarPlaceholder = __( 'Add to Google Calendar', 'the-events-calendar' );
+const iCalExportPlaceholder = __( 'Add to iCalendar', 'the-events-calendar' );
 
 const renderPlaceholder = ( label ) => (
 	<button className="tribe-editor__btn--link tribe-editor__btn--placeholder" disabled>

--- a/src/resources/postcss/components/skeleton/_ical-link.pcss
+++ b/src/resources/postcss/components/skeleton/_ical-link.pcss
@@ -32,15 +32,22 @@
 	 * iCal Subscribe Dropdown
 	 *
 	 * ----------------------------------------------------------------------------- */
+
 	.tribe-events-c-subscribe-dropdown {
 		display: flex;
 		flex-flow: column;
 		font-size: var(--tec-font-size-2);
 		justify-content: flex-end;
 		margin: var(--tec-spacer-7) 0;
+		width: auto;
 
-		@media (--viewport-medium) {
-			float: right;
+		.tribe-common--breakpoint-medium& {
+			margin-left: auto;
+		}
+
+		/* Fix for a FBAR style bug */
+		.tribe-events--filter-bar-vertical.tribe-common--breakpoint-medium& {
+			width: auto;
 		}
 
 		.tribe-events-c-subscribe-dropdown__button {

--- a/src/resources/postcss/components/skeleton/_ical-link.pcss
+++ b/src/resources/postcss/components/skeleton/_ical-link.pcss
@@ -42,6 +42,7 @@
 		width: auto;
 
 		.tribe-common--breakpoint-medium& {
+			float: right;
 			margin-left: auto;
 		}
 

--- a/src/views/blocks/event-links.php
+++ b/src/views/blocks/event-links.php
@@ -23,6 +23,11 @@ $has_ical       = $this->attr( 'hasiCal' );
 
 $should_render = $has_google_cal || $has_ical;
 
+if ( $has_google_cal ) {
+	$subscribe_links = empty( $this->context['subscribe_links'] ) ? false : $this->context['subscribe_links'];
+	$google_cal_link = $subscribe_links ? $subscribe_links[ 'gcal' ]->get_uri( null ) : Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
+}
+
 remove_filter( 'the_content', 'do_blocks', 9 );
 
 if ( $should_render ) :
@@ -31,9 +36,9 @@ if ( $should_render ) :
 		<?php if ( $has_google_cal ) : ?>
 			<div class="tribe-block__btn--link tribe-block__events-gcal">
 				<a
-					href="<?php echo Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() ); ?>"
+					href="<?php echo esc_url( $google_cal_link ); ?>"
 					target="_blank"
-					rel="noopener noreferrer"
+					rel="noopener noreferrer nofollow"
 					title="<?php esc_attr_e( 'Add to Google Calendar', 'the-events-calendar' ); ?>"
 				>
 					<img src="<?php echo Tribe__Main::instance()->plugin_url  . 'src/modules/icons/link.svg'; ?>" />
@@ -45,6 +50,7 @@ if ( $should_render ) :
 			<div class="tribe-block__btn--link tribe-block__-events-ical">
 				<a
 					href="<?php echo esc_url( tribe_get_single_ical_link() ); ?>"
+					rel="noopener noreferrer nofollow"
 					title="<?php esc_attr_e( 'Download .ics file', 'the-events-calendar' ); ?>"
 				>
 					<img src="<?php echo Tribe__Main::instance()->plugin_url  . 'src/modules/icons/link.svg'; ?>" />

--- a/src/views/blocks/event-links.php
+++ b/src/views/blocks/event-links.php
@@ -23,9 +23,16 @@ $has_ical       = $this->attr( 'hasiCal' );
 
 $should_render = $has_google_cal || $has_ical;
 
-if ( $has_google_cal ) {
+if ( $should_render ) {
 	$subscribe_links = empty( $this->context['subscribe_links'] ) ? false : $this->context['subscribe_links'];
+}
+
+if ( $has_google_cal ) {
 	$google_cal_link = $subscribe_links ? $subscribe_links[ 'gcal' ]->get_uri( null ) : Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
+}
+
+if ( $has_ical ) {
+	$ical_link = $subscribe_links ? $subscribe_links[ 'ical' ]->get_uri( null ) : tribe_get_single_ical_link();
 }
 
 remove_filter( 'the_content', 'do_blocks', 9 );
@@ -49,9 +56,9 @@ if ( $should_render ) :
 		<?php if ( $has_ical ) : ?>
 			<div class="tribe-block__btn--link tribe-block__-events-ical">
 				<a
-					href="<?php echo esc_url( tribe_get_single_ical_link() ); ?>"
+					href="<?php echo esc_url( $ical_link ); ?>"
 					rel="noopener noreferrer nofollow"
-					title="<?php esc_attr_e( 'Download .ics file', 'the-events-calendar' ); ?>"
+					title="<?php esc_attr_e( 'Add to iCalendar', 'the-events-calendar' ); ?>"
 				>
 					<img src="<?php echo Tribe__Main::instance()->plugin_url  . 'src/modules/icons/link.svg'; ?>" />
 					<?php echo esc_html( $this->attr( 'iCalLabel' ) ) ?>


### PR DESCRIPTION
1. Style bug with vertical FBAR
2. Event-Single share block now uses correct url for gCal.
3. Changed text and link for iCal in share block - no download, subscribe.

[TEC-4131]
1
📷 (bad): https://d.pr/i/PQpfWw
📸 (good): https://d.pr/i/gMzXbY

2
📸 (good): https://d.pr/i/tLorIs

3
📸 (good): https://d.pr/i/KvpUEg

[TEC-4131]: https://theeventscalendar.atlassian.net/browse/TEC-4131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ