### PR TITLE
[TEC-4349] Update Venue Website input type to url

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Tweak - Updated the venue website field to type URL. [TEC-4349]
 * Tweak - Added filters `tribe_merge_identical_organizers_enabled`, `tribe_merge_identical_venues_enabled`, `tribe_merge_identical_organizers_fields`, `tribe_merge_identical_venues_fields`, `tribe_amalgamate_venues_keep_venue`, `tribe_amalgamate_organizers_keep_organizer` for better control of the merge duplicate venues and organizers functionality. [BTRIA-1082]
 * Fix - Correctly calculate Event duration when the Event crosses the daylight saving date and time. [TEC-4336]
 * Fix - Ensure the Views don't try to do math with strings. [TEC-4322]

--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -196,7 +196,7 @@ if ( ! $_POST && is_admin() ) {
 	<td>
 		<input
 			tabindex="<?php tribe_events_tab_index(); ?>"
-			type='text'
+			type='url'
 			id='EventWebsite'
 			name='venue[URL][]'
 			size='14'

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -191,7 +191,7 @@ do_action( 'tribe_events_venue_before_metabox', $post );
 			name='venue[URL]'
 			size='14'
 			tabindex="<?php tribe_events_tab_index(); ?>"
-			type='text'
+			type='url'
 			value='<?php echo ( isset( $_VenueURL ) ? esc_attr( $_VenueURL ) : '' ); ?>'
 		/>
 	</td>


### PR DESCRIPTION
[TEC-4349]

When working on CE, we found that when adding new venue's the website URL was not validating. The file CE was using was found in TEC. 

This PR changes the input type from `text` to `url`. Therefore adding a small amount of validation so that invalid URL's are not submitted.

**Submitting an invalid URL from Edit Venue**
![image](https://user-images.githubusercontent.com/12241059/163417861-0bf24257-4ebb-4c19-b313-d14349ade891.png)



![image](https://user-images.githubusercontent.com/12241059/163417307-050f9e0f-6e16-4b89-980c-52bc8bede71c.png)


[TEC-4349]: https://theeventscalendar.atlassian.net/browse/TEC-4349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ