### PR TITLE
Shortcode based blocks DQA Feedback. [ECP-1022]

### DIFF
--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -668,7 +668,6 @@ class Tribe__Events__Editor extends Tribe__Editor {
 				[
 					'slug'  => 'tribe-events',
 					'title' => __( 'Event Blocks', 'the-events-calendar' ),
-					'icon'  => 'tec-horns',
 				],
 			]
 		);
@@ -702,7 +701,6 @@ class Tribe__Events__Editor extends Tribe__Editor {
 				[
 					'slug'  => 'tribe-events',
 					'title' => __( 'Event Blocks', 'the-events-calendar' ),
-					'icon'  => 'tec-horns',
 				],
 			]
 		);

--- a/src/modules/icons/events-list.svg
+++ b/src/modules/icons/events-list.svg
@@ -1,5 +1,5 @@
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.629639" y="0.46405" width="24" height="24" rx="2" fill="#499FD1"/>
+<rect x="0.629639" y="0.46405" width="24" height="24" rx="2" fill="#000000"/>
 <line x1="9.90588" y1="7.19293" x2="19.5663" y2="7.19293" stroke="white" stroke-width="2" stroke-linecap="round"/>
 <line x1="5.23474" y1="7.19293" x2="5.86738" y2="7.19293" stroke="white" stroke-width="2" stroke-linecap="round"/>
 <line x1="9.90588" y1="12.2855" x2="19.5663" y2="12.2855" stroke="white" stroke-width="2" stroke-linecap="round"/>

--- a/src/modules/icons/events-list.svg
+++ b/src/modules/icons/events-list.svg
@@ -1,5 +1,5 @@
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.629639" y="0.46405" width="24" height="24" rx="2" fill="#000000"/>
+<rect x="0.629639" y="0.46405" width="24" height="24" rx="2" fill="#499FD1"/>
 <line x1="9.90588" y1="7.19293" x2="19.5663" y2="7.19293" stroke="white" stroke-width="2" stroke-linecap="round"/>
 <line x1="5.23474" y1="7.19293" x2="5.86738" y2="7.19293" stroke="white" stroke-width="2" stroke-linecap="round"/>
 <line x1="9.90588" y1="12.2855" x2="19.5663" y2="12.2855" stroke="white" stroke-width="2" stroke-linecap="round"/>

--- a/src/modules/widgets/style.pcss
+++ b/src/modules/widgets/style.pcss
@@ -55,3 +55,7 @@
 [aria-label="Legacy Widget"].components-button.block-editor-block-switcher__no-switcher-icon {
 	display: none;
 }
+
+[aria-label="Select Events List"] .block-editor-block-icon svg rect {
+	fill: #0F1031;
+}

--- a/src/modules/widgets/style.pcss
+++ b/src/modules/widgets/style.pcss
@@ -6,6 +6,8 @@
 
 .block-editor-block-list__block {
 	.wp-block-legacy-widget__edit-form {
+		padding: 10px 20px;
+
 		.wp-block-legacy-widget__edit-form-title {
 			font-size: 24px;
 			line-height: 1;


### PR DESCRIPTION
Addresses some styling recommendations made by Rachel as part of the DQA for the `Events Featured Venue` and `Events Countdown blocks`. 

Please note that the change log was added to the bucket in this earlier [PR](https://github.com/the-events-calendar/events-pro/pull/1863).

Ticket: https://theeventscalendar.atlassian.net/browse/ECP-1022
Artifact : https://www.loom.com/share/d6cf451067c349f4a2717bf068e230d7