### PR TITLE
Adding post type to query filter.

### DIFF
--- a/src/Tribe/Front_Page_View.php
+++ b/src/Tribe/Front_Page_View.php
@@ -68,8 +68,9 @@ class Tribe__Events__Front_Page_View {
 		$query->set( 'tribe_events_front_page', true );
 
 		// Some extra tricks required to help avoid problems when the default view is list view
-		$query->is_page = false;
-		$query->is_singular = false;
+		$query->is_page            = false;
+		$query->is_singular        = false;
+		$query->query['post_type'] = Tribe__Events__Main::POSTTYPE;
 	}
 
 	/**


### PR DESCRIPTION
RBE issue 399.

This is a fix for notice errors displaying on the home page when the main events page is set as the static page for home.

The page object was not being fetched properly. Now it loads the TEC post type.