### PR TITLE
Enforce the second argument of date to be an int for custom date function | TEC-4161

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Add a valid rel value to the link tag for TEC REST API support in order to improve HTML 5 and WCAG 2.1 compliance. [TEC-4129]
 * Fix - Ensure the date selected when creating a new event from the Event Manager is applied to the block editor. [ECP-954]
 * Fix - Properly observe the disabling of JSON-LD output on widget blocks in the block editor. [TEC-4077]
+* Fix - Prevent PHP warning in some cases when fetching the date from `tribe_get_display_end_date()`. (props to @huubl for the fix!) [TEC-4161]
 * Tweak - Ensure the `Disable the Event Search Bar` setting doesn't get applied on the Event Manager page. [ECP-948]
 * Tweak - Ensure the `related events title` and `event titles` within the single event page for the block editor make use the customizer font settings. [TEC-4125]
 

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'tribe_get_display_end_date' ) ) {
 	 */
 	function tribe_get_display_end_date( $event = null, $display_time = true, $date_format = '', $timezone = null ) {
 		$timestamp = tribe_get_end_date( $event, true, 'U', $timezone );
-		$beginning_of_day = tribe_beginning_of_day( date( Tribe__Date_Utils::DBDATETIMEFORMAT, $timestamp ) );
+		$beginning_of_day = tribe_beginning_of_day( date( Tribe__Date_Utils::DBDATETIMEFORMAT, (int) $timestamp ) );
 
 		if ( tribe_event_is_multiday( $event ) && $timestamp < strtotime( $beginning_of_day ) ) {
 			$timestamp -= DAY_IN_SECONDS;


### PR DESCRIPTION
This is a handy change from @huubl (original PR: #3668) to prevent improper values of the second argument of the `date()` function.

:ticket: [TEC-4161]
📷 
![Screenshot 2021-12-03 111040](https://user-images.githubusercontent.com/430385/144635216-fdb172cb-5a07-4009-824f-702675aad4bc.png)

☝️ This artifact is just to show that the end date of a multi-day event continues to render as expected!

[TEC-4161]: https://theeventscalendar.atlassian.net/browse/TEC-4161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ