### PR TITLE
Update page content tweaks

### DIFF
--- a/src/Tribe/Admin/Notice/Update.php
+++ b/src/Tribe/Admin/Notice/Update.php
@@ -126,7 +126,7 @@ class Update {
 	 */
 	private function get_template_data() {
 		$data = [
-			'title' 		=>	esc_html__( 'One more thing left to do...', 'the-events-calendar' ),
+			'title' 		=>	esc_html__( '⚠️ One more thing left to do...', 'the-events-calendar' ),
 			'description' 	=> 	esc_html__( 'To complete this major calendar upgrade, you need to migrate your events to the new data storage system. Once migration finishes, you can take advantage of all the cool new 6.0 features!', 'the-events-calendar' ),
 			'upgrade_link' 	=> 	'edit.php?post_type=tribe_events&page=tec-events-settings&tab=upgrade',
 			'learn_link' 	=> 	'https://evnt.is/1b79',

--- a/src/Tribe/Admin/Notice/Update.php
+++ b/src/Tribe/Admin/Notice/Update.php
@@ -37,7 +37,7 @@ class Update {
 			[ $this, 'notice' ],
 			[
 				'dismiss' => 1,
-				'type'    => 'info',
+				'type'    => 'warning',
 				'wrap'    => false,
 				'recurring' => true,
 				'recurring_interval' => 'P1M'

--- a/src/admin-views/updates/6.0.0.php
+++ b/src/admin-views/updates/6.0.0.php
@@ -37,8 +37,11 @@ $common_main = Tribe__Main::instance();
 			</div>
 
 			<div class="tec-update-page-grid__item">
-				<p><?php esc_html_e( "We’re excited to bring all of our users faster event creation and editing in the WordPress dashboard as well as quicker loading times for your website’s calendar. Watch the video or check out the release notes to learn more." ); ?></p>
-				<p><?php esc_html_e( 'Be sure to migrate to the new data storage system so you can take advantage of the improved performance.', 'the-events-calendar' ); ?></p>
+				<p>
+					<?php esc_html_e( "We’re excited to bring all of our users faster event creation and editing in the WordPress dashboard as well as quicker loading times for your website’s calendar." ); ?>
+					<?php printf( wp_kses( __( 'Watch the video or check out the <a href="%s">release notes</a> to learn more.', 'the-events-calendar' ), [ 'a' => [ 'href' => [] ] ] ), esc_url( 'https://theeventscalendar.com/category/release-notes/' ) ); ?>
+				</p>
+				<p><?php printf( wp_kses( __( 'Be sure to <a href="%s">migrate</a> to the new data storage system so you can take advantage of the improved performance.', 'the-events-calendar' ), [ 'a' => [ 'href' => [] ] ] ), esc_url( 'https://evnt.is/1b79' ) ); ?></p>
 			</div>
 	</div>
 
@@ -48,6 +51,7 @@ $common_main = Tribe__Main::instance();
 			<div class="tec-update-page-grid__item">
 				<p><?php esc_html_e( 'A game-changing ✨new✨ post type, Series, allows you to group and display any single or recurring events together like never before.', 'the-events-calendar' ); ?></p>
 				<p><?php esc_html_e( 'With Series, you can edit an individual occurrence of a recurring event without disconnecting it from the others, allowing you to build complex event Series with different venues, images, and more.', 'the-events-calendar' ); ?></p>
+				<p class="tec-update-page__row"><a href="https://evnt.is/1b94"><?php esc_html_e( 'Learn more', 'the-events-calendar' ); ?></a> <a href="https://evnt.is/1b95"><?php esc_html_e( 'Watch a video', 'the-events-calendar' ); ?></a> <a href="https://evnt.is/1b96"><?php esc_html_e( 'See a demo', 'the-events-calendar' ); ?></a></p>
 			</div>
 
 			<div class="tec-update-page-grid__item">

--- a/src/resources/js/tec-update-6.0.0-notice.js
+++ b/src/resources/js/tec-update-6.0.0-notice.js
@@ -4,7 +4,7 @@
 
     wp.data.dispatch( 'core/notices' )
         .createNotice(
-            'info', 
+            'warning', 
             '<b>' +  data.title + '</b><p>' + data.description + '</p>', 
             { 
                 __unstableHTML: true, 

--- a/src/resources/postcss/admin-update-page.pcss
+++ b/src/resources/postcss/admin-update-page.pcss
@@ -61,7 +61,7 @@ body.tribe-update {
 	.tec-update-notice {
 		background: #ffffff;
 		border: 1px solid #cccccc;
-		border-left: 6px solid #3352F5;
+		border-left: 6px solid #dba617;
 		border-radius: 4px;
 		padding: 12px 32px;
 	}
@@ -69,14 +69,6 @@ body.tribe-update {
 	.tec-update-notice__link {
 		font-size: inherit;
 	}
-}
-
-/* utility class for box styles */
-.tec-update-page-box {
-	background: white;
-	border: 1px solid #cccccc;
-	border-radius: 8px;
-	padding: 32px;
 }
 
 /* Page intro */
@@ -137,6 +129,11 @@ body.tribe-update {
 	}
 }
 
+.tec-update-page__row {
+	display: flex;
+	gap: 24px;
+}
+
 /* Upgrade message section */
 .tec-update-page-upgrade-notice {
 	display: flex;
@@ -189,5 +186,18 @@ body.tribe-update {
 				margin-right: 12px;
 			}
 		}
+	}
+}
+
+/* utility class for box styles */
+.tec-update-page-box {
+	background: white;
+	border: 1px solid #cccccc;
+	border-radius: 8px;
+	padding: 32px;
+
+	h3 {
+		font-size: 1.5rem;
+		margin-top: 0;
 	}
 }

--- a/src/resources/postcss/events-admin.pcss
+++ b/src/resources/postcss/events-admin.pcss
@@ -790,13 +790,7 @@ table.eventForm {
 	}
 }
 
-
 /* Update Notice */
-
-.notice.tribe-notice-update-6-0 {
-	border-left-color: #3352f5;
-	padding-left: 20px;
-}
 
 h3.tec-update-notice__title {
 	font-size: 20px;


### PR DESCRIPTION
[ECP-1192]

The work in this PR addresses some content changes in the updates page and related notice. 

<img width="1133" alt="Screen Shot 2022-07-13 at 8 55 01 AM" src="https://user-images.githubusercontent.com/1430876/178751924-95e30bca-6a44-4d55-bf88-5ddfd6cc92fc.png">
<img width="1135" alt="Screen Shot 2022-07-13 at 8 54 49 AM" src="https://user-images.githubusercontent.com/1430876/178751943-dc9bdcb3-0b5c-43c9-9f1c-15bc628c7006.png">
<img width="1133" alt="Screen Shot 2022-07-13 at 8 54 39 AM" src="https://user-images.githubusercontent.com/1430876/178751966-5dc04521-0666-4fd4-91ba-eb1b59cf8622.png">



[ECP-1192]: https://theeventscalendar.atlassian.net/browse/ECP-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ