### PR TITLE
Put back the event website label for Classic editor.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Put back the event website label for Classic editor. [TEC-4334]
+
 = [5.14.2.1] 2022-04-28 =
 
 * Fix - Correct an issue with linked common release.

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -159,7 +159,6 @@ class Hooks extends \tad_DI52_ServiceProvider {
 
 		// Add filters to change the display of website links on the Single Event template.
 		add_filter( 'tribe_get_event_website_link_label', [ $this, 'filter_single_event_details_event_website_label' ], 10, 2 );
-		add_filter( 'tribe_events_get_event_website_title', '__return_empty_string' );
 
 		add_filter( 'tribe_get_venue_website_link_label', [ $this, 'filter_single_event_details_venue_website_label' ], 10, 2 );
 		add_filter( 'tribe_events_get_venue_website_title', '__return_empty_string' );


### PR DESCRIPTION
This was intentionally removed as part  of the single event redesign. Yet its removal was not in any of the design files I could find.

📸 https://d.pr/i/wVL5Ma

[TEC_4334]