### PR TITLE
Theme based CSS class [TEC-4391]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 == [TBD] TBD ==
 
+* Fix - Add a theme based CSS class to the HTML body tag when the `Default Page Template` setting is enabled under Events > Settings > Display. [TEC-4391]
 * Tweak - Add edit links to single venue and organizer pages to improve user experience. [ECP-1181]
 * Tweak - Add a CSS class i.e. `tribe-events-calendar-month__day--other-month` to past and future month dates in the month view to allow easy targeting similar to what we had in v1. [TEC-4034]
 

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -408,13 +408,13 @@ class Template_Bootstrap {
 	 */
 	public function filter_add_body_classes( $classes ) {
 		$setting  = $this->get_template_setting();
-		$template = $this->get_template_object()->get_path();
+		$active_theme = wp_get_theme();
 
 		if ( 'page' !== $setting ) {
 			return $classes;
 		}
 
-		$classes[] = 'page-template-' . sanitize_title( $template );
+		$classes[] = 'page-template-' . sanitize_title( $active_theme );
 
 		if ( ! get_queried_object() instanceof \WP_Term ) {
 			$key = array_search( 'archive', $classes, true );

--- a/src/resources/postcss/tribe-events-full.pcss
+++ b/src/resources/postcss/tribe-events-full.pcss
@@ -2380,7 +2380,7 @@ input[name*='tribe-bar-']:-moz-placeholder {
 	}
 
 	/* Ensure full-width calendar if Main Events Page is site homepage. */
-	&.page-template-page-php.blog:not(.has-sidebar) {
+	&.page-template-twenty-seventeen.blog:not(.has-sidebar) {
 		#primary article {
 			width: 100%;
 		}


### PR DESCRIPTION
Add a theme based CSS class to the HTML body tag when the `Default Page Template` setting is enabled under Events > Settings > Display. e.g. the CSS class would be `page-template-twenty-twenty-one` if the active theme is Twenty Twenty One.

https://theeventscalendar.atlassian.net/browse/TEC-4391

![image](https://user-images.githubusercontent.com/22029087/178509152-9fb1dd4d-d838-417d-8a52-cff85e575df9.png)
