### PR TITLE
Ensure it works with archive views.

### DIFF
--- a/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
+++ b/src/Tribe/Views/V2/Views/Traits/With_Fast_Forward_Link.php
@@ -45,14 +45,10 @@ trait With_Fast_Forward_Link {
 		}
 
 		$next_event = tribe_events()->where( 'starts_after', $date );
-		$tax = $this->context->get( 'taxonomy' );
 
-		// This only handles event category for now.
-		if ( ! empty( $tax ) && Tribe__Events__Main::TAXONOMY == $tax ) {
-			$cat = $this->context->get( $tax );
-			if ( ! empty( $cat ) ) {
-				$next_event = $next_event->where( 'category', (array) $cat );
-			}
+		$event_cat = isset( $this->repository_args[ Tribe__Events__Main::TAXONOMY ] ) ? $this->repository_args[ Tribe__Events__Main::TAXONOMY ] : null;
+		if ( ! empty( $event_cat ) ) {
+			$next_event = $next_event->where( 'category', (array) $event_cat );
 		}
 
 		/**


### PR DESCRIPTION
Tweak to make sure that the archive works the way expected.

$this->repository_args is more reliable than the context in situations where we use the date navigation.

[ECP-957]

[ECP-957]: https://theeventscalendar.atlassian.net/browse/ECP-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ