### PR TITLE
Fix/tec 4225 duplicate filters update

### DIFF
--- a/src/Tribe/Amalgamator.php
+++ b/src/Tribe/Amalgamator.php
@@ -32,7 +32,7 @@ class Tribe__Events__Amalgamator {
 		 *
 		 * @since TBD
 		 *
-		 * @param boolean $merge_organizers Whether duplicate organizers should be merged, defualt true.
+		 * @param boolean $merge_organizers Whether duplicate organizers should be merged, default true.
 		 */
 		$merge_organizers = (bool) apply_filters( 'tribe_merge_identical_organizers_enabled', true );
 


### PR DESCRIPTION
Addresses comments from: https://github.com/the-events-calendar/the-events-calendar/pull/3724

[TEC-4225]
Enhancements for merging duplicate venues and organizers:
- Added filters to control whether or not duplicate venues / organizers should be merged.
- Added filters to filter the fields that should be used for comparison when checking for duplicates.
- Added filters (and logic) to allow the customization of the venue / organizer ID that should be kept when merging duplicates.

[TEC-4225]: https://theeventscalendar.atlassian.net/browse/TEC-4225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
