### PR TITLE
Correct the mix up around venue and event id for tribe_get_full_address

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Feature - Add initial integration with Restrict Content Pro. This hides any events on the calendar views that the user is not allowed to view. [TBD]
+* Fix - Resolve problems with tribe_get_full_address() which was not properly returning venue address.
 * Fix - Correct a few misnamed custom prop references. [TEC-4445]
 * Fix - Add new function to properly escape event titles in URLs so they are better handled by rewrite rules. Props to @shisho585 for the fix! [TBD]
 * Fix - Ensure we handle if By_Day_View gets a null $event_obj->dates. Props to @juliangumenita for the fix! [TBD]

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -304,19 +304,19 @@ function tribe_get_country( $postId = null ) {
  * @param bool $includeVenueName To include the venue name or not.
  * @return string                Formatted event address.
  */
-function tribe_get_full_address( $post_id = null, $includeVenueName = false ) {
-	$venue_id  = tribe_get_venue_id( $post_id );
-	$tec       = Tribe__Events__Main::instance();
+function tribe_get_full_address( $event_id = null, $includeVenueName = false ) {
+	$post_id  = tribe_get_venue_id( $event_id );
 
 	global $post;
 	if ( ! is_null( $post_id ) ) {
 		$tmp_post = $post;
 		$post     = get_post( $post_id );
 	}
+
 	ob_start();
 	tribe_get_template_part( 'modules/address' );
-	$address = ob_get_contents();
-	ob_end_clean();
+	$address = ob_get_clean();
+
 	if ( ! empty( $tmp_post ) ) {
 		$post = $tmp_post;
 	}
@@ -328,10 +328,10 @@ function tribe_get_full_address( $post_id = null, $includeVenueName = false ) {
 	 * @since 4.5.11 Added docblock; also added $venue_id and $includeVenueName to filter.
 	 *
 	 * @param string $address The formatted event address
-	 * @param int $venue_id The venue ID.
-	 * @param bool $includeVenueName To include the venue name or not.
+	 * @param int    $post_id The venue ID.
+	 * @param bool   $includeVenueName To include the venue name or not.
 	 */
-	return apply_filters( 'tribe_get_full_address', $address, $venue_id, $includeVenueName );
+	return apply_filters( 'tribe_get_full_address', $address, $post_id, $includeVenueName );
 }
 
 /**

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -377,4 +377,83 @@ class venueTest extends Events_TestCase {
 			'When a Venue ID is passed the region should be that of the requested Venue.'
 		);
 	}
+
+
+	public function test_tribe_get_full_address() {
+		$address_string        = '%%ADDRESS_TEST%%';
+		$city_string           = '%%CITY_TEST%%';
+		$state_province_string = '%%STATE_PROVINCE_TEST%%';
+		$state_string          = '%%STATE_TEST%%';
+		$province_string       = '%%PROVINCE_TEST%%';
+		$zip_string            = '%%ZIP_TEST%%';
+		$country_string        = '%%COUNTRY_TEST%%';
+
+		$venue_with_state_province_id = static::factory()->venue->create( [
+			'meta_input' => [
+				'_VenueAddress' => $address_string,
+				'_VenueCity' => $city_string,
+				'_VenueStateProvince' => $state_province_string,
+				'_VenueZip' => $zip_string,
+				'_VenueCountry' => $country_string,
+			]
+		] );
+		$venue_in_usa_id             = static::factory()->venue->create( [
+			'meta_input' => [
+				'_VenueAddress' => $address_string,
+				'_VenueCity' => $city_string,
+				'_VenueState' => $state_string,
+				'_VenueStateProvince' => null,
+				'_VenueZip' => $zip_string,
+				'_VenueCountry' => 'United States',
+			]
+		] );
+		$venue_with_province_id     = static::factory()->venue->create( [
+			'meta_input' => [
+				'_VenueAddress' => $address_string,
+				'_VenueCity' => $city_string,
+				'_VenueProvince' => $province_string,
+				'_VenueStateProvince' => null,
+				'_VenueZip' => $zip_string,
+				'_VenueCountry' => $country_string,
+			]
+		] );
+
+		$event_with_state_province_id = static::factory()->event->create( [
+			'meta_input' => [
+				'_EventVenueID' => $venue_with_state_province_id,
+			]
+		] );
+		$event_in_usa_id              = static::factory()->event->create( [
+			'meta_input' => [
+				'_EventVenueID' => $venue_in_usa_id,
+			]
+		] );
+		$event_with_province_id       = static::factory()->event->create( [
+			'meta_input' => [
+				'_EventVenueID' => $venue_with_province_id,
+			]
+		] );
+
+		$full_address_html_with_state_province_id = tribe_get_full_address( $event_with_state_province_id );
+		$full_address_html_in_usa_id              = tribe_get_full_address( $event_in_usa_id );
+		$full_address_html_with_province_id       = tribe_get_full_address( $event_with_province_id );
+
+		$this->assertContains( $address_string, $full_address_html_with_state_province_id, 'Full Address should contain the address' );
+		$this->assertContains( $city_string, $full_address_html_with_state_province_id, 'Full Address should contain the city' );
+		$this->assertContains( $zip_string, $full_address_html_with_state_province_id, 'Full Address should contain the zip' );
+		$this->assertContains( $country_string, $full_address_html_with_state_province_id, 'Full Address should contain the country' );
+
+
+		$this->assertContains( $state_province_string, $full_address_html_with_state_province_id, 'Full Address for a Venue with StateProvince set should contain the the StateProvince value' );
+		$this->assertNotContains( $state_string, $full_address_html_with_state_province_id, 'Full Address for a Venue with StateProvince set should NOT contain the the State value' );
+		$this->assertNotContains( $province_string, $full_address_html_with_state_province_id, 'Full Address for a Venue with StateProvince set should NOT contain the the Province value' );
+
+		$this->assertContains( $state_string, $full_address_html_in_usa_id, 'Full Address for a Venue in the US without StateProvince should contain the State' );
+		$this->assertNotContains( $state_province_string, $full_address_html_in_usa_id, 'Full Address for a Venue in the US without StateProvince should contain the StateProvince' );
+		$this->assertNotContains( $province_string, $full_address_html_in_usa_id, 'Full Address for a Venue in the US without StateProvince should NOT contain the Province' );
+
+		$this->assertContains( $province_string, $full_address_html_with_province_id, 'Full Address for a Venue not the US without StateProvince should contain the Province' );
+		$this->assertNotContains( $state_province_string, $full_address_html_with_province_id, 'Full Address for a Venue not the US without StateProvince should NOT contain the StateProvince' );
+		$this->assertNotContains( $state_string, $full_address_html_with_province_id, 'Full Address for a Venue not the US without StateProvince should NOT contain the State' );
+	}
 }


### PR DESCRIPTION
The development team from Divi caught that `tribe_get_full_address()` was not returning the correct values. The problem was due to when I removed the internal method `Main::fullAddress()`, I didn't update the reference to Event/Venue IDs correctly.

🎫 [TEC-4505](https://theeventscalendar.atlassian.net/browse/TEC-4505)

---

📷 
![Screen Shot 2022-10-03 at 9 33 40 PM](https://user-images.githubusercontent.com/236579/193715597-65e414b7-1d64-45b5-ad59-b017608e718e.jpg)

