### PR TITLE
Updating the tests to match the new ical subscribe logic for month view

### DIFF
--- a/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
@@ -184,17 +184,11 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 				[]
 			],
 
-
 			'without_date_month_view' => [
 				[
 					'view' => 'month',
 				],
-				[
-					date( 'Y-m-01' ),
-					date( 'Y-m-07' ),
-					date( 'Y-m-15' ),
-					date( 'Y-m-18' ),
-				],
+				[], // This gets populated in the calling method below, since ical feeds for month defaults to the current day forward.
 				'create_and_get_month_events',
 			],
 			'with_date_month_view' => [
@@ -213,9 +207,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 					'view' => 'month',
 					'featured' => true,
 				],
-				[
-					date( 'Y-m-07' ),
-				],
+				[], // This gets populated in the calling method below, since ical feeds for month defaults to the current day forward.
 				'create_and_get_month_events',
 			],
 			'with_date_featured_month_view' => [
@@ -274,7 +266,34 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 		// create the events.
 		call_user_func_array( [ $this, $method ], [] );
 
+		/**
+		 * If we are looking at the month view ical data, the current month only grabs events for the current day forward.
+		 * So we have to do some extra work to make sure we get the right events based on the current calendar day that the
+		 * tests are being run vs the data that is being generated via the create_and_get_month_events() method.
+		 */
+		if (
+			'month' === $context_args['view']
+			&& empty( $context_args['event_date'] )
+		) {
+			$end_of_month = date( 'Y-m-d', strtotime( 'last day of this month' ) );
+			$now = date( 'Y-m-d' );
+			foreach ( static::$events as $date => $event ) {
+				if ( $date < $now || $date > $end_of_month ) {
+					continue;
+				}
+
+				if ( ! empty( $context_args['featured'] ) && empty( $event->featured ) ) {
+					continue;
+				}
+
+				$expected_events_index[] = $date;
+			}
+
+			$expected_events_index = array_slice( $expected_events_index, 0, 4 );
+		}
+
 		$events_indexed = wp_list_pluck( static::$events, 'ID' );
+
 		/*
 		codecept_debug(
 			array_combine(


### PR DESCRIPTION
This is a spotfix to adjust tests to ensure that the date of the text excution is taken into account when generating the expected values to test against when looking at the current month.

Related: https://github.com/the-events-calendar/the-events-calendar/pull/3794