### PR TITLE
Fix `Next` nav link for Event View Elementor widget [FBAR-263]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 == [TBD] TBD ==
 
+* Fix - Ensure the `Next` button when using the `Event View` Elementor widget navigates to the next page on the first click. [FBAR-263]
 * Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
 * Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -310,7 +310,7 @@ tribe.events.views.manager = {};
 
 		var $link = $( this );
 		var url = $link.attr( 'href' );
-		var currentUrl = containerData.prev_url;
+		var currentUrl = containerData.url;
 		var nonce = $link.data( 'view-rest-nonce' );
 		var shouldManageUrl = obj.shouldManageUrl( $container );
 		var shortcodeId = $container.data( 'view-shortcode' );


### PR DESCRIPTION
Ensure the `Next` button when using the `Event View` Elementor widget navigates to the next page on the first click.

https://theeventscalendar.atlassian.net/browse/FBAR-263

https://www.loom.com/share/2fe681f49d4b420aa1afe94624d11439