### PR TITLE
Fixes the double view slug in the URL

### DIFF
--- a/src/Tribe/Integrations/WPML/Language_Switcher.php
+++ b/src/Tribe/Integrations/WPML/Language_Switcher.php
@@ -56,7 +56,7 @@ class Tribe__Events__Integrations__WPML__Language_Switcher {
 		foreach ( $languages as &$language ) {
 			$sitepress->switch_lang( $language['code'] );
 			$language['url'] = $sitepress->convert_url(
-				$tec->getLink( $view, __( $view, 'the-events-calendar' ) ),
+				$tec->getLink( $view ),
 				$language['code']
 			);
 		}


### PR DESCRIPTION
With Events Calendar PRO, enabling the photo view, you get duplicated view slug in the URL, ie: /events/photo/photo