### PR TITLE
Iterative changes - fix hardcoded urls.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -230,6 +230,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Add a height to the subscribe to calendar export SVG icon on the single events page when using the `Skeleton Styles` to prevent it from taking over a huge portion of the page. [TEC-4399]
 * Fix - Remove link to Updates page from TEC Settings page. [TEC-4373]
 * Fix - Ensure Aggregator CSV imports continue to run when on an admin page. [TEC-4070]
+* Fix - Correct hardcoded admin urls used for Event Settings page(s). [ECP-1175]
 * Fix - Remove deprecated usage of `jQuery.attr( 'checked' )`
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--past-month` to past month dates in the month view to allow easy targetting. [TEC-3447]
 * Tweak - Add a unique CSS class i.e. `tribe-events-calendar-month__day--next-month` to future month dates in the month view to allow easy targetting. [TEC-3819]

--- a/src/Tribe/Admin/Notice/Full_Site_Editor.php
+++ b/src/Tribe/Admin/Notice/Full_Site_Editor.php
@@ -40,6 +40,7 @@ class Full_Site_Editor {
 			'tribe_events_page_tribe-app-shop', // App shop.
 			'events_page_tribe-app-shop', // App shop.
 			'tribe_events_page_tribe-common', // Settings & Welcome.
+			'tribe_events_page_tec-events-settings', // New Settings & Welcome.
 			'events_page_tribe-common', // Settings & Welcome.
 			'toplevel_page_tribe-common', // Settings & Welcome.
 		];

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -299,12 +299,20 @@ class Settings {
 		$current_page = is_network_admin() ? network_admin_url( 'settings.php' ) : admin_url( 'edit.php' );
 		$url          = add_query_arg(
 			[
-				'post_type' => Plugin::POSTTYPE,
 				'page'      => $page,
 				'tab'       => $tab,
 			],
 			$current_page
 		);
+
+		if ( ! is_network_admin() ) {
+			$url = add_query_arg(
+				[
+					'post_type' => Plugin::POSTTYPE,
+				],
+				$url
+			);
+		}
 
 		return $url;
 	}

--- a/src/Tribe/Aggregator/Settings.php
+++ b/src/Tribe/Aggregator/Settings.php
@@ -44,7 +44,7 @@ class Tribe__Events__Aggregator__Settings {
 	 * @param WP_Screen $screen
 	 */
 	public function maybe_clear_eb_credentials( $screen ) {
-		if ( 'tribe_events_page_tribe-common' !== $screen->base ) {
+		if ( 'tribe_events_page_tribe-common' !== $screen->base && 'tribe_events_page_tec-events-settings' !== $screen->base  ) {
 			return;
 		}
 
@@ -187,7 +187,7 @@ class Tribe__Events__Aggregator__Settings {
 	 * @param WP_Screen $screen The current screen instance.
 	 */
 	public function maybe_clear_meetup_credentials( $screen ) {
-		if ( 'tribe_events_page_tribe-common' !== $screen->base ) {
+		if ( 'tribe_events_page_tribe-common' !== $screen->base && 'tribe_events_page_tec-events-settings' !== $screen->base ) {
 			return;
 		}
 
@@ -750,7 +750,7 @@ class Tribe__Events__Aggregator__Settings {
 	public function maybe_clear_fb_credentials( $screen ) {
 		_deprecated_function( __FUNCTION__, '4.6.23', 'Importing from Facebook is no longer supported in Event Aggregator.' );
 
-		if ( 'tribe_events_page_tribe-common' !== $screen->base ) {
+		if ( 'tribe_events_page_tribe-common' !== $screen->base && 'tribe_events_page_tec-events-settings' !== $screen->base ) {
 			return;
 		}
 

--- a/src/Tribe/Views/V2/Customizer/Notice.php
+++ b/src/Tribe/Views/V2/Customizer/Notice.php
@@ -56,6 +56,7 @@ class Notice {
 			'tribe_events_page_tribe-app-shop', // App shop.
 			'events_page_tribe-app-shop', // App shop.
 			'tribe_events_page_tribe-common', // Settings & Welcome.
+			'tribe_events_page_tec-events-settings', // New Settings & Welcome.
 			'events_page_tribe-common', // Settings & Welcome.
 			'toplevel_page_tribe-common', // Settings & Welcome.
 		];


### PR DESCRIPTION
Tickets Menu changed the admin URLs from `'tribe_events_page_tribe-common'` to `'tribe_events_page_tec-events-settings'`

This is just clean-up for places those URLs were hardcoded that were missed in that release.

ALso fixes some issues with network admin URLs - same cause.

Next iteration: create functions for all this.

[TEC-4405]

[ECP-1175](https://theeventscalendar.atlassian.net/browse/ECP-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Requires: https://github.com/the-events-calendar/tribe-common/pull/1770

[TEC-4405]: https://theeventscalendar.atlassian.net/browse/TEC-4405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ