### PR TITLE
Fix the venue link/url in the event venue form

### DIFF
--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -24,7 +24,7 @@ if ( ! $_POST && is_admin() ) {
 
 	} else {
 		$_VenuePhone            = tribe_get_phone();
-		$_VenueURL              = strip_tags( tribe_get_venue_website_link( null, null ) );
+		$_VenueURL              = strip_tags( tribe_get_venue_link( null, false ) );
 		$_VenueAddress          = tribe_get_address();
 		$_VenueCity             = tribe_get_city();
 		$_VenueProvince         = tribe_get_province();

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -437,13 +437,15 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 					$url = "http://$url";
 				}
 			}
+
 			$html = sprintf(
-				'<a href="%s" target="%s" rel="%s">%s</a>',
+				'<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>',
 				esc_attr( esc_url( $url ) ),
 				esc_attr( $target ),
 				esc_attr( $rel ),
 				esc_html( $label )
 			);
+
 		} else {
 			$html = '';
 		}

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -773,7 +773,7 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 			$website_link_label = apply_filters( 'tribe_get_venue_website_link_label', esc_html( $label ), $post_id );
 
 			$html = sprintf(
-				'<a href="%s" target="%s" rel="%s">%s</a>',
+				'<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>',
 				esc_attr( esc_url( $url ) ),
 				esc_attr( $website_link_target ),
 				esc_attr( $rel ),


### PR DESCRIPTION
`tribe_get_venue_website_link` returns a formatted HTML anchor
we need a URL - we get that from `tribe_get_venue_link` with the second param set to false.

I also indexed the params for `tribe_get_organizer_website_link` and `tribe_get_venue_website_link` while testing and since we're supposed to always used indexed params, I left that in place.