### PR TITLE
Load stylesheet on Elementor preview page. [ECP-1196]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Remember to always make a backup of your database and files before updating!
 
 == [TBD] TBD ==
 
+* Fix - Ensure the recurring event tooltip styles are loaded on the Elementor preview page for the `Event Widget`. [ECP-1196]
 * Fix - Add a theme based CSS class to the HTML body tag when the `Default Page Template` setting is enabled under Events > Settings > Display. [TEC-4391]
 * Tweak - Add edit links to single venue and organizer pages to improve user experience. [ECP-1181]
 * Tweak - Add a CSS class i.e. `tribe-events-calendar-month__day--other-month` to past and future month dates in the month view to allow easy targeting similar to what we had in v1. [TEC-4034]

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -626,6 +626,23 @@ class Assets extends \tad_DI52_ServiceProvider {
 			return false;
 		}
 
+		/**
+		 * Checks whether the page is being viewed in Elementor preview mode.
+		 *
+		 * @since TBD
+		 *
+		 * @return bool Should the assets be enqueued.
+		 */
+		if (
+			defined( 'ELEMENTOR_PATH' )
+
+			&& ! empty( ELEMENTOR_PATH )
+
+			&& isset( $_GET[ 'elementor-preview' ] )
+		) {
+			return true;
+		}
+
 		// Bail if not Single Event.
 		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
 			return false;

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -635,9 +635,7 @@ class Assets extends \tad_DI52_ServiceProvider {
 		 */
 		if (
 			defined( 'ELEMENTOR_PATH' )
-
 			&& ! empty( ELEMENTOR_PATH )
-
 			&& isset( $_GET[ 'elementor-preview' ] )
 		) {
 			return true;


### PR DESCRIPTION
Ensure the recurring event tooltip styles are loaded on the Elementor preview page for the `Event Widget`.

Depends on : https://github.com/the-events-calendar/events-pro/pull/1974

https://theeventscalendar.atlassian.net/browse/ECP-1196