### PR TITLE
Ensure the kb help links only appear on the CSV screen. [TEC-4353]

### DIFF
--- a/src/admin-views/aggregator/origins/csv.php
+++ b/src/admin-views/aggregator/origins/csv.php
@@ -11,6 +11,7 @@ $field->source      = 'csv_content_type';
 
 $csv_record = Tribe__Events__Aggregator__Records::instance()->get_by_origin( 'csv' );
 $post_types = $csv_record->get_import_post_types();
+$main       = Tribe__Events__Main::instance();
 ?>
 <tr class="tribe-dependent" data-depends="#tribe-ea-field-origin" data-condition="csv">
 	<th scope="row">
@@ -77,3 +78,25 @@ $field->media_title = __( 'Upload a CSV File', 'the-events-calendar' );
 		</button>
 	</td>
 </tr>
+
+<div class="tec-admin-ea-help-message" data-depends="#tribe-ea-field-origin" data-condition-not-empty data-condition-relation="and" data-condition-not='["url","eventbrite", "gcal", "ics", "ical", "meetup", "url"]'>
+	<?php esc_html_e( 'Need assistance? You can find more information here:', 'the-events-calendar' ); ?>
+
+	<img
+		class="tec-admin-ea-help-message__icon"
+		src="<?php echo esc_url( tribe_resource_url( 'images/icons/tec-horns.svg', false, null, $main ) ); ?>"
+		alt="<?php esc_attr_e( 'The Events Calendar logo', 'the-events-calendar' ); ?>"
+	/>
+	<a href="https://evnt.is/1bam" target="_blank" rel="noopener noreferrer">
+		<?php esc_html_e( 'Importing Calendar Data From a CSV File', 'the-events-calendar' ); ?>
+	</a>
+
+	<img
+		class="tec-admin-ea-help-message__icon"
+		src="<?php echo esc_url( tribe_resource_url( 'images/icons/tec-horns.svg', false, null, $main ) ); ?>"
+		alt="<?php esc_attr_e( 'The Events Calendar logo', 'the-events-calendar' ); ?>"
+	/>
+	<a href="https://evnt.is/1ban" target="_blank" rel="noopener noreferrer">
+		<?php esc_html_e( 'CSV File Formatting and Examples ', 'the-events-calendar' ); ?>
+	</a>
+</div>

--- a/src/admin-views/aggregator/origins/limit.php
+++ b/src/admin-views/aggregator/origins/limit.php
@@ -37,31 +37,8 @@ if ( 'range' === $global_limit_type ) {
 
 $import_limit_link    = esc_url( tribe( Plugin_Settings::class )->get_url( [ 'tab' => 'imports#tribe-field-tribe_aggregator_default_import_limit_type' ] ) );
 $import_limit_message = $global_limit_message . ' ' . sprintf( '<a href="%s" target="_blank">%s</a> ', $import_limit_link, esc_html__( 'you can modify this setting here.', 'the-events-calendar' ) );
-$main = Tribe__Events__Main::instance();
 ?>
 
 <div class="tribe-dependent" data-depends="#tribe-ea-field-origin" data-condition-not-empty data-condition-relation="and" data-condition-not='["url","eventbrite"]'>
 	<p><?php echo $import_limit_message; ?></p>
-	
-	<div class="tec-admin-ea-help-message">
-		<?php esc_html_e( 'Need assistance? You can find more information here:', 'the-events-calendar' ); ?>
-
-		<img
-			class="tec-admin-ea-help-message__icon"
-			src="<?php echo esc_url( tribe_resource_url( 'images/icons/tec-horns.svg', false, null, $main ) ); ?>"
-			alt="<?php esc_attr_e( 'The Events Calendar logo', 'the-events-calendar' ); ?>"
-		/>
-		<a href="https://evnt.is/1bam" target="_blank" rel="noopener noreferrer">
-			<?php esc_html_e( 'Importing Calendar Data From a CSV File', 'the-events-calendar' ); ?>
-		</a>
-
-		<img
-			class="tec-admin-ea-help-message__icon"
-			src="<?php echo esc_url( tribe_resource_url( 'images/icons/tec-horns.svg', false, null, $main ) ); ?>"
-			alt="<?php esc_attr_e( 'The Events Calendar logo', 'the-events-calendar' ); ?>"
-		/>
-		<a href="https://evnt.is/1ban" target="_blank" rel="noopener noreferrer">
-			<?php esc_html_e( 'CSV File Formatting and Examples ', 'the-events-calendar' ); ?>
-		</a>
-	</div>
 </div>


### PR DESCRIPTION
Add some helpful knowledgebase article links to the CSV import screen.

This is a tweak to the work merged in this [PR](https://github.com/the-events-calendar/the-events-calendar/pull/3947).

https://theeventscalendar.atlassian.net/browse/TEC-4353

![image](https://user-images.githubusercontent.com/22029087/184338521-d4a404cd-cd3c-4a26-a716-31f3d7cca63d.png)
