### PR TITLE
Add some sanity checks around our use of subscribe_links in the block template.

### DIFF
--- a/src/views/blocks/event-links.php
+++ b/src/views/blocks/event-links.php
@@ -20,21 +20,23 @@ if ( post_password_required() ) {
 
 $has_google_cal = $this->attr( 'hasGoogleCalendar' );
 $has_ical       = $this->attr( 'hasiCal' );
-$should_render  = $has_google_cal || $has_ical;
+
+
+remove_filter( 'the_content', 'do_blocks', 9 );
+$subscribe_links = empty( $this->context['subscribe_links'] ) ? false : $this->context['subscribe_links'];
+
+$should_render  = $subscribe_links && ( $has_google_cal || $has_ical );
 
 if ( ! $should_render ) {
 	return;
 }
 
-remove_filter( 'the_content', 'do_blocks', 9 );
-$subscribe_links = empty( $this->context['subscribe_links'] ) ? false : $this->context['subscribe_links'];
-
 if ( $has_google_cal ) {
-	$google_cal_link = $subscribe_links ? $subscribe_links[ 'gcal' ]->get_uri( null ) : Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
+	$google_cal_link = ! empty( $subscribe_links[ 'gcal' ] ) ? $subscribe_links[ 'gcal' ]->get_uri( null ) : Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
 }
 
 if ( $has_ical ) {
-	$ical_link = $subscribe_links ? $subscribe_links[ 'ical' ]->get_uri( null ) : tribe_get_single_ical_link();
+	$ical_link = ! empty( $subscribe_links[ 'ical' ] ) ? $subscribe_links[ 'ical' ]->get_uri( null ) : tribe_get_single_ical_link();
 }
 
 ?>

--- a/src/views/blocks/event-links.php
+++ b/src/views/blocks/event-links.php
@@ -41,7 +41,7 @@ if ( $has_ical ) {
 
 ?>
 <div class="tribe-block tribe-block__events-link">
-	<?php if ( $has_google_cal ) : ?>
+	<?php if ( $has_google_cal && ! empty( $google_cal_link ) ) : ?>
 		<div class="tribe-block__btn--link tribe-block__events-gcal">
 			<a
 				href="<?php echo esc_url( $google_cal_link ); ?>"
@@ -54,7 +54,7 @@ if ( $has_ical ) {
 			</a>
 		</div>
 	<?php endif; ?>
-	<?php if ( $has_ical ) : ?>
+	<?php if ( $has_ical && ! empty( $ical_link ) ) : ?>
 		<div class="tribe-block__btn--link tribe-block__-events-ical">
 			<a
 				href="<?php echo esc_url( $ical_link ); ?>"

--- a/src/views/blocks/event-links.php
+++ b/src/views/blocks/event-links.php
@@ -13,6 +13,8 @@
  *
  */
 
+use Tribe\Events\Views\V2\iCalendar\Links\Link_Abstract;
+
 // don't show on password protected posts
 if ( post_password_required() ) {
 	return;
@@ -23,25 +25,35 @@ $has_ical       = $this->attr( 'hasiCal' );
 
 
 remove_filter( 'the_content', 'do_blocks', 9 );
-$subscribe_links = empty( $this->context['subscribe_links'] ) ? false : $this->context['subscribe_links'];
+$subscribe_links = empty( $this->get( ['subscribe_links'] ) ) ? false : $this->get( ['subscribe_links'] );
 
 $should_render  = $subscribe_links && ( $has_google_cal || $has_ical );
 
-if ( ! $should_render ) {
-	return;
-}
 
 if ( $has_google_cal ) {
-	$google_cal_link = ! empty( $subscribe_links[ 'gcal' ] ) ? $subscribe_links[ 'gcal' ]->get_uri( null ) : Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
+	if ( $this->get( [ 'subscribe_links', 'gcal' ] ) instanceof Link_Abstract ) {
+		$google_cal_link = $subscribe_links['gcal']->get_uri( null );
+	} else {
+		$google_cal_link = Tribe__Events__Main::instance()->esc_gcal_url( tribe_get_gcal_link() );
+	}
 }
 
 if ( $has_ical ) {
-	$ical_link = ! empty( $subscribe_links[ 'ical' ] ) ? $subscribe_links[ 'ical' ]->get_uri( null ) : tribe_get_single_ical_link();
+	if ( $this->get( [ 'subscribe_links', 'ical' ] ) instanceof Link_Abstract ) {
+		$ical_link = $subscribe_links['ical']->get_uri( null );
+	} else {
+		$ical_link = tribe_get_single_ical_link();
+	}
+}
+
+if ( empty( $google_cal_link ) && empty( $ical_link ) ) {
+	return;
 }
 
 ?>
 <div class="tribe-block tribe-block__events-link">
-	<?php if ( $has_google_cal && ! empty( $google_cal_link ) ) : ?>
+
+	<?php if ( ! empty( $google_cal_link ) ) : ?>
 		<div class="tribe-block__btn--link tribe-block__events-gcal">
 			<a
 				href="<?php echo esc_url( $google_cal_link ); ?>"
@@ -54,8 +66,9 @@ if ( $has_ical ) {
 			</a>
 		</div>
 	<?php endif; ?>
-	<?php if ( $has_ical && ! empty( $ical_link ) ) : ?>
-		<div class="tribe-block__btn--link tribe-block__-events-ical">
+
+	<?php if ( ! empty( $ical_link ) ) : ?>
+		<div class="tribe-block__btn--link tribe-block__events-ical">
 			<a
 				href="<?php echo esc_url( $ical_link ); ?>"
 				rel="noopener noreferrer nofollow"
@@ -66,6 +79,7 @@ if ( $has_ical ) {
 			</a>
 		</div>
 	<?php endif; ?>
+
 </div>
 
 <?php add_filter( 'the_content', 'do_blocks', 9 );


### PR DESCRIPTION
Prevent some potential fatals and reinforce the bail-out conditions.

Note: The fatals _appear_ to be connected to VE, so we should examine where VE hooks into the links and alters things (we shouldn't be getting `null`) but this will act as a buffer to prevent a fatal if something does go wrong.

[TEC-4258]

[TEC-4258]: https://theeventscalendar.atlassian.net/browse/TEC-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ