### PR TITLE
Add custom logic for multisite 

### DIFF
--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -228,7 +228,13 @@ $display_tab_fields = Tribe__Main::array_insert_before_key(
 	$styling_array
 );
 
-if ( tribe( 'tec.main' )->show_upgrade() ) {
+if (
+	tribe( 'tec.main' )->show_upgrade()
+	|| (
+		is_multisite()
+		&& current_user_can( 'customize' )
+	)
+	) {
 	$display_tab_fields = Tribe__Main::array_insert_before_key(
 		'tribeEventsDateFormatSettingsTitle',
 		$display_tab_fields,


### PR DESCRIPTION
to allow sub-site admins to use the "Use updated calendar designs" checkbox when they are not allowed to activate plugins.

FWIW - there are likely _other_ places this might be prudent 🤔 

[TEC-4382]