### PR TITLE
Add a filter to ensure we use the correct date.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [5.16.4] TBD =
+
+* Fix - Ensure date formats are escaped on properly when they contain slashes. [ECP-1136]
+
 = [5.16.3.1] 2022-07-21 =
 
 * Fix - Update Freemius to avoid PHP 8 fatals. [TEC-4330]

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -170,6 +170,8 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_ical_template_event_ids', [ $this, 'inject_ical_event_ids' ] );
 
 		add_filter( 'tec_events_query_default_view', [ $this, 'filter_tec_events_query_default_view' ] );
+
+		add_filter( 'tribe_events_views_v2_rest_params', [ $this, 'filter_url_date_conflicts'], 12, 2 );
 	}
 
 	/**
@@ -1113,5 +1115,15 @@ class Hooks extends \tad_DI52_ServiceProvider {
 			'Views V2 Status' => tribe_events_views_v2_is_enabled() ? esc_html__( 'Enabled', 'the-events-calendar' ) : esc_html__( 'Disabled', 'the-events-calendar' ),
 		];
 		return \Tribe__Main::array_insert_before_key( 'Settings', $info, $views_v2_status );
+	}
+
+	public function filter_url_date_conflicts( $params, $request ) {
+		if ( ! isset( $params['tribe-bar-date'] ) || ! isset( $params[ 'eventDate'] ) ) {
+			return $params;
+		}
+
+		$params[ 'eventDate'] = $params['tribe-bar-date'];
+
+		return $params;
 	}
 }

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -138,6 +138,8 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_filter( 'tribe_get_option', [ $this, 'filter_live_filters_option_value' ], 10, 2 );
 		add_filter( 'tribe_field_value', [ $this, 'filter_live_filters_option_value' ], 10, 2 );
 
+		add_filter( 'tribe_get_option', [ $this, 'filter_date_escaping' ], 10, 2 );
+
 		if ( tribe_context()->doing_php_initial_state() ) {
 			add_filter( 'tribe_events_filter_views_v2_wp_title_plural_events_label', [ $this, 'filter_wp_title_plural_events_label' ], 10, 2 );
 			add_filter( 'wp_title', [ $this, 'filter_wp_title' ], 10, 2 );
@@ -871,6 +873,25 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		$return_value = apply_filters( 'tribe_events_option_convert_live_filters', $return_value, $value );
 
 		return $return_value;
+	}
+
+	public function filter_date_escaping( $value, $optionName ) {
+		// A list of date options we may need to unescape.
+		$date_options = [
+			'dateWithoutYearFormat',
+			'monthAndYearFormat',
+		];
+
+		if ( ! in_array( $optionName, $date_options ) ) {
+			return $value;
+		}
+
+		// Note: backslash is hte escape character - so we need to escape it.
+		// This is the equivalent of replacing any occurrence of \\ with \
+		$value = str_replace( "\\\\", "\\", $value);
+		//$value = stripslashes( $value ); will strip out ones we want to keep!
+
+		return $value;
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -875,6 +875,17 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		return $return_value;
 	}
 
+	/**
+	 * Ensures that date formats are escaped properly.
+	 * Converts "\\" to "\"  for escaped characters.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value      The current value of the option.
+	 * @param string $optionName The option "key"
+	 *
+	 * @return mixed  $value     The modified value of the option.
+	 */
 	public function filter_date_escaping( $value, $optionName ) {
 		// A list of date options we may need to unescape.
 		$date_options = [
@@ -883,6 +894,11 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		];
 
 		if ( ! in_array( $optionName, $date_options ) ) {
+			return $value;
+		}
+
+		// Don't try to run string modification on an array or something.
+		if ( ! is_string( $value ) ) {
 			return $value;
 		}
 
@@ -1138,6 +1154,17 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		return \Tribe__Main::array_insert_before_key( 'Settings', $info, $views_v2_status );
 	}
 
+	/**
+	 * Ensure we use the correct date on shortcodes.
+	 * If both `tribe-bar-date` and `eventDate` are present, `tribe-bar-date` overrides `eventDate`.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $params An associative array of parameters from the REST request.
+	 * @param \WP_REST_Request $request The current REST request.
+	 *
+	 * @return array $params A modified array of parameters from the REST request.
+	 */
 	public function filter_url_date_conflicts( $params, $request ) {
 		if ( ! isset( $params['tribe-bar-date'] ) || ! isset( $params[ 'eventDate'] ) ) {
 			return $params;


### PR DESCRIPTION
The Day and Week View shortcodes will get two dates like so:
https://dev.tec/events/week/2022-08-01/?shortcode=a8a52185&hide_subsequent_recurrences=1&tribe-bar-date=2022-08-08

and utilize the first one rather than the second.

This adds a filter so that if both tribe-bar-date and eventDate are present, the former overrides the latter.

Also addresses ECP-1195 where backslashes were not getting unescaped properly and breaking the date formats.

[ECP-1136]
[ECP-1195]

[ECP-1136]: https://theeventscalendar.atlassian.net/browse/ECP-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ECP-1195]: https://theeventscalendar.atlassian.net/browse/ECP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ