### PR TITLE
Task/change upgrade button text

### DIFF
--- a/src/admin-views/notices/update-6-0-0.php
+++ b/src/admin-views/notices/update-6-0-0.php
@@ -20,7 +20,7 @@
     </div>
     <div class="tec-update-notice__actions">
         <a class="tec-update-notice__button button" href="<?php echo esc_url( get_admin_url( null, $upgrade_link ) ); ?>">
-            <?php esc_html_e( 'Migrate your site', 'the-events-calendar' ); ?>
+            <?php esc_html_e( 'Upgrade your events', 'the-events-calendar' ); ?>
         </a>
         <a class="tec-update-notice__link" href="<?php echo esc_url( $learn_link ); ?>">
             <?php esc_html_e( 'Learn more', 'the-events-calendar' ); ?>


### PR DESCRIPTION
[ECP-1160]

The work in this PR updates the text of the button in the "upgrade" notice. 

Button with new text:
<img width="567" alt="Screen Shot 2022-06-29 at 12 14 50 PM" src="https://user-images.githubusercontent.com/1430876/176496983-2fc5209e-a3cd-4ddd-b9a0-c84f8885862f.png">



[ECP-1160]: https://theeventscalendar.atlassian.net/browse/ECP-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ