### PR TITLE
Note required Composer version in Contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ see in terms of code formatting, so don't ignore him.
 
 ### Prerequisites
 
-* [composer](https://getcomposer.org/download/)
+* [composer](https://getcomposer.org/download/) (composer v1 required)
 * [node](https://nodejs.org/download/)
 * [nvm](https://github.com/nvm-sh/nvm)
 


### PR DESCRIPTION
**Issue**
When onboarding, burned a decent amount of time not knowing that composer v1 was required to get through the build when I already has v2 installed on my computer.

**Resolution**
Just a minor change to the CONTRIBUTING.md doc noting that v1 is required as a prerequisite. 