### PR TITLE
Correct the FBAR check.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct conditional in Filter Bar upsell banner. [TEC-4284]
+
 = [5.14.0.1] 2022-02-15 =
 
 * Fix - Prevent parse error due to trailing comma on a method call, PHP 7.1 compatibility required. Props @kzeni

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: theeventscalendar, borkweb, bordoni, brianjessee, aguseo, camwynsp
 Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
 Requires at least: 5.6
-Stable tag: 5.14.0.1
+Stable tag: 5.14.0.2
 Tested up to: 5.9.0
 Requires PHP: 7.1
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -221,7 +221,7 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [TBD] TBD =
+= [5.14.0.2] 2022-02-21 =
 
 * Fix - Correct conditional in Filter Bar upsell banner. [TEC-4284]
 

--- a/src/Tribe/Admin/Filter_Bar/Provider.php
+++ b/src/Tribe/Admin/Filter_Bar/Provider.php
@@ -20,8 +20,8 @@ class Provider extends \tad_DI52_ServiceProvider {
 	 * @since 5.14.0
 	 */
 	public function register() {
-		// Bail if Filter Bar is already installed.
-		if ( class_exists( 'Tribe__Events__Filterbar__View' ) ) {
+		// Bail if Filter Bar is already installed/registered.
+		if ( has_action( 'tribe_common_loaded', 'tribe_register_filterbar' ) ) {
 			return;
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -636,17 +636,18 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// First boot.
 			tribe_register_provider( Tribe\Events\Service_Providers\First_Boot::class );
 
+			// Filter Bar upsell.
+			tribe_register_provider( Tribe\Events\Admin\Filter_Bar\Provider::class );
 
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.
+			 *
+			 * DO NOT put anything after this unless you _need to_ and know the implications!
 			 */
 			do_action( 'tribe_events_bound_implementations' );
 
 			// Database locks.
 			tribe_singleton( 'db-lock', DB_Lock::class );
-
-			// Filter Bar.
-			tribe_register_provider( Tribe\Events\Admin\Filter_Bar\Provider::class );
 		}
 
 		/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
 
-		const VERSION             = '5.14.0.1';
+		const VERSION             = '5.14.0.2';
 
 		/**
 		 * Min Pro Addon

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: The Events Calendar
  * Description: The Events Calendar is a carefully crafted, extensible plugin that lets you easily share your events. Beautiful. Solid. Awesome.
- * Version: 5.14.0.1
+ * Version: 5.14.0.2
  * Author: The Events Calendar
  * Author URI: https://evnt.is/1x
  * Text Domain: the-events-calendar


### PR DESCRIPTION
This corrects the check in the provider so it works,
and moves the singleton creation to _before_ the action we can use to hook into it.

This bug is a great argument for testing admin views...

No FBAR: https://d.pr/i/0frA5z
With FBAR: https://d.pr/i/g0ptNz

[TEC-4284]

[TEC-4284]: https://theeventscalendar.atlassian.net/browse/TEC-4284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ