### PR TITLE
Correct useage of currency code

### DIFF
--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -67,6 +67,7 @@ class Tribe__Events__Editor__Configuration implements Tribe__Editor__Configurati
 			'timezoneHTML'  => tribe_events_timezone_choice( Tribe__Events__Timezones::get_event_timezone_string() ),
 			'priceSettings' => [
 				'defaultCurrencySymbol'   => tribe_get_option( 'defaultCurrencySymbol', '$' ),
+				'defaultCurrencyCode'   => tribe_get_option( 'defaultCurrencyCode', 'USD' ),
 				'defaultCurrencyPosition' => (
 				tribe_get_option( 'reverseCurrencyPosition', false ) ? 'suffix' : 'prefix'
 				),

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -36,6 +36,7 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta( 'post', '_EventCost', $this->text() );
 		register_meta( 'post', '_EventCostDescription', $this->text() );
 		register_meta( 'post', '_EventCurrencySymbol', $this->text() );
+		register_meta( 'post', '_EventCurrencyCode', $this->text() );
 		register_meta( 'post', '_EventCurrencyPosition', $this->text() );
 
 		// Use sanitize_textarea_field to allow whitespaces

--- a/src/Tribe/JSON_LD/Event.php
+++ b/src/Tribe/JSON_LD/Event.php
@@ -129,10 +129,9 @@ class Tribe__Events__JSON_LD__Event extends Tribe__JSON_LD__Abstract {
 			$price = tribe_get_cost( $post_id );
 			$price = $this->normalize_price( $price );
 			if ( '' !== $price ) {
-
 				// The currency has to be in ISO 4217
-				$event_currency = get_post_meta( $post_id, '_EventCurrencySymbol', true );
-				$currency       = ( '' !== $event_currency ) ? $event_currency : 'USD';
+				$event_currency = get_post_meta( $post_id, '_EventCurrencyCode', true );
+				$currency       = ( '' !== $event_currency ) ? $event_currency : tribe_get_option( 'defaultCurrencyCode', 'USD' );
 
 				// Manually Include the Price for non Event Tickets
 				$data->offers = (object) [

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -207,6 +207,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			'_EventShowMapLink',
 			'_EventShowMap',
 			'_EventCurrencySymbol',
+			'_EventCurrencyCode',
 			'_EventCurrencyPosition',
 			'_EventCost',
 			'_EventCostMin',

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -127,6 +127,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 			'cost'                   => tribe_get_cost( $event_id, true ),
 			'cost_details'           => array(
 				'currency_symbol'   => isset( $meta['_EventCurrencySymbol'] ) ? $meta['_EventCurrencySymbol'] : '',
+				'currency_code'     => isset( $meta['_EventCurrencyCode'] ) ? $meta['_EventCurrencyCode'] : '',
 				'currency_position' => isset( $meta['_EventCurrencyPosition'] ) ? $meta['_EventCurrencyPosition'] : '',
 				'values'            => $this->get_cost_values( $event_id ),
 			),

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -252,6 +252,20 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 					</td>
 				</tr>
 				<tr>
+					<td><?php esc_html_e( 'ISO Currency Code:', 'the-events-calendar' ); ?></td>
+					<td>
+						<input
+							tabindex="<?php tribe_events_tab_index(); ?>"
+							type='text'
+							id='EventCurrencyCode'
+							name='EventCurrencyCode'
+							size='2'
+							value='<?php echo isset( $_EventCurrencyCode ) ? esc_attr( $_EventCurrencyCode ) : tribe_get_option( 'defaultCurrencyCode', 'USD' ); ?>'
+							class='alignleft'
+						/>
+					</td>
+				</tr>
+				<tr>
 					<td><?php esc_html_e( 'Cost:', 'the-events-calendar' ); ?></td>
 					<td>
 						<input tabindex="<?php tribe_events_tab_index(); ?>" type='text' id='EventCost' name='EventCost' size='6' value='<?php echo ( isset( $_EventCost ) ) ? esc_attr( $_EventCost ) : ''; ?>' />

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -147,6 +147,19 @@ $general_tab_fields = Tribe__Main::array_insert_before_key(
 			'size'            => 'small',
 			'default'         => '$',
 		],
+		'defaultCurrencyCode'         => [
+			'type'            => 'text',
+			'label'           => esc_html__( 'Default currency code', 'the-events-calendar' ),
+			'tooltip'         => esc_html__( 'Set the default currency ISO-4217 code for event costs. This is a three-letter code and is mainly used for data/SEO purposes.', 'the-events-calendar' ),
+			'validation_type' => 'textarea',
+			'size'            => 'small',
+			'default'         => 'USD',
+			'attributes'      => [
+				'minlength'   => 3,
+				'maxlength'   => 3,
+				'placeholder' => __( 'Three-letter ISO currency code.', 'the-events-calendar' ),
+			],
+		],
 		'reverseCurrencyPosition'       => [
 			'type'            => 'checkbox_bool',
 			'label'           => esc_html__( 'Currency symbol follows value', 'the-events-calendar' ),

--- a/src/modules/blocks/classic-event-details/container.js
+++ b/src/modules/blocks/classic-event-details/container.js
@@ -43,6 +43,7 @@ const mapStateToProps = ( state ) => ( {
 	cost: priceSelectors.getPrice( state ),
 	currencyPosition: priceSelectors.getPosition( state ),
 	currencySymbol: priceSelectors.getSymbol( state ),
+	currencyCode: priceSelectors.getCode( state ),
 	url: websiteSelectors.getUrl( state ),
 	organizers: organizerSelectors.getOrganizersInClassic( state ),
 } );
@@ -64,6 +65,10 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	setSymbol: ( symbol ) => {
 		ownProps.setAttributes( { currencySymbol: symbol } );
 		dispatch( priceActions.setSymbol( symbol ) );
+	},
+	setCode: ( code ) => {
+		ownProps.setAttributes( { currencyCode: code } );
+		dispatch( priceActions.setCode( code ) );
 	},
 	setWebsite: ( url ) => {
 		ownProps.setAttributes( { url } );

--- a/src/modules/blocks/classic-event-details/index.js
+++ b/src/modules/blocks/classic-event-details/index.js
@@ -66,6 +66,11 @@ export default {
 			source: 'meta',
 			meta: '_EventCurrencySymbol',
 		},
+		currencyCode: {
+			type: 'string',
+			source: 'meta',
+			meta: '_EventCurrencyCode',
+		},
 		currencyPosition: {
 			type: 'string',
 			source: 'meta',
@@ -79,4 +84,3 @@ export default {
 		return null;
 	},
 };
-

--- a/src/modules/blocks/classic-event-details/template.js
+++ b/src/modules/blocks/classic-event-details/template.js
@@ -132,6 +132,7 @@ const ClassicEventDetails = ( props ) => {
 		currencyPosition,
 		setCurrencyPosition,
 		currencySymbol,
+		currencyCode,
 		setSymbol,
 		setAttributes,
 	} = props;
@@ -192,6 +193,12 @@ const ClassicEventDetails = ( props ) => {
 						placeholder={ __( 'E.g.: $', 'the-events-calendar' ) }
 						onChange={ setSymbol }
 					/>
+					<TextControl
+						label={ __( ' Currency Code', 'the-events-calendar' ) }
+						value={ currencyCode }
+						placeholder={ __( 'E.g.: USD', 'the-events-calendar' ) }
+						onChange={ setCode }
+					/>
 				</PanelBody>
 			</InspectorControls>
 		),
@@ -206,12 +213,14 @@ ClassicEventDetails.propTypes = {
 	cost: PropTypes.string,
 	currencyPosition: PropTypes.string,
 	currencySymbol: PropTypes.string,
+	currencyCode: PropTypes.string,
 	allDay: PropTypes.bool,
 	isSelected: PropTypes.bool,
 	setWebsite: PropTypes.func,
 	setCost: PropTypes.func,
 	toggleDashboardDateTime: PropTypes.func,
 	setSymbol: PropTypes.func,
+	setCode: PropTypes.func,
 	setCurrencyPosition: PropTypes.func,
 	setAllDay: PropTypes.func,
 };

--- a/src/modules/blocks/classic-event-details/template.js
+++ b/src/modules/blocks/classic-event-details/template.js
@@ -134,6 +134,7 @@ const ClassicEventDetails = ( props ) => {
 		currencySymbol,
 		currencyCode,
 		setSymbol,
+		setCode,
 		setAttributes,
 	} = props;
 

--- a/src/modules/blocks/event-datetime/content/container.js
+++ b/src/modules/blocks/event-datetime/content/container.js
@@ -26,6 +26,7 @@ const mapStateToProps = ( state ) => ( {
 	cost: priceSelectors.getPrice( state ),
 	currencyPosition: priceSelectors.getPosition( state ),
 	currencySymbol: priceSelectors.getSymbol( state ),
+	currencyCode: priceSelectors.getCode( state ),
 	end: dateTimeSelectors.getEnd( state ),
 	isEditable: dateTimeSelectors.isEditable( state ),
 	multiDay: dateTimeSelectors.getMultiDay( state ),

--- a/src/modules/blocks/event-datetime/content/template.js
+++ b/src/modules/blocks/event-datetime/content/template.js
@@ -212,6 +212,8 @@ EventDateTimeContent.propTypes = {
 	cost: PropTypes.string,
 	currencyPosition: PropTypes.oneOf( [ 'prefix', 'suffix', '' ] ),
 	currencySymbol: PropTypes.string,
+	currencyCode: PropTypes.string,
+	currencyCost: PropTypes.string,
 	end: PropTypes.string,
 	isEditable: PropTypes.bool,
 	isOpen: PropTypes.bool,

--- a/src/modules/blocks/event-price/container.js
+++ b/src/modules/blocks/event-price/container.js
@@ -35,6 +35,7 @@ const mapStateToProps = ( state, ownProps ) => ( {
 	cost: priceSelectors.getPrice( state ),
 	currencyPosition: priceSelectors.getPosition( state ),
 	currencySymbol: priceSelectors.getSymbol( state ),
+	currencyCode: priceSelectors.getCode( state ),
 	showCurrencySymbol: showCurrencySymbol( priceSelectors.getPrice( state ) ),
 	showCost: showCost( priceSelectors.getPrice( state ) ),
 	showCostDescription: ! isEmpty( trim( ownProps.attributes.costDescription ) ),
@@ -49,6 +50,10 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 	setSymbol: ( symbol ) => {
 		ownProps.setAttributes( { currencySymbol: symbol } );
 		dispatch( priceActions.setSymbol( symbol ) );
+	},
+	setCode: ( code ) => {
+		ownProps.setAttributes( { currencyCode: code } );
+		dispatch( priceActions.setCode( code ) );
 	},
 	setCurrencyPosition: ( value ) => {
 		const position = priceUtils.getPosition( ! value );

--- a/src/modules/blocks/event-price/index.js
+++ b/src/modules/blocks/event-price/index.js
@@ -47,6 +47,11 @@ export default {
 			source: 'meta',
 			meta: '_EventCurrencySymbol',
 		},
+		currencyCode: {
+			type: 'string',
+			source: 'meta',
+			meta: '_EventCurrencyCode',
+		},
 		currencyPosition: {
 			type: 'string',
 			source: 'meta',

--- a/src/modules/blocks/event-price/template.js
+++ b/src/modules/blocks/event-price/template.js
@@ -150,6 +150,8 @@ const renderControls = ( {
 	currencyCode,
 	currencyPosition,
 	setCurrencyPosition,
+	setCode,
+	setSymbol,
 } ) => (
 	isSelected && (
 		<InspectorControls key="inspector">

--- a/src/modules/blocks/event-price/template.js
+++ b/src/modules/blocks/event-price/template.js
@@ -149,7 +149,6 @@ const renderControls = ( {
 	currencySymbol,
 	currencyCode,
 	currencyPosition,
-	setSymbol,
 	setCurrencyPosition,
 } ) => (
 	isSelected && (
@@ -196,6 +195,7 @@ EventPrice.propTypes = {
 	isFree: PropTypes.bool,
 	setCost: PropTypes.func,
 	setSymbol: PropTypes.func,
+	setCode: PropTypes.func,
 	setCurrencyPosition: PropTypes.func,
 	onKeyDown: PropTypes.func,
 	onClick: PropTypes.func,

--- a/src/modules/blocks/event-price/template.js
+++ b/src/modules/blocks/event-price/template.js
@@ -147,6 +147,7 @@ const renderUI = ( props ) => (
 const renderControls = ( {
 	isSelected,
 	currencySymbol,
+	currencyCode,
 	currencyPosition,
 	setSymbol,
 	setCurrencyPosition,
@@ -160,6 +161,13 @@ const renderControls = ( {
 					value={ currencySymbol }
 					placeholder={ __( 'E.g.: $', 'the-events-calendar' ) }
 					onChange={ setSymbol }
+				/>
+				<TextControl
+					className="tribe-editor__event-price__currency-code-setting"
+					label={ __( ' Currency Code', 'the-events-calendar' ) }
+					value={ currencyCode }
+					placeholder={ __( 'E.g.: USD', 'the-events-calendar' ) }
+					onChange={ setCode }
 				/>
 				<CheckboxControl
 					label={ __( 'Currency symbol follows price', 'the-events-calendar' ) }
@@ -181,6 +189,7 @@ EventPrice.propTypes = {
 	cost: PropTypes.string,
 	currencyPosition: PropTypes.oneOf( [ 'prefix', 'suffix', '' ] ),
 	currencySymbol: PropTypes.string,
+	currencyCode: PropTypes.string,
 	showCurrencySymbol: PropTypes.bool,
 	showCost: PropTypes.bool,
 	showCostDescription: PropTypes.bool,

--- a/src/modules/data/blocks/price/__tests__/reducer.test.js
+++ b/src/modules/data/blocks/price/__tests__/reducer.test.js
@@ -12,6 +12,7 @@ const data = {
 	meta: {
 		_EventCurrencyPosition: 'prefix',
 		_EventCurrencySymbol: '€',
+		_EventCurrencyCode: 'EUR',
 		_EventCost: '15',
 	},
 };
@@ -31,6 +32,10 @@ describe( '[STORE] - Price reducer', () => {
 
 	it( 'Should set the cost symbol', () => {
 		expect( reducer( DEFAULT_STATE, actions.setSymbol( '€' ) ) ).toMatchSnapshot();
+	} );
+
+	it( 'Should set the cost code', () => {
+		expect( reducer( DEFAULT_STATE, actions.setCode( 'EUR' ) ) ).toMatchSnapshot();
 	} );
 
 	it( 'Should return the default state to meta map', () => {

--- a/src/modules/data/blocks/price/__tests__/selectors.test.js
+++ b/src/modules/data/blocks/price/__tests__/selectors.test.js
@@ -28,4 +28,8 @@ describe( '[STORE] - Price selectors', () => {
 	it( 'Should return the price symbol', () => {
 		expect( selectors.getSymbol( state ) ).toMatchSnapshot();
 	} );
+
+	it( 'Should return the price code', () => {
+		expect( selectors.getCode( state ) ).toMatchSnapshot();
+	} );
 } );

--- a/src/modules/data/blocks/price/actions.js
+++ b/src/modules/data/blocks/price/actions.js
@@ -23,3 +23,10 @@ export const setSymbol = ( symbol ) => ( {
 		symbol,
 	},
 } );
+
+export const setCode = ( code ) => ( {
+	type: types.SET_PRICE_CODE,
+	payload: {
+		code,
+	},
+} );

--- a/src/modules/data/blocks/price/reducer.js
+++ b/src/modules/data/blocks/price/reducer.js
@@ -21,12 +21,16 @@ export const DEFAULT_STATE = {
 	symbol: priceSettings() && priceSettings().defaultCurrencySymbol
 		? priceSettings().defaultCurrencySymbol
 		: __( '$', 'the-events-calendar' ),
+	code: priceSettings() && priceSettings().defaultCurrencyCode
+		? priceSettings().defaultCurrencyCode
+		: __( 'USD', 'the-events-calendar' ),
 	cost: '',
 };
 
 export const defaultStateToMetaMap = {
 	position: '_EventCurrencyPosition',
 	symbol: '_EventCurrencySymbol',
+	code: '_EventCurrencyCode',
 	cost: '_EventCost',
 };
 

--- a/src/modules/data/blocks/price/reducer.js
+++ b/src/modules/data/blocks/price/reducer.js
@@ -65,7 +65,7 @@ export default ( state = DEFAULT_STATE, action ) => {
 		case types.SET_PRICE_CODE:
 			return {
 				...state,
-				symbol: action.payload.code,
+				code: action.payload.code,
 			};
 		default:
 			return state;

--- a/src/modules/data/blocks/price/reducer.js
+++ b/src/modules/data/blocks/price/reducer.js
@@ -62,6 +62,11 @@ export default ( state = DEFAULT_STATE, action ) => {
 				...state,
 				symbol: action.payload.symbol,
 			};
+		case types.SET_PRICE_CODE:
+			return {
+				...state,
+				symbol: action.payload.code,
+			};
 		default:
 			return state;
 	}

--- a/src/modules/data/blocks/price/selectors.js
+++ b/src/modules/data/blocks/price/selectors.js
@@ -19,3 +19,8 @@ export const getPosition = createSelector(
 	[ getPriceBlock ],
 	( block ) => block.position,
 );
+
+export const getCode = createSelector(
+	[ getPriceBlock ],
+	( block ) => block.code,
+);

--- a/src/modules/data/blocks/price/types.js
+++ b/src/modules/data/blocks/price/types.js
@@ -5,4 +5,5 @@ import { PREFIX_EVENTS_STORE } from '@moderntribe/events/data/utils';
 
 export const SET_PRICE_COST = `${ PREFIX_EVENTS_STORE }/SET_PRICE_COST`;
 export const SET_PRICE_SYMBOL = `${ PREFIX_EVENTS_STORE }/SET_PRICE_SYMBOL`;
+export const SET_PRICE_CODE = `${ PREFIX_EVENTS_STORE }/SET_PRICE_CODE`;
 export const SET_PRICE_POSITION = `${ PREFIX_EVENTS_STORE }/SET_PRICE_POSITION`;


### PR DESCRIPTION
[TEC-4212]

This corrects our usage of currency code i.e. `priceCurrency` in our JSON-LD by adding a field for a default value to the admin and an event-specific one to both the classic and block editors.

Previously we were incorrectly using the currency _symbol_ but the ISO-4217 three-letter code is what's expected (as $ can be USD, AUD, CAD, Mexican Peso, etc...)

**Blocks:**
https://d.pr/i/Dzgjxk
https://d.pr/i/MqzhXU

**Classic**
https://d.pr/i/10IDFO
https://d.pr/i/T3Bw6l
(output in validator)
https://d.pr/i/8Eg8H3  