### PR TITLE
Updating some test methods to properly be declared as static

### DIFF
--- a/tests/views_integration/Tribe/Events/Views/V2/ManagerTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ManagerTest.php
@@ -19,7 +19,7 @@ class ManagerTest extends \Codeception\TestCase\WPTestCase {
 		static::factory()->event = new Event();
 	}
 
-	public function wpSetUpBeforeClass() {
+	public static function wpSetUpBeforeClass() {
 		static::factory()->event = new Event();
 	}
 

--- a/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
@@ -247,7 +247,7 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( '', $page_1_view->prev_url() );
 	}
 
-	public function wpSetUpBeforeClass() {
+	public static function wpSetUpBeforeClass() {
 		static::factory()->event = new Event();
 	}
 

--- a/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/View_RegisterTest.php
@@ -40,7 +40,7 @@ class View_RegisterTest extends \Codeception\TestCase\WPTestCase {
 		static::factory()->event = new Event();
 	}
 
-	public function wpSetUpBeforeClass() {
+	public static function wpSetUpBeforeClass() {
 		static::factory()->event = new Event();
 		// Let's backup the query vars to make sure we're using the full ones.
 		global $wp, $wp_rewrite;


### PR DESCRIPTION
This resolves some PHP 7.3 compatibility issues with methods being called statically when they weren't being declared as such.

I'm PR-ing this against `release/B22.royal` on purpose.