### PR TITLE
Date formatting critical error fix.

### DIFF
--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -599,8 +599,8 @@ abstract class By_Day_View extends View {
 					$cache_key             = $event . '_' . $week_start . '_week';
 					$happens_this_week     = true;
 					$event_obj             = tribe_get_event( $event );
-					$event_start           = $event_obj->dates->start_display->format( Dates::DBDATEFORMAT );
-					$event_end             = $event_obj->dates->end_display->format( Dates::DBDATEFORMAT );
+					$event_start           = $event_obj->dates->start_display ? $event_obj->dates->start_display->format( Dates::DBDATEFORMAT ) : "";
+					$event_end             = $event_obj->dates->end_display ? $event_obj->dates->end_display->format( Dates::DBDATEFORMAT ) : "";
 					$starts_this_week      = $occurrences['first'][ $event ] >= $week_start && $event_start >= $week_start;
 					$ends_this_week        = $occurrences['last'][ $event ] <= $week_end && $event_end <= $week_end;
 					$displays_on[ $event ] = [];


### PR DESCRIPTION
On some of the WordPress sites that use this plugin, it throws a critical error due to not checking the nullability of the date object.

With this fix, we are checking if the date is set and, if not, returning an empty string.