### PR TITLE
Remove CSS attributes targeting `aria-labels` [TEC-4227]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,7 @@ Remember to always make a backup of your database and files before updating!
 = [5.12.4] 2022-01-17 =
 
 * Tweak - Minor CSS tweaks to align with the new shortcode based blocks in ECP. [ECP-1016]
+* Fix - Remove CSS attributes targeting `aria-labels` to prevent inconsistent styling for different languages. [TEC-4227]
 
 = [5.12.3] 2022-01-10 =
 

--- a/src/modules/widgets/style.pcss
+++ b/src/modules/widgets/style.pcss
@@ -51,11 +51,3 @@
 		}
 	}
 }
-
-[aria-label="Legacy Widget"].components-button.block-editor-block-switcher__no-switcher-icon {
-	display: none;
-}
-
-[aria-label="Select Events List"] .block-editor-block-icon svg rect {
-	fill: #0F1031;
-}


### PR DESCRIPTION
Remove CSS attributes targeting `aria-labels` to prevent inconsistent styling for different languages.

Ticket : https://theeventscalendar.atlassian.net/browse/TEC-4227
Artifact : https://www.loom.com/share/03ddc5e6514b4bd6857db3289b5c9fff