### PR TITLE
Use https to pull php-date-formatter submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/php-date-formatter"]
 	path = vendor/php-date-formatter
-	url = git@github.com:kartik-v/php-date-formatter
+	url = https://github.com/kartik-v/php-date-formatter.git
 [submodule "common"]
 	path = common
 	url = git@github.com:the-events-calendar/tribe-common.git


### PR DESCRIPTION
Use the `https` address to pull the `php-date-formatter` submodule.
[See article about deprecation on GitHub blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/).

While working on EA, I could not pull submodules and this fixed it.

- Use https to pull the php-date-formatter sub-module
