### PR TITLE
CT1 Migration - do not throw on others' notices and warnings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -239,6 +239,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Update the venue website field to type URL. [TEC-4349]
 * Fix - Remove strict type hinting from Custom Tables v1 code that would cause fatals in some environments. [ECP-1343]
 * Fix - Correctly deprecate the `Tribe__Events__Main::get_closest_event` method [ECP-1326]
+* Fix - Do not throw during migration when notices or errors come from other plugins [ECP-1318]
 
 = [6.0.1] 2022-09-22 =
 

--- a/src/Events/Custom_Tables/V1/Migration/Process_Worker.php
+++ b/src/Events/Custom_Tables/V1/Migration/Process_Worker.php
@@ -110,7 +110,7 @@ class Process_Worker {
 	 */
 	private function bind_shutdown_handlers() {
 		// Watch for any errors that may occur and store them in the Event_Report.
-		set_error_handler( [ $this, 'error_handler' ] );
+		set_error_handler( [ $this, 'error_handler' ], E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE );
 
 		// Set this as a fallback: we'll remove it later if everything goes fine.
 		add_action( 'shutdown', [ $this, 'shutdown_handler' ] );
@@ -605,17 +605,15 @@ class Process_Worker {
 	 * @throws Migration_Exception A reference to an exception wrapping the error.
 	 */
 	public function error_handler( int $errno, string $errstr, string $errfile ): bool {
-		if ( $errno === E_WARNING ) {
-			$check_plugins = [ basename( TRIBE_EVENTS_FILE ) ];
+		$check_plugins = [ basename( TRIBE_EVENTS_FILE ) ];
 
-			if ( defined( 'EVENTS_CALENDAR_PRO_FILE' ) ) {
-				$check_plugins[] = basename( EVENTS_CALENDAR_PRO_FILE );
-			}
+		if ( defined( 'EVENTS_CALENDAR_PRO_FILE' ) ) {
+			$check_plugins[] = basename( EVENTS_CALENDAR_PRO_FILE );
+		}
 
-			if ( ! tec_is_file_from_plugins( $errfile, ...$check_plugins ) ) {
-				// Do not handle Warnings when coming from outside TEC or ECP codebase (e.g. caching plugins).
-				return false;
-			}
+		if ( ! tec_is_file_from_plugins( $errfile, ...$check_plugins ) ) {
+			// Do not handle Warnings when coming from outside TEC or ECP codebase (e.g. caching plugins).
+			return false;
 		}
 
 		// Delegate to our try/catch handler.


### PR DESCRIPTION
Ticket: [ECP-1318](https://theeventscalendar.atlassian.net/browse/ECP-1318)

Artifacts: tests and [screencast](https://share.cleanshot.com/Ebqn5Q)

Update the error handler logic we set during the migration process to
not throw due to notices (`E_NOTICE` and `E_USER_NOTICE`) and warnings
(`E_WARNING` and `E_USER_WARANING`) generated by non-TEC plugins.

The previous, stricter, code would stop the Event migration when notices
and warnings are raised during Event migration. Other plugins and themes
not as strict would routinely emit those and would, thus, prevent the
migration from happening.

The PR does not alter how notices and warnings coming from TEC plugins
are handled: they will raise an exception. This is a decision based on
the fact the TEC team cannot control others' code, but can control, thus
fix, its own code.
