### PR TITLE
CSV Import Fix on PHP 8.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Correctly calculate Event duration when the Event crosses the daylight saving date and time. [TEC-4336]
 * Fix - don't try to validate "raw" as a date. [TEC-4254]
 * Fix - Ensure the Views don't try to do math with strings. [TEC-4322]
+* Fix - Enable more than 5 csv entries to be imported when using 8.0.15 to 8.0.17 or 8.1.2 to 8.1.4. [TEC-4312]
 
 = [5.14.1] 2022-03-17 =
 

--- a/src/Tribe/Importer/File_Reader.php
+++ b/src/Tribe/Importer/File_Reader.php
@@ -9,6 +9,13 @@ class Tribe__Events__Importer__File_Reader {
 	private $last_line_read = 0;
 	public $lines;
 
+	/**
+	 * Construct for Tribe__Events__Importer__File_Reader.
+	 *
+	 * @since TBD - Fix for PHP 8.0.15 to 8.0.17 on getting the last line of the csv file.
+	 *
+	 * @param string $file_path The full path to the file.
+	 */
 	public function __construct( $file_path ) {
 		ini_set( 'auto_detect_line_endings', true );
 		$this->path = $file_path;
@@ -17,8 +24,12 @@ class Tribe__Events__Importer__File_Reader {
 		$this->set_csv_params( $this->get_csv_params() );
 		$this->file->seek( PHP_INT_MAX );
 		$total_lines = $this->file->key();
-		// In PHP 8.0.15 to 8.0.17 or 8.1.2 to 8.1.4 the use of seek() and then key() returns 0 when using the flag SplFileObject::READ_CSV.
-		// This bug is fixed in PHP 8.0.18 and 8.1.5.
+		/*
+		 * In PHP 8.0.15 to 8.0.17 or 8.1.2 to 8.1.4 the use of seek() and then key() returns 0 when using the flag SplFileObject::READ_CSV.
+		 * This bug is fixed in PHP 8.0.18 and 8.1.5.
+		 * @see https://github.com/php/php-src/pull/8138
+		 * @see https://github.com/php/php-src/issues/8121
+		 */
 		if ( 0 === $total_lines ) {
 			$total_lines = iterator_count( $this->file );
 		}

--- a/src/Tribe/Importer/File_Reader.php
+++ b/src/Tribe/Importer/File_Reader.php
@@ -27,8 +27,8 @@ class Tribe__Events__Importer__File_Reader {
 		/*
 		 * In PHP 8.0.15 to 8.0.17 or 8.1.2 to 8.1.4 the use of seek() and then key() returns 0 when using the flag SplFileObject::READ_CSV.
 		 * This bug is fixed in PHP 8.0.18 and 8.1.5.
-		 * @see https://github.com/php/php-src/pull/8138
-		 * @see https://github.com/php/php-src/issues/8121
+		 * @see https://github.com/php/php-src/issues/8236 - outlines the issue with seek()
+		 * @see https://github.com/php/php-src/pull/8138 - PR to fix the issue
 		 */
 		if ( 0 === $total_lines ) {
 			$total_lines = iterator_count( $this->file );


### PR DESCRIPTION
n PHP 8.0.15 they added this patch: [Fixed bug #75917 ](https://bugs.php.net/bug.php?id=75917)(SplFileObject::seek broken with CSV flags).

That appears to be the source of the issue. 
Before that patch this coding would return the last line of a csv file:
$this->file->seek( $this->file->getSize() );
$this->lines = $this->file->key();

It is similar to an example of getting the last line for [PHP: Hypertext Preprocessor](http://php.net/) 
https://www.php.net/manual/en/splfileobject.seek.php#121666

In PHP 8.0.18 this patch was added: [Fixed bug #8121](https://github.com/php/php-src/pull/8138) (SplFileObject - seek and key with csv file inconsistent).

_Ref:_ [TEC-4312](https://theeventscalendar.atlassian.net/browse/TEC-4312)