### PR TITLE
Remove link to updates page from Event settings. [TEC-4373]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
+
 = [5.16.1] 2022-06-09 =
 
 * Fix - Add rel="noindex" to links that point to empty Month and Day Views so as to not dilute SEO with empty results. [TEC-4354]

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -225,13 +225,6 @@ $general_tab_fields = Tribe__Main::array_insert_after_key(
 					esc_html__( 'View Welcome Page', 'the-events-calendar' ) .
 				'</legend><div class="tribe-field-wrap"><a href="' . tribe( 'tec.main' )->settings()->get_url( [ Tribe__Events__Main::instance()->activation_page->welcome_slug => 1 ] ) . '" class="button">' . esc_html__( 'View Welcome Page', 'the-events-calendar' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you initially installed the plugin.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
 		],
-		'viewUpdatePage'          => [
-			'type'        => 'html',
-			'html'        =>
-				'<fieldset class="tribe-field tribe-field-html"><legend>' .
-					esc_html__( 'View Update Page', 'the-events-calendar' ) .
-				'</legend><div class="tribe-field-wrap"><a href="' . tribe( 'tec.main' )->settings()->get_url( [ Tribe__Events__Main::instance()->activation_page->update_slug => 1 ] ) . '" class="button">' . esc_html__( 'View Update Page', 'the-events-calendar' ) . '</a><p class="tribe-field-indent description">' . esc_html__( 'View the page that displayed when you updated the plugin.', 'the-events-calendar' ) . '</p></div></fieldset><div class="clear"></div>',
-		],
 	]
 );
 


### PR DESCRIPTION
We're no longer updating the `updates page` and thus we're removing the link to it from the Event settings to prevent customers from navigating there.

https://theeventscalendar.atlassian.net/browse/TEC-4373

https://www.loom.com/share/81d84e3265024700aad87f5dda7ad91f