### PR TITLE
fix syntax errors leading to invalid html being rendered

### DIFF
--- a/src/views/v2/components/subscribe-links/item.php
+++ b/src/views/v2/components/subscribe-links/item.php
@@ -27,7 +27,7 @@ if( ! $item->is_visible( $view ) ) {
 }
 ?>
 
-<li class="tribe-events-c-subscribe-dropdown__list-item"">
+<li class="tribe-events-c-subscribe-dropdown__list-item">
 	<a
 		href="<?php echo esc_url( $item->get_uri( $view ) ); ?>"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/src/views/v2/components/subscribe-links/list.php
+++ b/src/views/v2/components/subscribe-links/list.php
@@ -26,6 +26,7 @@ if ( empty( $items ) ) {
 		<?php $this->template( 'components/icons/caret-down', [ 'classes' => [ 'tribe-events-c-subscribe-dropdown__button-icon' ] ] ); ?>
 	</div>
 	<div class="tribe-events-c-subscribe-dropdown__content">
+	</div>
 	<ul class="tribe-events-c-subscribe-dropdown__list" tabindex="0">
 		<?php foreach ( $items as $item ) : ?>
 			<?php $this->template( 'components/subscribe-links/item', [ 'item' => $item ] ); ?>


### PR DESCRIPTION
I found my events page with a broken layout where a floating div didn't behave like expected. 
After some debugging I found that there was a div opened but never closed. Leading an invalid html being rendered.
That's what I'd like to fix with this PR. Also there was a little extra double-quote.