### PR TITLE
fix(CT1) update earliest/latest markers correctly

### DIFF
--- a/src/Events/Custom_Tables/V1/Updates/Events.php
+++ b/src/Events/Custom_Tables/V1/Updates/Events.php
@@ -135,6 +135,10 @@ class Events {
 	public function rebuild_known_range() {
 		tribe_update_option( 'earliest_date', $this->get_earliest_date()->format( Dates::DBDATETIMEFORMAT ) );
 		tribe_update_option( 'latest_date', $this->get_latest_date()->format( Dates::DBDATETIMEFORMAT ) );
+		$earliest = Occurrence::order_by( 'start_date_utc', 'ASC' )->first();
+		$latest = Occurrence::order_by( 'end_date_utc', 'DESC' )->first();
+		tribe_update_option( 'earliest_date_markers', $earliest instanceof Occurrence ? [ $earliest->provisional_id ] : [] );
+		tribe_update_option( 'latest_date_markers', $latest instanceof Occurrence ? [ $latest->provisional_id ] : [] );
 
 		return true;
 	}


### PR DESCRIPTION
When an Event is updated or created, then TEC will update the earliest
and latest dates and date markers.
The markers are the post IDs of the Events that should be used as
"signposts", the CT1 one code was not updating those creating an issue
where Views, like the Week one, would find those signposts empty and
would not set up navigation correctly.
