### PR TITLE
Fix CT1 migration undefined ECP const issue

### DIFF
--- a/src/Events/Custom_Tables/V1/Migration/Process_Worker.php
+++ b/src/Events/Custom_Tables/V1/Migration/Process_Worker.php
@@ -606,10 +606,13 @@ class Process_Worker {
 	 */
 	public function error_handler( int $errno, string $errstr, string $errfile ): bool {
 		if ( $errno === E_WARNING ) {
-			$tec = basename( TRIBE_EVENTS_FILE );
-			$ecp = basename( EVENTS_CALENDAR_PRO_FILE );
+			$check_plugins = [ basename( TRIBE_EVENTS_FILE ) ];
 
-			if ( ! tec_is_file_from_plugins( $errfile, $tec, $ecp ) ) {
+			if ( defined( 'EVENTS_CALENDAR_PRO_FILE' ) ) {
+				$check_plugins[] = basename( EVENTS_CALENDAR_PRO_FILE );
+			}
+
+			if ( ! tec_is_file_from_plugins( $errfile, ...$check_plugins ) ) {
 				// Do not handle Warnings when coming from outside TEC or ECP codebase (e.g. caching plugins).
 				return false;
 			}


### PR DESCRIPTION
Do not assume ECP is active in warning handler.

Ticket: [BTRIA-1341](https://theeventscalendar.atlassian.net/browse/BTRIA-1341)

Screencasts:
* [TEC only](https://share.cleanshot.com/11Txqb)
* [ECP and TEC](https://share.cleanshot.com/iHljTF)

The migration code has an error handler that will deal with `E_WARNINGS`
coming from plugins that are not TEC or ECP differently. That code has a
bug where the existence of the `EVENTS_CALENDAR_PRO_FILE` constant is
assumed.

This PR fixes that.

Plugin used to trigger the `E_WARNING`:
```php
<?php
/**
 * Plugin Name: TEC - Test CT1 migration warning
 */

function tec_test_trigger_error() {
	include 'some-file-that-will-not-exist.php';
}

add_action( 'tec_events_custom_tables_v1_before_migration_applied', 'tec_test_trigger_error' );
```