### PR TITLE
Tame the rogue SVG icon on the single events page. [TEC-4399]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+== [TBD] TBD ==
+
+* Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
+
 = [5.16.1] 2022-06-09 =
 
 * Fix - Add rel="noindex" to links that point to empty Month and Day Views so as to not dilute SEO with empty results. [TEC-4354]

--- a/src/resources/postcss/components/skeleton/_ical-link.pcss
+++ b/src/resources/postcss/components/skeleton/_ical-link.pcss
@@ -65,6 +65,10 @@
 			width: 10px;
 		}
 
+		.tribe-events-c-subscribe-dropdown__export-icon {
+			height: 16px;
+		}
+
 		.tribe-events-c-subscribe-dropdown__content {
 			display: none;
 		}


### PR DESCRIPTION
Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page.

https://theeventscalendar.atlassian.net/browse/TEC-4399

Before Fix
![image](https://user-images.githubusercontent.com/22029087/173324610-137e3bd3-46c7-4cfe-a45d-b9130d584539.png)

After Fix
![image](https://user-images.githubusercontent.com/22029087/173324353-2bd3de6a-3f31-4723-bc37-a1f2359bf19d.png)
