### PR TITLE
Use better logic on choosing the URL function.

### DIFF
--- a/src/Tribe/Front_Page_View.php
+++ b/src/Tribe/Front_Page_View.php
@@ -73,7 +73,7 @@ class Tribe__Events__Front_Page_View {
 	}
 
 	/**
-	 * Parse the query when the customizer sends request to preview specifc page to avoid 404 pages
+	 * Parse the query when the customizer sends request to preview specific page to avoid 404 pages
 	 * or the wrong page.
 	 *
 	 * @since 4.6.15

--- a/src/Tribe/Views/V2/Views/List_View.php
+++ b/src/Tribe/Views/V2/Views/List_View.php
@@ -85,7 +85,7 @@ class List_View extends View {
 		$current_page = (int) $this->context->get( 'page', 1 );
 		$display      = $this->context->get( 'event_display_mode', $this->slug );
 
-		if ( $this->slug === $display || 'default' === $display ) {
+		if ( $this->slug === $display || 'default' === $display || $this instanceof $display ) {
 			$url = parent::next_url( $canonical );
 		} elseif ( $current_page > 1 ) {
 			$url = parent::prev_url( $canonical, [ Utils\View::get_past_event_display_key() => 'past' ] );
@@ -189,15 +189,6 @@ class List_View extends View {
 		] ) ) );
 
 		$upcoming->order_by( '__none' );
-
-		/**
-		 * Check whether the Main Events Page is set as the homepage.
-		 * 
-		 * @since TBD
-		 */
-		if ( ! tribe_is_events_front_page() ) {
-			$page = 2;
-		}
 
 		if ( $upcoming->count() > 0 ) {
 			$query_args = [


### PR DESCRIPTION
Instead of some suspicious logic in the `get_upcoming_url` function, let's add a sanity check to the `display` check in `next_url`

Ref: https://github.com/the-events-calendar/the-events-calendar/pull/3873