### PR TITLE
Make sure the Event Options metabox gets loaded in the block editor.

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3910,6 +3910,15 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 */
 		public function addEventBox() {
+			add_meta_box(
+				'tribe_events_event_options',
+				sprintf( esc_html__( '%s Options', 'the-events-calendar' ), $this->singular_event_label ),
+				[ $this, 'eventMetaBox' ],
+				self::POSTTYPE,
+				'side',
+				'default'
+			);
+
 			if ( tribe( 'editor' )->should_load_blocks() ) {
 				return;
 			}
@@ -3924,15 +3933,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				[
 						'__back_compat_meta_box' => ! class_exists( 'Tribe__Events__Pro__Main' ),
 				]
-			);
-
-			add_meta_box(
-					'tribe_events_event_options',
-					sprintf( esc_html__( '%s Options', 'the-events-calendar' ), $this->singular_event_label ),
-					[ $this, 'eventMetaBox' ],
-					self::POSTTYPE,
-					'side',
-					'default'
 			);
 
 			if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {


### PR DESCRIPTION
When we (I) placed the bailout for the metaboxes, I inadvertently included the Event Options mb. This corrects that:

Bad: https://d.pr/i/za1jir
Good: https://d.pr/i/mgLtz0

[TEC-4258]

[TEC-4258]: https://theeventscalendar.atlassian.net/browse/TEC-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ