### PR TITLE
Include a declarative Width to the views container

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,15 +221,15 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [TBD] =
+= [5.14.0] =
 
+* Feature - Add a Filter Bar upsell banner to the Filters tab that displays when the Filter Bar plugin isn't active. [TEC-4238]
 * Tweak - Correct documentation around the subscribe link filters. Add link slug as array keys for `tec_views_v2_single_subscribe_links` filter. [TEC-4215]
 * Tweak - Move and deprecate some methods specific to the Google Calendar link from Main to the new Google_Calendar class. [TEC-4235]
 * Fix - Ensure that the tec_views_v2_use_subscribe_links filter applies to the single event view. [TEC-4219]
 * Fix - Hide the "Export to .ics file" link by default, allow showing it via a filter. Also ensure the link is correct. [TEC-4214]
 * Fix - Serve a single event import url for Google Calendar on the single event view. [TEC-4235]
-* Feature - Add a Filter Bar upsell banner to the Filters tab that displays when the Filter Bar plugin isn't active. [TEC-4238]
-
+* Fix - Improve theme CSS compatibility on View container by making sure our views take 100% of the width available (props @askwpgirl) [TEC-4257]
 
 = [5.13.0] 2022-01-31 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -246,7 +246,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Prevent Onboarding assets from loading on the admin when not needed.
 * Fix - Remove CSS attributes targeting `aria-labels` to prevent inconsistent styling for different languages. [TEC-4227]
 * Fix - Resolve sorting problems when using orderby with the Event repository when no other orderby values are specified. [TEC-4232]
-
+* Fix - Prevent unwanted notice on single-event and embed views from legacy views deprecation
 
 = [5.12.3] 2022-01-10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -221,7 +221,7 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [5.14.0] =
+= [5.14.0] TBD =
 
 * Feature - Add a Filter Bar upsell banner to the Filters tab that displays when the Filter Bar plugin isn't active. [TEC-4238]
 * Tweak - Correct documentation around the subscribe link filters. Add link slug as array keys for `tec_views_v2_single_subscribe_links` filter. [TEC-4215]

--- a/src/modules/blocks/event-venue/venue-details.js
+++ b/src/modules/blocks/event-venue/venue-details.js
@@ -96,8 +96,6 @@ export default class VenueDetails extends Component {
 	}
 
 	renderAddress() {
-		console.log('renderAddress');
-		console.log( this.props );
 		const { address = {} } = this.props;
 		if ( isEmpty( address ) ) {
 			return null;

--- a/src/resources/postcss/base/skeleton/_view.pcss
+++ b/src/resources/postcss/base/skeleton/_view.pcss
@@ -6,4 +6,5 @@
 
 .tribe-events-view {
 	position: relative;
+	width: 100%;
 }

--- a/src/resources/postcss/base/skeleton/_view.pcss
+++ b/src/resources/postcss/base/skeleton/_view.pcss
@@ -6,5 +6,4 @@
 
 .tribe-events-view {
 	position: relative;
-	width: 100%;
 }


### PR DESCRIPTION
Resolving problems with GeneratePress and Astra by adding a CSS width to the view container.

🎫 [TEC-4257](https://theeventscalendar.atlassian.net/browse/TEC-4257)


| Before | After |
| - | - |
| <img width="1296" alt="Screen Shot 2022-02-07 at 9 39 19 AM" src="https://user-images.githubusercontent.com/236579/152809062-15e338cf-3dd8-4b77-86a5-0c58ddcbe433.png"> | <img width="1234" alt="Screen Shot 2022-02-07 at 9 36 12 AM" src="https://user-images.githubusercontent.com/236579/152809237-07ebae74-797d-4775-ba0c-6c59558564db.png"> |

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/236579/152809345-6e2cd5ae-c09a-4ee6-a2a8-507c5af70fe9.png) | ![image](https://user-images.githubusercontent.com/236579/152809468-7f654f79-68c0-4fee-b720-4b3853a55b55.png) |
