### PR TITLE
[WPML] Single occurrence language switcher

### DIFF
--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -79,6 +79,7 @@ class Tribe__Events__Integrations__WPML__WPML {
 
 		$language_switcher = Tribe__Events__Integrations__WPML__Language_Switcher::instance();
 		add_filter( 'icl_ls_languages', [ $language_switcher, 'filter_icl_ls_languages' ], 5 );
+		add_filter( 'wpml_get_ls_translations', [ $language_switcher, 'add_ls_to_single_occurrence' ], 10, 2 );
 
 		$meta = tribe( 'tec.integrations.wpml.meta' );
 		add_filter( 'get_post_metadata', tribe_callback( $meta, 'translate_post_id' ), 10, 3 );


### PR DESCRIPTION
Get translations of single occurrences to display WPML's language switcher.

With WPML you can configure a language switcher in several different location. As an example I have added a language switcher in the footer and another one in the menu:
https://the-events-calendar.sandbox.otgs.work/events/

When we visit the single occurrence of a recurring event, the language switcher is not displayed:
https://the-events-calendar.sandbox.otgs.work/event/weekly-update/2022-06-10/

This is caused by the provisional ID that you use, and WPML doesn't recognize it.

I put together some code that fetches the translations of a single occurrence for the language switcher to work.

I'm not proud of the code, take it more like a **proof of concept***. The idea is simple, we convert the provisional id to a real post_id. We fetch the translations. And finally we convert the translated post_id to provisional ids again.

There are 3 things I'm not comfortable with, but due to time constraints I'm sending it as it is:
- I used direct DB queries. You probably have better ways to do this ...
- I used a hardcoded 10000000 to convert from and to provisional ids
- Recurring is a PRO feature, maybe it should go there?

Anyway, I hope this helps resolve the issue. I'm in your Slack channel if you need anything from me.