### PR TITLE
V2 Styling > Month view: add CSS selector tribe-events-othermonth. [TEC-4034]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -226,6 +226,7 @@ Remember to always make a backup of your database and files before updating!
 == [TBD] TBD ==
 
 * Tweak - Add edit links to single venue and organizer pages to improve user experience. [ECP-1181]
+* Tweak - Add a CSS class i.e. `tribe-events-othermonth` to past and future month dates in the month view to allow easy targeting similar to what we had in v1. [TEC-4034]
 
 == [5.16.2] 2022-07-06 ==
 

--- a/src/views/v2/month/calendar-body/day.php
+++ b/src/views/v2/month/calendar-body/day.php
@@ -53,7 +53,7 @@ if ( $today_date > $day_date ) {
  * @since 5.16.2
  */
 if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
-	$day_classes[] = 'tribe-events-calendar-month__day--past-month tribe-events-othermonth';
+	$day_classes[] = 'tribe-events-calendar-month__day--past-month';
 }
 
 /**
@@ -62,7 +62,7 @@ if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
  * @since 5.16.2
  */
 if ( $day[ 'month_number' ] > date( 'm', strtotime( $today_date ) ) ) {
-	$day_classes[] = 'tribe-events-calendar-month__day--next-month tribe-events-othermonth';
+	$day_classes[] = 'tribe-events-calendar-month__day--next-month';
 }
 
 /**

--- a/src/views/v2/month/calendar-body/day.php
+++ b/src/views/v2/month/calendar-body/day.php
@@ -53,7 +53,7 @@ if ( $today_date > $day_date ) {
  * @since 5.16.2
  */
 if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
-	$day_classes[] = 'tribe-events-calendar-month__day--past-month';
+	$day_classes[] = 'tribe-events-calendar-month__day--past-month tribe-events-othermonth';
 }
 
 /**
@@ -62,7 +62,7 @@ if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
  * @since 5.16.2
  */
 if ( $day[ 'month_number' ] > date( 'm', strtotime( $today_date ) ) ) {
-	$day_classes[] = 'tribe-events-calendar-month__day--next-month';
+	$day_classes[] = 'tribe-events-calendar-month__day--next-month tribe-events-othermonth';
 }
 ?>
 

--- a/src/views/v2/month/calendar-body/day.php
+++ b/src/views/v2/month/calendar-body/day.php
@@ -64,6 +64,15 @@ if ( $day[ 'month_number' ] < date( 'm', strtotime( $today_date ) ) ) {
 if ( $day[ 'month_number' ] > date( 'm', strtotime( $today_date ) ) ) {
 	$day_classes[] = 'tribe-events-calendar-month__day--next-month tribe-events-othermonth';
 }
+
+/**
+ * Add a unique CSS class to any date that is not in the current month.
+ * 
+ * @since TBD
+ */
+if ( $day[ 'month_number' ] !== date( 'm', strtotime( $today_date ) ) ) {
+	$day_classes[] = 'tribe-events-calendar-month__day--other-month';
+}
 ?>
 
 <div

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Calendar_BodyTest__test_static_render__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Calendar_BodyTest__test_static_render__1.php
@@ -7,7 +7,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -57,7 +57,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -107,7 +107,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--current" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--current tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-03"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -157,7 +157,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-04"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -207,7 +207,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-05"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -257,7 +257,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-06"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -307,7 +307,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-07"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -363,7 +363,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-08"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -413,7 +413,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-09"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -463,7 +463,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-10"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -513,7 +513,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-11"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -563,7 +563,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-12"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -613,7 +613,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-13"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -663,7 +663,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-14"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -719,7 +719,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-15"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -769,7 +769,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-16"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -819,7 +819,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-17"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -869,7 +869,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-18"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -919,7 +919,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-19"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -969,7 +969,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-20"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1019,7 +1019,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-21"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1075,7 +1075,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-22"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1125,7 +1125,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-23"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1175,7 +1175,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-24"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1225,7 +1225,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-25"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1275,7 +1275,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-26"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1325,7 +1325,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-27"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1375,7 +1375,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-28"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1431,7 +1431,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-29"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1481,7 +1481,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-30"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1531,7 +1531,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-07-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1581,7 +1581,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1631,7 +1631,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1681,7 +1681,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-03"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1731,7 +1731,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-04"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Calendar_BodyTest__test_static_render__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Month_View/__snapshots__/Calendar_BodyTest__test_static_render__1.php
@@ -1581,7 +1581,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1631,7 +1631,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1681,7 +1681,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-03"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1731,7 +1731,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-08-04"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
@@ -371,7 +371,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1995,7 +1995,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2045,7 +2045,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2095,7 +2095,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
@@ -371,7 +371,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -1995,7 +1995,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2045,7 +2045,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2095,7 +2095,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -362,7 +362,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2176,7 +2176,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2226,7 +2226,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2276,7 +2276,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -362,7 +362,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2176,7 +2176,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2226,7 +2226,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2276,7 +2276,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
@@ -362,7 +362,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2158,7 +2158,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2208,7 +2208,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2258,7 +2258,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
@@ -362,7 +362,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2158,7 +2158,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2208,7 +2208,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2258,7 +2258,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
@@ -384,7 +384,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2180,7 +2180,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2230,7 +2230,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2280,7 +2280,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
@@ -384,7 +384,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--past tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2018-12-31"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2180,7 +2180,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-01"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2230,7 +2230,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-02"
 	data-js="tribe-events-month-grid-cell"
 >
@@ -2280,7 +2280,7 @@
 			
 				
 <div
-	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-othermonth" 	role="gridcell"
+	 class="tribe-events-calendar-month__day tribe-events-calendar-month__day--next-month tribe-events-calendar-month__day--other-month" 	role="gridcell"
 	aria-labelledby="tribe-events-calendar-day-2019-02-03"
 	data-js="tribe-events-month-grid-cell"
 >


### PR DESCRIPTION
Add a CSS class i.e. `tribe-events-othermonth` to past and future month dates in the month view to allow easy targeting similar to what we had in v1. 

https://theeventscalendar.atlassian.net/browse/TEC-4034

![image](https://user-images.githubusercontent.com/22029087/177969159-1a068506-5841-4df5-b60e-875247024f59.png)
