### PR TITLE
Add an `is_now` property to events.

### DIFF
--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -173,6 +173,14 @@ class Event extends Base {
 			$end_site           = $end_date_object->setTimezone( $site_timezone );
 			$use_event_timezone = Timezones::is_mode( Timezones::EVENT_TIMEZONE );
 
+			// Determine if current datetime is between event start and end dates.
+			$is_now             = Dates::range_coincides(
+				$now->format( 'U' ),
+				$now->add( $one_second )->format( 'U' ),
+				$start_date_utc_object->format( 'U' ),
+				$end_date_utc_object->format( 'U' )
+			);
+
 			$properties = [
 				'start_date'             => $start_date,
 				'start_date_utc'         => $start_date_utc,
@@ -192,6 +200,7 @@ class Event extends Base {
 				'duration'               => $duration,
 				'multiday'               => $multiday,
 				'is_past'                => $start_date_object < $now,
+				'is_now'                 => $is_now,
 				'all_day'                => $all_day,
 				'starts_this_week'       => $starts_this_week,
 				'ends_this_week'         => $ends_this_week,

--- a/src/functions/template-tags/event.php
+++ b/src/functions/template-tags/event.php
@@ -175,7 +175,7 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			 */
 			$post = apply_filters( 'tribe_get_event', $post, $output, $filter );
 
-			// Dont try to reset cache when forcing.
+			// Don't try to reset cache when forcing.
 			if ( ! $force ) {
 				$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 			}


### PR DESCRIPTION
This allows checking the event against the current time easily via `$event->is_now`
to allow for things like this filter:
https://d.pr/i/C0QXFH
https://d.pr/i/QnmxPP

This is from a conversation in Slack: https://lw.slack.com/archives/C01SYM19N7K/p1660147997503949