### PR TITLE
Ensure that max returns an int since we're doing math with it.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Tweak - Added filters `tribe_merge_identical_organizers_enabled`, `tribe_merge_identical_venues_enabled`, `tribe_merge_identical_organizers_fields`, `tribe_merge_identical_venues_fields`, `tribe_amalgamate_venues_keep_venue`, `tribe_amalgamate_organizers_keep_organizer` for better control of the merge duplicate venues and organizers functionality. [BTRIA-1082]
 * Fix - Correctly calculate Event duration when the Event crosses the daylight saving date and time. [TEC-4336]
+* Fix - Ensure the Views don't try to do math with strings. [TEC-4322]
 
 = [5.14.1] 2022-03-17 =
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1224,6 +1224,7 @@ class View implements View_Interface {
 	 * This allows us to save a query when determining pagination for list-like views.
 	 *
 	 * @since 5.0.0
+	 * @since TBD ZEnsure our max() gets all ints for math reasons
 	 *
 	 * @param null|int $offset_override Offset override value.
 	 * @param \WP_Query $query WP Query object.
@@ -1238,11 +1239,12 @@ class View implements View_Interface {
 		$context = $this->get_context();
 
 		$current_page = max(
-			$context->get( 'page' ),
-			$context->get( 'paged' ),
+			(int) $context->get( 'page' ),
+			(int) $context->get( 'paged' ),
 			1
 		);
-		return ( $current_page - 1 ) * $this->get_context()->get( 'events_per_page' );
+
+		return ( $current_page - 1 ) * $context->get( 'events_per_page' );
 	}
 
 	/**

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1224,7 +1224,7 @@ class View implements View_Interface {
 	 * This allows us to save a query when determining pagination for list-like views.
 	 *
 	 * @since 5.0.0
-	 * @since TBD ZEnsure our max() gets all ints for math reasons
+	 * @since TBD Ensure our max() gets all ints, for math reasons.
 	 *
 	 * @param null|int $offset_override Offset override value.
 	 * @param \WP_Query $query WP Query object.


### PR DESCRIPTION
[TEC-4322]

If fed a string like "hello" and it equates to a larger number than the others, `max()` will return the string, not the integer representation of it. `"hello" - 1` will fail (and fatal)

[TEC-4322]: https://theeventscalendar.atlassian.net/browse/TEC-4322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ