### PR TITLE
Fix `Next` arrow url when the Main Events Page is set to Homepage. [TEC-4247]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,7 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 == [TBD] TBD ==
 
-* Fix - Ensure the `Next` arrow navigates to the correct page when the `Main Events Page` is set as the homepage. [TEC-4247]
+* Fix - Ensure the `Next` arrow in `List` and `Summary` views navigates to the correct page when the `Main Events Page` is set as the homepage. [TEC-4247]
 * Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
 * Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 == [TBD] TBD ==
 
+* Fix - Ensure the `Next` arrow navigates to the correct page when the `Main Events Page` is set as the homepage. [TEC-4247]
 * Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
 * Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -190,6 +190,15 @@ class List_View extends View {
 
 		$upcoming->order_by( '__none' );
 
+		/**
+		 * Check whether the Main Events Page is set as the homepage.
+		 * 
+		 * @since TBD
+		 */
+		if ( ! tribe_is_events_front_page() ) {
+			$page = 2;
+		}
+
 		if ( $upcoming->count() > 0 ) {
 			$query_args = [
 				'post_type'        => TEC::POSTTYPE,


### PR DESCRIPTION
Ensure the `Next` arrow in `List` and `Summary` views navigates to the correct page when the `Main Events Page` is set as the homepage.

Related to : https://github.com/the-events-calendar/events-pro/pull/1960

https://theeventscalendar.atlassian.net/browse/TEC-4247

https://www.loom.com/share/0448a7f864424f99adb391586dcf626b