### PR TITLE
Add a Legacy Views provider and force v2 to be active

### DIFF
--- a/src/Events/Custom_Tables/V1/Provider.php
+++ b/src/Events/Custom_Tables/V1/Provider.php
@@ -100,9 +100,7 @@ class Provider extends Service_Provider {
 			$this->container->register( WP_Query\Provider::class );
 			$this->container->register( Updates\Provider::class );
 
-			if ( tribe_events_views_v2_is_enabled() ) {
-				$this->container->register( Views\V2\Provider::class );
-			}
+			$this->container->register( Views\V2\Provider::class );
 
 			/*
 			 * Integrations with 3rd party code are registered last to

--- a/src/Events/Legacy/Views/V1/Provider.php
+++ b/src/Events/Legacy/Views/V1/Provider.php
@@ -46,6 +46,7 @@ class Provider extends Service_Provider {
 			'tribe-events/month.php',
 			'tribe-events/pro/map/',
 			'tribe-events/pro/map.php',
+			'tribe-events/pro/map-basic.php',
 			'tribe-events/pro/photo/',
 			'tribe-events/pro/photo.php',
 			'tribe-events/pro/week/',

--- a/src/Events/Legacy/Views/V1/Provider.php
+++ b/src/Events/Legacy/Views/V1/Provider.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Manages the legacy view removal and messaging.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Legacy\Views\V1
+ */
+
+namespace TEC\Events\Legacy\Views\V1;
+
+use tad_DI52_ServiceProvider as Service_Provider;
+use Tribe__Utils__Array as Arr;
+
+/**
+ * Class Provider
+ *
+ * @since   TBD
+ * @package TEC\Events\Legacy\Views\V1
+ */
+class Provider extends Service_Provider {
+	/**
+	 * Registers the handlers and modifiers for notifying the site
+	 * that Legacy views are removed.
+	 *
+	 * @since TBD
+	 */
+	public function register() {
+		add_action( 'init', [ $this, 'check_theme_for_removed_paths' ] );
+	}
+
+	/**
+	 * Gets the files and paths that have been removed from the plugin.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string>
+	 */
+	public function get_removed_paths() {
+		$paths = [
+			'tribe-events/day/',
+			'tribe-events/day.php',
+			'tribe-events/list/',
+			'tribe-events/list.php',
+			'tribe-events/month/',
+			'tribe-events/month.php',
+			'tribe-events/pro/map/',
+			'tribe-events/pro/map.php',
+			'tribe-events/pro/photo/',
+			'tribe-events/pro/photo.php',
+			'tribe-events/pro/week/',
+			'tribe-events/pro/week.php',
+			'tribe-events/widgets/',
+		];
+
+		/**
+		 * Filters the paths that have been removed from the plugin.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string> $paths The paths that have been removed from the plugin.
+		 */
+		$paths = apply_filters( 'tec_events_legacy_views_v1_removed_paths', $paths );
+
+		return $paths;
+	}
+
+	/**
+	 * Gets the files and paths that have been removed from the plugin.
+	 *
+	 * @since TBD
+	 */
+	public function check_theme_for_removed_paths() {
+		$transient_key = 'tec_events_legacy_views_v1_removed_paths_checked';
+		$cached_data   = (array) get_transient( $transient_key );
+
+		$identical_abspath        = ABSPATH === Arr::get( $cached_data, 'ABSPATH', null );
+		$identical_stylesheetpath = STYLESHEETPATH === Arr::get( $cached_data, 'STYLESHEETPATH', null );
+		$identical_templatepath   = TEMPLATEPATH === Arr::get( $cached_data, 'TEMPLATEPATH', null );
+
+		// We don't need to check again if the transient exists and key paths are identical.
+		if (
+			$identical_abspath
+			&& $identical_stylesheetpath
+			&& $identical_templatepath
+		) {
+			return;
+		}
+
+		$data = [
+			'ABSPATH'        => ABSPATH,
+			'STYLESHEETPATH' => STYLESHEETPATH,
+			'TEMPLATEPATH'   => TEMPLATEPATH,
+			'paths'          => [],
+		];
+
+		$paths = $this->get_removed_paths();
+
+		foreach ( $paths as $path ) {
+			if ( $template_path = $this->check_theme_for_removed_path( $path ) ) {
+				$data['paths'][ $path ] = $template_path;
+			}
+		}
+
+		foreach ( $data['paths'] as $path => $template_path ) {
+			_deprecated_file( $path, '6.0.0', null, 'Please refer to <a href="https://evnt.is/v1-removal">https://evnt.is/v1-removal</a> for template customization assistance.' );
+		}
+
+		set_transient( 'tec_events_legacy_views_v1_removed_paths_checked', $data, DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Locate the template path for a given path.
+	 *
+	 * @since TBD
+	 *
+	 * @param $string $path
+	 * @return string|null
+	 */
+	public function check_theme_for_removed_path( $path ) {
+		return locate_template( $path );
+	}
+}

--- a/src/Events/Legacy/Views/V1/Provider.php
+++ b/src/Events/Legacy/Views/V1/Provider.php
@@ -16,6 +16,7 @@ use Tribe__Utils__Array as Arr;
  * Class Provider
  *
  * @since   TBD
+ 
  * @package TEC\Events\Legacy\Views\V1
  */
 class Provider extends Service_Provider {

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -644,6 +644,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			if ( class_exists( '\\TEC\\Events\\Custom_Tables\\V1\\Provider' ) ) {
 				tribe_register_provider( '\\TEC\\Events\\Custom_Tables\\V1\\Provider' );
 			}
+
+			tribe_register_provider( \TEC\Events\Legacy\Views\V1\Provider::class );
 		}
 
 		/**

--- a/src/functions/views/provider.php
+++ b/src/functions/views/provider.php
@@ -24,30 +24,25 @@ function tribe_register_view( $slug, $name, $class, $priority = 50, $route_slug 
  * the `TRIBE_EVENTS_V2_VIEWS` environment variable and, finally, the `Manager::$option_enabled` option.
  *
  * @since 4.9.2
+ * @since 6.0.0 Deprecate function.
  *
  * @return bool Whether v2 of the Views are enabled or not.
  */
 function tribe_events_views_v2_is_enabled() {
-	if ( defined( 'TRIBE_EVENTS_V2_VIEWS' ) ) {
-		return (bool) TRIBE_EVENTS_V2_VIEWS;
-	}
-
-	$env_var = getenv( 'TRIBE_EVENTS_V2_VIEWS' );
-	if ( false !== $env_var ) {
-		return (bool) $env_var;
-	}
-
-	$enabled = (bool) tribe_get_option( Manager::$option_enabled, false );
-
 	/**
 	 * Allows filtering of the Events Views V2 provider, doing so will render
 	 * the methods and classes no longer load-able so keep that in mind.
 	 *
-	 * @since  4.9.2
+	 * @since 4.9.2
+	 * @since 6.0.0 Deprecate filter.
 	 *
-	 * @param boolean $enabled Determining if V2 Views is enabled\
+	 * @deprecated 6.0.0
+	 *
+	 * @param boolean $enabled Determining if V2 Views is enabled
 	 */
-	return apply_filters( 'tribe_events_views_v2_is_enabled', $enabled );
+	apply_filters_deprecated( 'tribe_events_views_v2_is_enabled', [ true ], '6.0.0', 'No replacement. Legacy views have been removed.' );
+
+	return true;
 }
 
 /**
@@ -56,76 +51,40 @@ function tribe_events_views_v2_is_enabled() {
  * Current only being triggered on plugin activation hook.
  *
  * @since 4.9.13
+ * @since 6.0.0 Deprecate function.
+ *
+ * @deprecated 6.0.0
  *
  * @return bool Wether we just activated the v2 on the database.
  */
 function tribe_events_views_v2_smart_activation() {
-	/**
-	 * Allows filtering of the Events Views V2 smart activation..
-	 *
-	 * @since  4.9.13
-	 *
-	 * @param boolean $enabled Determining if V2 Views is enabled\
-	 */
-	$should_smart_activate = apply_filters( 'tribe_events_views_v2_should_smart_activate', true );
-
-	if ( ! $should_smart_activate ) {
-		return false;
-	}
-
-	if ( tribe_events_views_v2_is_enabled() ) {
-		return false;
-	}
-
-	if ( ! tribe_events_is_new_install() ) {
-		return false;
-	}
-
-	$current_status = tribe_get_option( Manager::$option_enabled, null );
-
-	// Only update when value is either null or empty string.
-	if ( null !== $current_status && '' !== $current_status ) {
-		return false;
-	}
-
-	$status = tribe_update_option( Manager::$option_enabled, true );
-
-	if ( $status ) {
-		// Update the default posts_per_page to 12
-		tribe_update_option( 'postsPerPage', 12 );
-
-		// Update default events per day on month view amount to 3
-		tribe_update_option( 'monthEventAmount', 3 );
-	}
-
-	return $status;
+	return false;
 }
 
 /**
  * Returns whether the Event Period repository should be used or not.
  *
  * @since 4.9.13
+ * @since 6.0.0 Deprecate function.
+ *
+ * @deprecated 6.0.0
  *
  * @return bool whether the Event Period repository should be used or not.
  */
 function tribe_events_view_v2_use_period_repository() {
-	$enabled = false;
-	if ( defined( 'TRIBE_EVENTS_V2_VIEWS_USE_PERIOD_REPOSITORY' ) ) {
-		$enabled = (bool) TRIBE_EVENTS_V2_VIEWS_USE_PERIOD_REPOSITORY;
-	}
-
-	$env_var = getenv( 'TRIBE_EVENTS_V2_VIEWS_USE_PERIOD_REPOSITORY' );
-	if ( false !== $env_var ) {
-		$enabled = (bool) $env_var;
-	}
 	/**
 	 * Filters whether to use the period repository or not.
 	 *
 	 * @since 4.9.13
+	 * @since 6.0.0 Deprecate filter.
+	 *
+	 * @deprecated 6.0.0
 	 *
 	 * @param boolean $enabled Whether the Event Period repository should be used or not.
 	 */
-	return (bool) apply_filters( 'tribe_events_views_v2_use_period_repository', $enabled );
+	apply_filters_deprecated( 'tribe_events_views_v2_use_period_repository', [ false ], '6.0.0', 'No replacement. Period repository never in use.' );
+
+	return false;
 }
 
 /**
@@ -138,34 +97,24 @@ function tribe_events_view_v2_use_period_repository() {
  * while the names of the constant/env_var are "...DISABLED".
  *
  * @since 5.3.0
+ * @since 6.0.0 Deprecate function.
  *
  * @return bool Whether Widgets v2 should load.
  */
 function tribe_events_widgets_v2_is_enabled() {
-	// Must have v2 views active.
-	if ( ! tribe_events_views_v2_is_enabled() ) {
-		return false;
-	}
-
-	// If the constant is defined, returns the opposite of the constant.
-	if ( defined( 'TRIBE_EVENTS_WIDGETS_V2_DISABLED' ) ) {
-		return (bool) ! TRIBE_EVENTS_WIDGETS_V2_DISABLED;
-	}
-
-	// Allow env_var to short-circuit for testing.
-	$env_var = (bool) getenv( 'TRIBE_EVENTS_WIDGETS_V2_DISABLED' );
-	if ( false !== $env_var ) {
-		return ! $env_var;
-	}
-
 	/**
 	 * Allows toggling of the v2 widget views via a filter. Defaults to true.
 	 *
 	 * @since 5.3.0
+	 * @since 6.0.0 Deprecate filter.
 	 *
-	 * @return boolean Do we enable the widget views?
+	 * @deprecated 6.0.0
+	 *
+	 * @param boolean $enabled Determining if V2 Views is enabled
 	 */
-	return apply_filters( 'tribe_events_widgets_v2_is_enabled', true );
+	apply_filters_deprecated( 'tribe_events_widgets_v2_is_enabled', [ true ], '6.0.0', 'No replacement. Legacy views have been removed.' );
+
+	return true;
 }
 
 /**
@@ -178,32 +127,22 @@ function tribe_events_widgets_v2_is_enabled() {
  * while the names of the constant/env_var are "...DISABLED".
  *
  * @since 5.5.0
+ * @since 6.0.0 Deprecate function.
  *
  * @return bool Whether Single Event v2 styles overrides should load.
  */
 function tribe_events_single_view_v2_is_enabled() {
-	// Must have v2 views active.
-	if ( ! tribe_events_views_v2_is_enabled() ) {
-		return false;
-	}
-
-	// If the constant is defined, returns the opposite of the constant.
-	if ( defined( 'TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED' ) ) {
-		return (bool) ! TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED;
-	}
-
-	// Allow env_var to short-circuit for testing.
-	$env_var = (bool) getenv( 'TRIBE_EVENTS_SINGLE_VIEW_V2_DISABLED' );
-	if ( false !== $env_var ) {
-		return ! $env_var;
-	}
-
 	/**
 	 * Allows toggling of the single event v2 overrides via a filter. Defaults to true.
 	 *
 	 * @since 5.5.0
+	 * @since 6.0.0 Deprecate filter.
+	 *
+	 * @deprecated 6.0.0
 	 *
 	 * @return boolean Do we enable the single event styles overrides?
 	 */
-	return apply_filters( 'tribe_events_single_view_v2_is_enabled', true );
+	apply_filters_deprecated( 'tribe_events_single_view_v2_is_enabled', [ true ], '6.0.0', 'No replacement. Legacy views have been removed.' );
+
+	return true;
 }


### PR DESCRIPTION
The core bits of this PR are:
* Forcing views, widgets, and single to be v2 versions.
* This adds some cached notification of v1 files existing within themes.

That's pretty much it, other than removing a superfluous check on v2 being enabled in the Custom_Tables provider.