### PR TITLE
Stopgap fix for aggregator csv imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
 * Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
+* Fix - Ensure Aggregator CSV imports continue to run when on an admin page. [TEC-4070]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--next-month` to future month dates in the month view to allow easy targetting. [TEC-3819]
 

--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -411,7 +411,7 @@ class Tribe__Events__Aggregator {
 		$should_load = (bool) apply_filters( 'tribe_aggregator_should_load', true );
 
 		// You shall not Load!
-		if ( false === $should_load ) {
+		if ( true !== $should_load ) {
 			return false;
 		}
 

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -166,18 +166,12 @@ class Tribe__Events__Aggregator__Cron {
 		// Fetch the initial Date and Hour
 		$date = date( 'Y-m-d H' );
 
-		// Based on the Minutes construct a Cron
+		// Based on the Minutes construct a wp_cron
 		$minutes = (int) date( 'i' );
-		if ( $minutes < 15 ) {
-			$date .= ':00';
-		} elseif ( $minutes >= 15 && $minutes < 30 ) {
-			$date .= ':15';
-		}elseif ( $minutes >= 30 && $minutes < 45 ) {
-			$date .= ':30';
-		} else {
-			$date .= ':45';
-		}
-		$date .= ':00';
+		// Get minutes / 15 with no remainder.
+		$minutes = intdiv( $minutes, 15 ) * 15;
+		// Format it & insert into date string. Add 0 seconds.
+		$date .= sprintf(':%02d', $minutes) . ':00';
 
 		// Fetch the last half hour as a timestamp
 		$start_timestamp = strtotime( $date );
@@ -188,12 +182,12 @@ class Tribe__Events__Aggregator__Cron {
 
 		$current_time = time();
 
-		// if the start timestamp is older than RIGHT NOW, set it for 5 minutes from now
+		// if the start timestamp is older than RIGHT NOW, set it for 5 minutes from now.
 		if ( $current_time > $start_timestamp ) {
 			$start_timestamp = $current_time + absint( $random_minutes );
 		}
 
-		// Now add an action twice hourly
+		// Now add an action once every fifteen minutes.
 		wp_schedule_event( $start_timestamp, 'tribe-every15mins', self::$action );
 	}
 

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -171,7 +171,7 @@ class Tribe__Events__Aggregator__Cron {
 		// Get minutes / 15 with no remainder.
 		$minutes = intdiv( $minutes, 15 ) * 15;
 		// Format it & insert into date string. Add 0 seconds.
-		$date .= sprintf(':%02d', $minutes) . ':00';
+		$date .= sprintf( ':%02d', $minutes ) . ':00';
 
 		// Fetch the last half hour as a timestamp
 		$start_timestamp = strtotime( $date );

--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -17,7 +17,7 @@ class Tribe__Events__Aggregator__Page {
 	public static $slug = 'aggregator';
 
 	/**
-	 * Stores the Registred ID from `add_submenu_page`
+	 * Stores the Registered ID from `add_submenu_page`
 	 *
 	 * @var string
 	 */
@@ -175,9 +175,6 @@ class Tribe__Events__Aggregator__Page {
 			],
 			'admin_enqueue_scripts',
 			[
-				'conditionals' => [
-					[ $this, 'is_screen' ],
-				],
 				'localize'     => (object) $localize_data,
 			]
 		);
@@ -240,7 +237,7 @@ class Tribe__Events__Aggregator__Page {
 	}
 
 	/**
-	 * Checks if we are in the correct screen
+	 * Checks if we are on the correct screen.
 	 *
 	 * @return boolean
 	 */
@@ -328,7 +325,7 @@ class Tribe__Events__Aggregator__Page {
 	}
 
 	/**
-	 * Gets the Page title for the Aggegator
+	 * Gets the Page title for the Aggregator
 	 *
 	 * @return string
 	 */

--- a/src/Tribe/Aggregator/Record/Queue_Processor.php
+++ b/src/Tribe/Aggregator/Record/Queue_Processor.php
@@ -70,15 +70,15 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 	 * batches of pending import record inserts/updates.
 	 */
 	public function register_scheduled_task() {
-		// Bail on registration of scheduled event in case we dont have an API setup.
+		// Bail on registration of scheduled event in case we don't have an API setup.
 		if ( is_wp_error( tribe( 'events-aggregator.service' )->api() ) ) {
-			// Also clear in case we dont have an API key.
+			// Also clear in case we don't have an API key.
 			$this->clear_scheduled_task();
 
 			return;
 		}
 
-		// Prevent from trying to schedule in case we dont have any scheduled records to process, value will either be false or 0.
+		// Prevent from trying to schedule in case we don't have any scheduled records to process, value will either be false or 0.
 		if ( ! $this->next_waiting_record( false, true ) ) {
 			// Also clear in case we don't have any records to process.
 			$this->clear_scheduled_task();
@@ -86,6 +86,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 			return;
 		}
 
+		// If we have one scheduled, don't schedule another.
 		if ( wp_next_scheduled( self::$scheduled_key ) ) {
 			return;
 		}
@@ -93,7 +94,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 		/**
 		 * Filter the interval at which to process import records.
 		 *
-		 * By default a custom interval of ever 30mins is specified, however
+		 * By default a custom interval of every 15mins is specified, however
 		 * other intervals such as "hourly", "twicedaily" and "daily" can
 		 * normally be substituted.
 		 *
@@ -105,7 +106,7 @@ class Tribe__Events__Aggregator__Record__Queue_Processor {
 	}
 
 	/**
-	 * Expected to fire upon plugin deactivation.
+	 * Fires upon plugin deactivation.
 	 */
 	public function clear_scheduled_task() {
 		wp_clear_scheduled_hook( self::$scheduled_key );

--- a/src/Tribe/Aggregator/Record/Queue_Realtime.php
+++ b/src/Tribe/Aggregator/Record/Queue_Realtime.php
@@ -36,6 +36,7 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		tribe_notice( 'aggregator-update-msg', [ $this, 'render_update_message' ], 'type=warning&dismiss=0' );
 
 		add_filter( 'heartbeat_received', [ $this, 'receive_heartbeat' ], 10, 2 );
+
 		add_action( 'wp_ajax_tribe_aggregator_realtime_update', [ $this, 'ajax' ] );
 
 		$this->queue           = $queue;
@@ -64,10 +65,6 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 	}
 
 	public function render_update_message() {
-		if ( ! Tribe__Events__Aggregator__Page::instance()->is_screen() ) {
-			return false;
-		}
-
 		/** @var Tribe__Events__Aggregator__Record__Queue_Processor $processor */
 		$processor = tribe( 'events-aggregator.main' )->queue_processor;
 		if ( ! $this->record_id = $processor->next_waiting_record( true ) ) {
@@ -86,11 +83,13 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 
 		ob_start();
 		$percent   = $this->sanitize_progress( $this->queue->progress_percentage() );
-		$spinner   = '<img src="' . get_admin_url( null, '/images/spinner.gif' ) . '">';
 		?>
 		<div class="tribe-message">
 			<p>
-				<?php esc_html_e( 'Your import is currently in progress. Don\'t worry, you can safely navigate away&ndash;the import will continue in the background.', 'the-events-calendar' ); ?>
+				<?php esc_html_e(
+						'Your import is currently in progress. Don\'t worry, you can safely navigate away&ndash;the import will continue in the background.',
+						'the-events-calendar'
+				); ?>
 			</p>
 		</div>
 		<ul class="tracker">
@@ -139,7 +138,6 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		}
 
 		$response['ea_progress'] = $data;
-
 		return $response;
 	}
 
@@ -232,14 +230,14 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 	 * @return array<string, mixed> An array with the details of the progress bar.
 	 */
 	private function get_queue_progress_data() {
-		if ( $this->record_id <= 0 ) {
+		if ( (int) $this->record_id <= 0 ) {
 			return [];
 		}
 
 		// Load the queue.
 		/** @var \Tribe__Events__Aggregator__Record__Queue_Interface $queue */
 		$queue = $this->queue ? $this->queue : Tribe__Events__Aggregator__Record__Queue_Processor::build_queue( $this->record_id );
-		// We always need to setup the Current Queue.
+		// We always need to set up the Current Queue.
 		$this->queue_processor->set_current_queue( $queue );
 
 		// Only if it's not empty that we care about processing.
@@ -256,7 +254,6 @@ class Tribe__Events__Aggregator__Record__Queue_Realtime {
 		$done          = $current_queue->is_empty() && empty( $current_queue->is_fetching() );
 
 		$percentage = $current_queue->progress_percentage();
-
 		return $this->get_progress_data( $current_queue, $percentage, $done );
 	}
 

--- a/src/resources/js/aggregator-fields.js
+++ b/src/resources/js/aggregator-fields.js
@@ -1136,12 +1136,13 @@ tribe_aggregator.fields = {
 			obj.progress.$.notice.find( '.tribe-message' ).html( data.error_text );
 			obj.progress.$.tracker.remove();
 			obj.progress.$.notice.find( '.progress-container' ).remove();
-			obj.progress.$.notice.removeClass( 'warning' ).addClass( 'error' );
+			obj.progress.$.notice.removeClass( 'notice-warning' ).addClass( 'notice-error' );
 		} else if ( data.complete ) {
+			//obj.progress.$.notice.show();
 			obj.progress.$.notice.find( '.tribe-message' ).html( data.complete_text );
 			obj.progress.$.tracker.remove();
 			obj.progress.$.notice.find( '.progress-container' ).remove();
-			obj.progress.$.notice.removeClass( 'warning' ).addClass( 'completed' );
+			obj.progress.$.notice.removeClass( 'notice-warning' ).addClass( 'notice-success' );
 		}
 	};
 

--- a/src/resources/js/aggregator-fields.js
+++ b/src/resources/js/aggregator-fields.js
@@ -1138,11 +1138,11 @@ tribe_aggregator.fields = {
 			obj.progress.$.notice.find( '.progress-container' ).remove();
 			obj.progress.$.notice.removeClass( 'notice-warning' ).addClass( 'notice-error' );
 		} else if ( data.complete ) {
-			//obj.progress.$.notice.show();
 			obj.progress.$.notice.find( '.tribe-message' ).html( data.complete_text );
 			obj.progress.$.tracker.remove();
 			obj.progress.$.notice.find( '.progress-container' ).remove();
 			obj.progress.$.notice.removeClass( 'notice-warning' ).addClass( 'notice-success' );
+			obj.progress.$.notice.show();
 		}
 	};
 

--- a/src/resources/postcss/aggregator-page.pcss
+++ b/src/resources/postcss/aggregator-page.pcss
@@ -1,10 +1,10 @@
 .tribe-ea {
 
 	.tribe-ea-tab {
-		padding: 20px;
-		margin-top: 20px;
-		border: 1px solid #ccc;
 		background-color: #fff;
+		border: 1px solid #ccc;
+		margin-top: 20px;
+		padding: 20px;
 
 		.form-table {
 			th[scope="row"] {
@@ -42,9 +42,9 @@
 	}
 
 	.tribe-ea-help {
-		padding: 4px;
 		color: #0073aa;
 		cursor: pointer;
+		padding: 4px;
 	}
 
 	.tribe-ea-hidden {
@@ -65,9 +65,9 @@
 	.tribe-ea-raw-list {
 		line-height: 1.25em;
 		list-style: square;
-		margin-top: 0;
-		margin-left: 22px;
 		margin-bottom: 6px;
+		margin-left: 22px;
+		margin-top: 0;
 
 		> li {
 			margin-bottom: 2px;
@@ -152,7 +152,7 @@
 		.dashicons {
 			font-size: 1.5rem;
 			line-height: 1.2rem;
-			margin-right: .5rem;
+			margin-right: 0.5rem;
 		}
 
 		.dashicons-warning {
@@ -166,9 +166,6 @@
 
 		#facebook_api_key {
 			margin-right: 1.5rem;
-		}
-
-		.tribe-message {
 		}
 
 		.tribe-credentials-success {
@@ -186,21 +183,22 @@
 		}
 
 		&.column-total {
-			width: 15%;
 			text-align: left;
+			width: 15%;
 		}
 	}
 
 	.tribe-ea-tab-scheduled {
 		td.column-source {
 			padding-left: 10px;
+
 			:not(.row-actions) a:first-of-type {
-				overflow : hidden;
-				white-space : nowrap;
-				text-overflow : ellipsis;
-				display : inline-block;
-				max-width : 100%;
+				display: inline-block;
+				max-width: 100%;
+				overflow: hidden;
+				text-overflow: ellipsis;
 				vertical-align: bottom;
+				white-space: nowrap;
 			}
 		}
 	}
@@ -219,17 +217,17 @@
 	}
 
 	.tribe-ea-report-status {
-		position: absolute;
-		width: 45px;
 		bottom: 0;
-		top: 0;
-		left: 0;
 		font-size: 25px;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 45px;
 
 		> .dashicons {
-			width: 100%;
-			padding-top: 10px;
 			font-size: inherit;
+			padding-top: 10px;
+			width: 100%;
 		}
 
 		.tribe-ea-status-success {
@@ -258,12 +256,13 @@
 		margin: 0 1px 0 0;
 	}
 
-	input, select {
+	input,
+	select {
 		margin-left: 0;
 	}
 
 	.tribe-refine {
-		margin-bottom: .25rem;
+		margin-bottom: 0.25rem;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -279,9 +278,9 @@
 	}
 
 	.tribe-notice-tribe-missing-aggregator-license {
-		background-color: #F9F7F4;
+		background-color: #f9f7f4;
+		border: 1px solid #f9f7f4;
 		border-radius: 16px;
-		border: 1px solid #F9F7F4;
 		display: flex;
 		justify-content: space-between;
 		padding: 60px;
@@ -293,7 +292,7 @@
 		}
 
 		.tribe-notice-tribe-missing-aggregator-license__image {
-			background-image: url(../images/aggregator/ea-intro-img-text.png);
+			background-image: url('../images/aggregator/ea-intro-img-text.png');
 			background-position: center right;
 			background-repeat: no-repeat;
 			background-size: contain;
@@ -307,7 +306,7 @@
 		}
 
 		.upsell-banner {
-			background: url(../images/aggregator/EventAggregator-icon.svg) transparent no-repeat;
+			background: url('../images/aggregator/EventAggregator-icon.svg') transparent no-repeat;
 			background-position: left;
 			background-size: contain;
 			font-family: apercu-mono-bold, monospace;
@@ -363,10 +362,11 @@
 		&.tribe-active.tribe-dependent {
 			display: flex;
 		}
-		display: flex;
+
 		align-items: center;
-		justify-content: center;
+		display: flex;
 		flex: 1 1 auto;
+		justify-content: center;
 
 		&.tribe-banner-eventbrite-tickets {
 			background-image: linear-gradient(135deg, #0178ba 0%, #0178ba 25%, #01bdac 65%, #01bdac 100%);
@@ -377,8 +377,8 @@
 			h3 {
 				color: #fff;
 				font-size: 26px;
-				letter-spacing: 1px;
 				font-weight: normal;
+				letter-spacing: 1px;
 				padding: 0 45px;
 			}
 
@@ -386,7 +386,6 @@
 				max-width: 165px;
 			}
 		}
-
 	}
 
 	.tribe-button {
@@ -428,7 +427,7 @@
 	.dataTables_length,
 	.dataTables_filter {
 		line-height: 28px;
-		margin-bottom: .5rem;
+		margin-bottom: 0.5rem;
 
 		select {
 			margin-top: -2px;
@@ -441,14 +440,14 @@
 
 	dl.tribe-filters {
 		display: none;
-		margin-left: .5rem;
+		margin-left: 0.5rem;
 		margin-top: 0;
 
 		dt {
 			clear: left;
 			display: inline-block;
 			font-weight: bold;
-			margin-right: .25rem;
+			margin-right: 0.25rem;
 		}
 
 		dd {
@@ -458,13 +457,13 @@
 			&:after {
 				content: '';
 				display: block;
-				margin-bottom: .25rem;
+				margin-bottom: 0.25rem;
 			}
 		}
 	}
 
 	.widefat td p {
-		margin-bottom: .25em;
+		margin-bottom: 0.25em;
 	}
 
 	.tribe-ea-login-button {
@@ -474,17 +473,17 @@
 }
 
 .tribe-ea-table-container {
-	background-color: #FAFAFA;
-	border: 1px solid #E7E7E7;
+	background-color: #fafafa;
+	border: 1px solid #e7e7e7;
 	min-height: 25px;
-	padding: .5rem;
+	padding: 0.5rem;
 }
 
 .tribe-preview-container {
 	display: none;
+	margin-top: 0.5rem;
 	padding-left: 1rem;
 	padding-right: 1rem;
-	margin-top: .5rem;
 
 	.edit-form &,
 	.show-data &,
@@ -551,7 +550,7 @@
 
 	.spinner-message {
 		display: block;
-		margin-top: .25rem;
+		margin-top: 0.25rem;
 	}
 
 	.dataTable {
@@ -680,12 +679,13 @@
 
 	.tribe-timezone-message {
 		font-style: italic;
-		padding-top: .5rem;
+		padding-top: 0.5rem;
 	}
+
 	.tribe-limits-message {
 		font-style: italic;
-		padding: 0;
 		margin: 1em 0 -1.5em;
+		padding: 0;
 	}
 }
 
@@ -708,27 +708,19 @@
 		}
 	}
 
-	&.completed {
-		border-left-color: #46b450;
-
-		.progress .bar {
-			background: #7ad03a;
-		}
-	}
-
 	.tracker {
 		margin: 0;
 		padding: 0;
 
 		.tracked-item {
 			display: none;
-			margin: .25rem 0;
+			margin: 0.25rem 0;
 		}
 
 		&.has-created,
 		&.has-updated,
 		&.has-skipped {
-			padding-bottom: .25rem;
+			padding-bottom: 0.25rem;
 
 			.track-remaining {
 				display: block;
@@ -761,14 +753,14 @@
 }
 
 .select2-disabled {
-	margin-bottom: 0;
 	color: gray;
 	cursor: default;
+	margin-bottom: 0;
 }
 
 .tribe-dropdown-subtitle {
-	font-size: 11px;
 	color: gray;
+	font-size: 11px;
 }
 
 .select2-highlighted .tribe-dropdown-subtitle {
@@ -784,8 +776,8 @@
 			padding-right: 0;
 
 			input[type=text] {
-				width: 92%;
 				display: inline-block;
+				width: 92%;
 			}
 		}
 

--- a/src/resources/postcss/aggregator-page.pcss
+++ b/src/resources/postcss/aggregator-page.pcss
@@ -694,6 +694,8 @@
 }
 
 .tribe-notice-aggregator-update-msg {
+	display: none;
+
 	.progress {
 		border: 1px solid #ccc;
 		float: left;
@@ -744,6 +746,10 @@
 				display: block;
 			}
 		}
+	}
+
+	.tribe_events_page_aggregator & {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
[TEC-4070]

This is a stopgap to get the import running on all admin pages. We should shift to using action scheduler, but that has to wait for RBE/V1-removal.

1. Ensure that import continues when we're in the admin: https://d.pr/i/TxrEif
   - The intent is to hide the notice on non-aggregator pages, but w/o it the import stalls.
2. Use the built-in classes for notices, since we're copying their styling (colors, etc) 

[TEC-4070]: https://theeventscalendar.atlassian.net/browse/TEC-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ