### PR TITLE
Notify before/after Views container replacement

### DIFF
--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -27,6 +27,7 @@ use Tribe__Events__Rewrite as TEC_Rewrite;
 use Tribe__Events__Venue as Venue;
 use Tribe__Repository__Interface as Repository;
 use Tribe__Utils__Array as Arr;
+use WP_Post;
 
 /**
  * Class View
@@ -1469,8 +1470,8 @@ class View implements View_Interface {
 		 *
 		 * @since 6.0.0
 		 *
-		 * @param array $events Which events were just selected.
-		 * @param self  $view   Which view we are dealing with.
+		 * @param array<WP_Post> $events Which events were just selected.
+		 * @param self           $view   Which view we are dealing with.
 		 */
 		do_action( 'tec_events_views_v2_after_get_events', $events, $this );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -136,7 +136,8 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.2
 	 *
-	 * @todo  Requirement to setup other JS modules after hijacking Click and Submit
+	 * @todo  Requirement to setup other JS modules after hijacking Click and
+	 *     Submit
 	 *
 	 * @param  {Integer}        index     jQuery.each index param
 	 * @param  {Element|jQuery} container Which element we are going to setup
@@ -171,7 +172,8 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.2
 	 *
-	 * @param  {Element|jQuery} element Which element we getting the container from
+	 * @param  {Element|jQuery} element Which element we getting the container
+	 *     from
 	 *
 	 * @return {jQuery}
 	 */
@@ -212,7 +214,8 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.4
 	 *
-	 * @param  {Element|jQuery} $container Which element we are using as the container.
+	 * @param  {Element|jQuery} $container Which element we are using as the
+	 *     container.
 	 *
 	 * @return {Boolean}
 	 */
@@ -461,8 +464,8 @@ tribe.events.views.manager = {};
 	};
 
 	/**
-	 * Performs an AJAX request given the data for the REST API and which container
-	 * we are going to pass the answer to.
+	 * Performs an AJAX request given the data for the REST API and which
+	 * container we are going to pass the answer to.
 	 *
 	 * @since 4.9.2
 	 *
@@ -601,12 +604,31 @@ tribe.events.views.manager = {};
 		// Clean up the container and event listeners
 		obj.cleanup( $container );
 
+		/*
+		 * Dispatch an event before the container is replaced; bound events are
+		 * removed!
+		 */
+		document.dispatchEvent(
+				new CustomEvent(
+						'containerReplaceBefore.tribeEvents',
+						{ detail: $container },
+				),
+		);
+
 		// Replace the current container with the new Data.
 		$container.replaceWith( $html );
 		$container = $html;
 
 		// Setup the container with the data received.
 		obj.setup( 0, $container );
+
+		// Dispatch an event after the container is replaced and set up.
+		document.dispatchEvent(
+				new CustomEvent(
+						'containerReplaceAfter.tribeEvents',
+						{ detail: $container },
+				),
+		);
 
 		// Update the global set of containers with all of the manager object.
 		obj.selectContainers();
@@ -669,7 +691,8 @@ tribe.events.views.manager = {};
 	 */
 	obj.getLastContainer = function() {
 		/**
-		 * @todo @bordoni @paul improve this when shortcodes are also managing the URL.
+		 * @todo @bordoni @paul improve this when shortcodes are also managing the
+		 *     URL.
 		 */
 		if ( ! obj.$lastContainer.length ) {
 			obj.$lastContainer = obj.$containers.filter( '[data-view-manage-url="1"]' ).eq( 0 );

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -136,8 +136,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.2
 	 *
-	 * @todo  Requirement to setup other JS modules after hijacking Click and
-	 *     Submit
+	 * @todo  Requirement to setup other JS modules after hijacking Click and Submit
 	 *
 	 * @param  {Integer}        index     jQuery.each index param
 	 * @param  {Element|jQuery} container Which element we are going to setup
@@ -172,8 +171,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.2
 	 *
-	 * @param  {Element|jQuery} element Which element we getting the container
-	 *     from
+	 * @param  {Element|jQuery} element Which element we getting the container from
 	 *
 	 * @return {jQuery}
 	 */
@@ -214,8 +212,7 @@ tribe.events.views.manager = {};
 	 *
 	 * @since 4.9.4
 	 *
-	 * @param  {Element|jQuery} $container Which element we are using as the
-	 *     container.
+	 * @param  {Element|jQuery} $container Which element we are using as the container.
 	 *
 	 * @return {Boolean}
 	 */
@@ -464,8 +461,8 @@ tribe.events.views.manager = {};
 	};
 
 	/**
-	 * Performs an AJAX request given the data for the REST API and which
-	 * container we are going to pass the answer to.
+	 * Performs an AJAX request given the data for the REST API and which container
+	 * we are going to pass the answer to.
 	 *
 	 * @since 4.9.2
 	 *
@@ -691,8 +688,7 @@ tribe.events.views.manager = {};
 	 */
 	obj.getLastContainer = function() {
 		/**
-		 * @todo @bordoni @paul improve this when shortcodes are also managing the
-		 *     URL.
+		 * @todo @bordoni @paul improve this when shortcodes are also managing the URL.
 		 */
 		if ( ! obj.$lastContainer.length ) {
 			obj.$lastContainer = obj.$containers.filter( '[data-view-manage-url="1"]' ).eq( 0 );


### PR DESCRIPTION
Ticket: [ECP-1308](https://theeventscalendar.atlassian.net/browse/ECP-1308).

Required by [ECP PR](https://github.com/the-events-calendar/events-pro/pull/2037).

This PR updates the Views v2 manager code to make it dispatch native JS events when the container HTML is replaced using jQuery.

The jQuery `element.replaceWith` method will not only replace the element HTML, but **it will remove all bound event listeners**.

Dispatching a native event before and after the container HTML is replaced will allow listeners to gracefully unbind and re-bind events before and after the container is replaced.

Artifacts: [ECP PR Screencast](https://share.cleanshot.com/dJSrQL)
