### PR TITLE
Do not apply Events_Not_In_Scope modifier when ECP not active.

### DIFF
--- a/src/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Not_In_Series_Modifier.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Not_In_Series_Modifier.php
@@ -45,6 +45,11 @@ class Events_Not_In_Series_Modifier extends Base_Modifier {
 	 * {@inheritdoc}
 	 */
 	public function applies_to( WP_Query $query = null ) {
+
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			return false;
+		}
+
 		if ( empty( $query->query_vars[ self::POST_NOT_IN_SERIES ] ) ) {
 			return false;
 		}


### PR DESCRIPTION
[BTRIA-1332]

[BTRIA-1332]: https://theeventscalendar.atlassian.net/browse/BTRIA-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ