### PR TITLE
Add unique CSS classes to past and future month dates [TEC-3447] and [TEC-3819]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,11 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]
+* Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--next-month` to future month dates in the month view to allow easy targetting. [TEC-3819]
+
 = [5.16.1] 2022-06-09 =
 
 * Fix - Add rel="noindex" to links that point to empty Month and Day Views so as to not dilute SEO with empty results. [TEC-4354]

--- a/src/views/v2/month/calendar-body/day.php
+++ b/src/views/v2/month/calendar-body/day.php
@@ -46,6 +46,22 @@ if ( $today_date === $day_date ) {
 if ( $today_date > $day_date ) {
 	$day_classes[] = 'tribe-events-calendar-month__day--past';
 }
+
+/**
+ * Add a unique CSS class to past month dates.
+ * 
+ * @since TBD
+ */
+if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
+	$day_classes[] = 'tribe-events-calendar-month__day--past-month';
+}
+
+/**
+ * Add a unique CSS class to future month dates.
+ */
+if ( $day[ 'month_number' ] > date( 'm', strtotime( $today_date ) ) ) {
+	$day_classes[] = 'tribe-events-calendar-month__day--next-month';
+}
 ?>
 
 <div


### PR DESCRIPTION
We currently don't have any way to target past and future month dates in the month view. This PR adds 2 new classes i.e. `tribe-events-calendar-month__day--past-month` and `tribe-events-calendar-month__day--next-month` for past and future month dates respectively.

https://theeventscalendar.atlassian.net/browse/TEC-3447 and https://theeventscalendar.atlassian.net/browse/TEC-3819

https://www.loom.com/share/e500169f3cfe4478b0f498ac89e9b256