### PR TITLE
EA-426 - fix the default ea category

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - Ensure that subscription links include events up to the limit, no matter the view settings. [TEC-4264]
+* Fix - Default event category in Global Import Settings to apply on new imports in Event Aggregator. [EA-426]
 
 = [5.14.2.1] 2022-04-28 =
 

--- a/src/Tribe/Aggregator/Settings.php
+++ b/src/Tribe/Aggregator/Settings.php
@@ -418,24 +418,25 @@ class Tribe__Events__Aggregator__Settings {
 	 *
 	 * Origin default settings trump global settings
 	 *
-	 * @param string $origin Origin
+	 * @since TBD - Fix the default category is added to the origin.
 	 *
-	 * @return string
+	 * @param string $origin The name of the EA origin.
+	 *
+	 * @return integer|null The category id for null if none set.
 	 */
 	public function default_category( $origin = null ) {
-		$default = null;
-		$setting = tribe_get_option( 'tribe_aggregator_default_category', $default );
-
-		if ( $origin ) {
-			$origin_setting = tribe_get_option( "tribe_aggregator_default_{$origin}_category", $setting );
-
-			if ( ! empty( $origin_setting ) ) {
-				$setting = $origin_setting;
-			}
+		$setting = null;
+		$default = tribe_get_option( 'tribe_aggregator_default_category', null );
+		if ( -1 !== (int) $default ) {
+			$setting = $default;
 		}
 
-		if ( -1 === (int) $setting ) {
-			$setting = $default;
+		if ( $origin ) {
+			$origin_setting = tribe_get_option( "tribe_aggregator_default_{$origin}_category", $default );
+
+			if ( ! empty( $origin_setting ) && -1 !== (int) $origin_setting ) {
+				$setting = $origin_setting;
+			}
 		}
 
 		return $setting;


### PR DESCRIPTION
Fixes so the default category so it is selected for an import.

Artifact:
Video Review: https://cloudup.com/c7-m_qCB5Kl

Ticket
_Ref:_ [EA-426](https://theeventscalendar.atlassian.net/browse/EA-426)