### PR TITLE
Remove deprecated `wp.editor.InnerBlocks` component in favor of `wp.blockEditor.InnerBlocks` [TEC-4178]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Remove the `wp.editor.InnerBlocks` gutenberg component in favor of `wp.blockEditor.InnerBlocks` which was deprecated since version 5.3. [TEC-4178]
+
 = [5.12.4] 2022-01-17 =
 
 * Tweak - Minor CSS tweaks to align with the new shortcode based blocks in ECP. [ECP-1016]

--- a/src/modules/widgets/events-list/index.js
+++ b/src/modules/widgets/events-list/index.js
@@ -10,7 +10,7 @@ import EventsList from './template';
 import { EventsList as EventsListIcon } from '@moderntribe/events/icons';
 
 const { __ } = wp.i18n;
-const { InnerBlocks } = wp.editor;
+const { InnerBlocks } = wp.blockEditor;
 
 /**
  * Module Code

--- a/src/modules/widgets/events-list/template.js
+++ b/src/modules/widgets/events-list/template.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-const { InnerBlocks } = wp.editor;
+const { InnerBlocks } = wp.blockEditor;
 
 const EVENTS_LIST_TEMPLATE = [
 	[


### PR DESCRIPTION
Remove the `wp.editor.InnerBlocks` gutenberg component in favor of `wp.blockEditor.InnerBlocks` which was deprecated since version 5.3. 
Ticket : [[TEC-4178]](https://theeventscalendar.atlassian.net/browse/TEC-4178)

[TEC-4178]: https://theeventscalendar.atlassian.net/browse/TEC-4178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Artifact : 
![image](https://user-images.githubusercontent.com/22029087/149913144-e50298b0-567e-42b8-85b0-24f4662d3405.png)
https://www.loom.com/share/c380d889c527450eb005dab87ccd822b