### PR TITLE
Fix ECP comparison string.

### DIFF
--- a/src/Events/Custom_Tables/V1/admin-views/migration/upgrade-box.php
+++ b/src/Events/Custom_Tables/V1/admin-views/migration/upgrade-box.php
@@ -12,7 +12,7 @@
 use TEC\Events\Custom_Tables\V1\Migration\String_Dictionary;
 use TEC\Events\Custom_Tables\V1\Migration\Admin\Upgrade_Tab;
 
-$is_outdated_pro = class_exists( 'Tribe__Events__Pro__Main' ) && version_compare( Tribe__Events__Pro__Main::VERSION, '6.0.0-beta4-dev', '<=' );
+$is_outdated_pro = class_exists( 'Tribe__Events__Pro__Main' ) && version_compare( Tribe__Events__Pro__Main::VERSION, '6.0.0-dev', '<=' );
 ?>
 
 <?php if ( $is_outdated_pro ) : ?>


### PR DESCRIPTION
Screencast: [link](https://share.cleanshot.com/0EB0sD)

This PR fixes the string used to assert that ECP is not outdate to compare it to the last possible dev version (`6.0.0-dev`) and not the last Beta version (`6.0.0-beta-4-dev`).
