### PR TITLE
Ensure the venue saves for non-US venues.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure that the State/Province field saves for non-US venues. [TEC-4309]
+
 = [5.14.0.4] 2022-03-01 =
 
 * Tweak - Update version of Freemius to 2.4.3.

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -120,7 +120,6 @@ do_action( 'tribe_events_venue_before_metabox', $post );
 	<td>
 		<input
 			id="StateProvinceText"
-			name=''
 			name="venue[Province]"
 			size='25'
 			tabindex="<?php tribe_events_tab_index(); ?>"

--- a/tests/integration/Venue_Creation_Test.php
+++ b/tests/integration/Venue_Creation_Test.php
@@ -104,7 +104,7 @@ class Venue_Creation_Test extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 'Wellington St', get_post_meta( $post->ID, '_VenueAddress', true ) );
 		$this->assertEquals( 'Ottawa', get_post_meta( $post->ID, '_VenueCity', true ) );
 		$this->assertEquals( 'Canada', get_post_meta( $post->ID, '_VenueCountry', true ) );
-		$this->assertEquals( 'Ontario', get_post_meta( $post->ID, '_VenueState', true ) );
+		$this->assertEquals( 'Ontario', get_post_meta( $post->ID, '_VenueProvince', true ) );
 		$this->assertEquals( 'K1A 0A9', get_post_meta( $post->ID, '_VenueZip', true ) );
 		$this->assertEquals( '+1 613-992-4793', get_post_meta( $post->ID, '_VenuePhone', true ) );
 	}

--- a/tests/integration/Venue_Creation_Test.php
+++ b/tests/integration/Venue_Creation_Test.php
@@ -9,7 +9,7 @@ class Venue_Creation_Test extends \Codeception\TestCase\WPTestCase {
 
 	function setUp() {
 		parent::setUp();
-		$this->post_example_settings = array(
+		$this->post_example_settings = [
 			'post_author'      => 2,
 			'Venue'            => 'White House',
 			'Description'      => 'Home and office of the United States president',
@@ -20,7 +20,20 @@ class Venue_Creation_Test extends \Codeception\TestCase\WPTestCase {
 			'State'            => 'District of Columbia',
 			'Zip'              => '20500',
 			'Phone'            => '+1 202-456-1111',
-		);
+		];
+
+		$this->post_example_settings_intl = [
+			'post_author'      => 2,
+			'Venue'            => 'Parliament Hill',
+			'Description'      => 'Home of the Parliament of Canada',
+			'post_status'      => 'publish',
+			'Address'          => 'Wellington St',
+			'City'             => 'Ottawa',
+			'Country'          => 'Canada',
+			'Province'         => 'Ontario',
+			'Zip'              => 'K1A 0A9',
+			'Phone'            => '+1 613-992-4793',
+		];
 	}
 
 	/**
@@ -76,6 +89,24 @@ class Venue_Creation_Test extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 'District of Columbia', get_post_meta( $post->ID, '_VenueState', true ) );
 		$this->assertEquals( '20500', get_post_meta( $post->ID, '_VenueZip', true ) );
 		$this->assertEquals( '+1 202-456-1111', get_post_meta( $post->ID, '_VenuePhone', true ) );
+	}
+
+	/**
+	 * Check to make sure that the venue data is saved properly.
+	 *
+	 * @since 4.6.19
+	 */
+	public function test_tribe_create_intl_venue_API_meta_information() {
+		$post = get_post( Tribe__Events__API::createVenue( $this->post_example_settings_intl ) );
+
+		$this->assertEquals( 2, $post->post_author );
+		$this->assertEquals( 'Home of the Parliament of Canada', $post->post_content );
+		$this->assertEquals( 'Wellington St', get_post_meta( $post->ID, '_VenueAddress', true ) );
+		$this->assertEquals( 'Ottawa', get_post_meta( $post->ID, '_VenueCity', true ) );
+		$this->assertEquals( 'Canada', get_post_meta( $post->ID, '_VenueCountry', true ) );
+		$this->assertEquals( 'Ontario', get_post_meta( $post->ID, '_VenueState', true ) );
+		$this->assertEquals( 'K1A 0A9', get_post_meta( $post->ID, '_VenueZip', true ) );
+		$this->assertEquals( '+1 613-992-4793', get_post_meta( $post->ID, '_VenuePhone', true ) );
 	}
 
 }


### PR DESCRIPTION
A duplicated name attribute appears to be the underlying problem.

https://d.pr/i/0SzZSi

[TEC-4309]

[TEC-4309]: https://theeventscalendar.atlassian.net/browse/TEC-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ