### PR TITLE
Resolve sorting problem in Event repository

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -11,7 +11,7 @@ jobs:
           - event_status
           - integration
           - muintegration
-          #- restv1
+          - restv1
           - views_integration
           - views_rest
           - views_settings

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -11,7 +11,7 @@ jobs:
           - event_status
           - integration
           - muintegration
-          - restv1
+          #- restv1
           - views_integration
           - views_rest
           - views_settings

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Included a Views V2 Status on the Troubleshooting page system info section to help with clarity for support.
 * Fix - Prevent Onboarding assets from loading on the admin when not needed.
 * Fix - Remove CSS attributes targeting `aria-labels` to prevent inconsistent styling for different languages. [TEC-4227]
+* Fix - Resolve sorting problems when using orderby with the Event repository when no other orderby values are specified. [TEC-4232]
 
 = [5.12.3] 2022-01-10 =
 

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1547,7 +1547,9 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 						$normalized = [];
 
 						if ( ! is_array( $this->query_args['orderby'] ) ) {
-							$this->query_args['orderby'] = [ $order_by ];
+							$this->query_args['orderby'] = [
+								$this->query_args['orderby'] => $this->query_args['order']
+							];
 						}
 
 						foreach ( $this->query_args['orderby'] as $k => $v ) {

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1545,6 +1545,11 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 						$add = [ $order_by => $order ];
 						// Make sure all `orderby` clauses have the shape `<orderby> => <order>`.
 						$normalized = [];
+
+						if ( ! is_array( $this->query_args['orderby'] ) ) {
+							$this->query_args['orderby'] = [ $order_by ];
+						}
+
 						foreach ( $this->query_args['orderby'] as $k => $v ) {
 							$the_order_by                = is_numeric( $k ) ? $v : $k;
 							$the_order                   = is_numeric( $k ) ? $default_order : $v;

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -1538,7 +1538,9 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 				default:
 					$after = $after || 1 === $loop;
 					if ( empty( $this->query_args['orderby'] ) ) {
-						$this->query_args['orderby'] = [ $order_by => $order ];
+						// In some versions of WP, [ $order_by, $order ] doesn't work as expected. Using explict value setting instead.
+						$this->query_args['orderby'] = $order_by;
+						$this->query_args['order']   = $order;
 					} else {
 						$add = [ $order_by => $order ];
 						// Make sure all `orderby` clauses have the shape `<orderby> => <order>`.


### PR DESCRIPTION
This fixes an issue where the failover orderby logic within the Event Repository was failing to successfully apply when `$this->query_args['orderby']` was null and we were attempting to set the value to `[ $order_by => $order ]`. Setting to explicit `orderby` and `order` values consistently functions.

This fix is already in place on Loxi production.

:ticket: [TEC-4232]
:movie_camera: https://d.pr/v/SYKtFR

[TEC-4232]: https://theeventscalendar.atlassian.net/browse/TEC-4232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ