### PR TITLE
Adds a filter to allow folks to "turn on (or off)" the taxonomy breadcrumbs for the page title.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,10 +224,10 @@ Remember to always make a backup of your database and files before updating!
 = [5.12.3] TBD =
 
 * Fix - Ensure the modifications made through the `tribe_events_views_v2_category_title` are respected. [TEC-4110]
-* Fix - Correct issue where mobile default view does not load correctly when homepage set to Events Main. [TEC-3862]
+* Fix - Correct issue where mobile default view does not load correctly when homepage set to Events Main. [TEC-3826]
 * Tweak - Boost SEO for category archive pages by fixing the title tag. [TEC-4110]
 * Tweak - Add filter to allow users to choose if the taxonomy should show parent categories [TEC-4110]
-* Tweak - Move handling of mobile view to ECP. [TEC-3862]
+* Tweak - Move handling of mobile view to ECP. Add filter to allow overriding default view. [TEC-3826]
 
 = [5.12.2] 2021-12-20 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Ensure the modifications made through the `tribe_events_views_v2_category_title` are respected. [TEC-4110]
 * Fix - Correct issue where mobile default view does not load correctly when homepage set to Events Main. [TEC-3862]
 * Tweak - Boost SEO for category archive pages by fixing the title tag. [TEC-4110]
+* Tweak - Add filter to allow users to choose if the taxonomy should show parent categories [TEC-4110]
 * Tweak - Move handling of mobile view to ECP. [TEC-3862]
 
 = [5.12.2] 2021-12-20 =

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -232,7 +232,7 @@ class Title {
 		$sep       = apply_filters( 'document_title_separator', '-' );
 		$the_title = $title['title'];
 
-		$new_title = $this->build_title( $title['title'], false );
+		$new_title = $this->build_title( $title['title'] );
 
 		/**
 		 * Filters the page title built for event single or archive pages.
@@ -374,6 +374,18 @@ class Title {
 	protected function build_category_title( $title, $cat, $depth = true, $separator = ' &#8250; ' ) {
 		$separator = is_null( $separator ) ? ' &#8250; ' : $separator;
 
+		/**
+		 * Allow folks to hook in and alter the option to show parent taxonomies in the title.
+		 *
+		 * @since TBD
+		 *
+	 	 * @param boolean     $depth Whether to display the taxonomy hierarchy as part of the title.
+		 * @param string      $title The input title.
+		 * @param  \WP_Term   $cat   The category term to use to build the title.
+		 */
+		$depth = apply_filters( 'tec_display_tax_hierarchy_in_title', $depth, $title, $cat );
+
+		// This list includes the child taxonomy!
 		if ( $depth ) {
 			$term_parents = get_term_parents_list(
 				$cat->term_id,
@@ -386,10 +398,10 @@ class Title {
 		}
 
 		if ( empty( $term_parents ) || is_wp_error( $term_parents ) ) {
-			$term_parents = '';
+			$term_parents = $cat->name;
 		}
 
-		$new_title =  $title . $separator . $term_parents . $cat->name;
+		$new_title =  $title . $separator . $term_parents;
 
 		/**
 		 * Filters the Event Category Archive title.

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -383,7 +383,7 @@ class Title {
 		 * @param string      $title The input title.
 		 * @param  \WP_Term   $cat   The category term to use to build the title.
 		 */
-		$depth = apply_filters( 'tec_display_tax_hierarchy_in_title', $depth, $title, $cat );
+		$depth = apply_filters( 'tec_events_views_v2_display_tax_hierarchy_in_title', $depth, $title, $cat );
 
 		// This list includes the child taxonomy!
 		if ( $depth ) {

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/__snapshots__/TitleTest__test_w_category__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/__snapshots__/TitleTest__test_w_category__1.php
@@ -1,1 +1,1 @@
-<?php return 'Upcoming Events &#8250; test &#8250; test';
+<?php return 'Upcoming Events &#8250; test &#8250; ';

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/__snapshots__/TitleTest__test_w_category_and_featured__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/__snapshots__/TitleTest__test_w_category_and_featured__1.php
@@ -1,1 +1,1 @@
-<?php return 'Upcoming Featured Events &#8250; test &#8250; test';
+<?php return 'Upcoming Featured Events &#8250; test &#8250; ';


### PR DESCRIPTION
NOT the on-page title, the "meta" title.

Needed because everywhere we call this function we're been passing false - which turns it off.

Note this also removes the default "false" where we call the function.

[TEC-4110]

:camera: https://d.pr/i/qJMlUN

[TEC-4110]: https://theeventscalendar.atlassian.net/browse/TEC-4110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ