### PR TITLE
Divi integration - don't reset postdata

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -245,6 +245,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Update the venue website field to type URL. [TEC-4349]
 * Tweak - Add an event property for if the event is currently happening. [TBD]
 * Fix - Correctly set `found_posts` and `max_num_pages` when redirecting a query to the custom tables. [BTRIA-1385]
+* Fix - Avoid resetting post data in some Dive theme and plugins. [BTRIA-1397]
 
 = [6.0.1] 2022-09-22 =
 

--- a/src/Tribe/Integrations/Divi/Service_Provider.php
+++ b/src/Tribe/Integrations/Divi/Service_Provider.php
@@ -40,8 +40,19 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 	 *
 	 * @since 6.0.1
 	 */
-	protected function hooks() {
+	protected function hooks(): void {
 		add_filter( 'tribe_post_id', [ $this, 'filter_tribe_post_id' ] );
+	}
+
+	/**
+	 * Unregisters the filters and actions required for this integration to work.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_filter( 'tribe_post_id', [ $this, 'filter_tribe_post_id' ] );
 	}
 
 	/**
@@ -52,19 +63,17 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 	 * @param int $event_id The event ID.
 	 */
 	public function filter_tribe_post_id( $event_id ) {
-		// try the "normal" way first.
+		// Try the "normal" way first.
 		if ( empty( $event_id ) ) {
 			$event_id = get_the_ID();
 		}
 
-		// look for a post
+		// Look for a post in the query variables.
 		if ( ! tribe_is_event( $event_id ) && tribe_get_request_var( 'et_post_id' ) ) {
 			$event_id = tribe_get_request_var( 'et_post_id' );
 		}
 
 		if ( ! tribe_is_event( $event_id ) ) {
-			wp_reset_postdata();
-
 			$event_id = get_queried_object_id();
 		}
 

--- a/tests/integration/Tribe/Events/Integrations/DiviTest.php
+++ b/tests/integration/Tribe/Events/Integrations/DiviTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tribe\Events\Integrations;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Events\Integrations\Divi\Service_Provider;
+
+class DiviTest extends WPTestCase {
+	/**
+	 * @before
+	 */
+	public function register_divi_integration(): void {
+		update_option( 'stylesheet', 'Divi' );
+		update_option( 'template', 'Divi' );
+		tribe( Service_Provider::class )->register();
+	}
+
+	/**
+	 * @after
+	 */
+	public function unregister_divi_integration(): void {
+		tribe( Service_Provider::class )->register();
+	}
+
+	/**
+	 * It should not reset postdata in custom queries for non-Events
+	 *
+	 * @test
+	 */
+	public function should_not_reset_postdata_in_custom_queries_for_non_events() {
+		$page = static::factory()->post->create( [ 'post_type' => 'page' ] );
+		// Set up a main  query for the page.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $page, 'post_type' => 'page' ] );
+		$wp_query->reset_postdata();
+		// Create some posts to iterate on.
+		$posts = static::factory()->post->create_many( 3 );
+
+		$query = new \WP_Query( [
+			'posts_per_page' => 12,
+			'post_type'      => 'post',
+			'post_status'    => 'publish',
+		] );
+
+		if ( $query->have_posts() ) {
+			while ( $query->have_posts() ) {
+				$query->the_post();
+
+				$this->assertContains( get_the_ID(), $posts, 'Before the post_id_helper filter application, get_the_ID should return the correct value.' );
+
+				\Tribe__Main::post_id_helper( get_the_ID() ); // This will trigger the issue.
+
+				$this->assertContains( get_the_ID(), $posts, 'The ID filter should not reset the postdata to the page!' );
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ticket: [BTRIA-1397](https://theeventscalendar.atlassian.net/browse/BTRIA-1397)

Artifacts: tests

When trying to determine the post ID of an post that is not an Event,
the current code would call the `wp_reset_postdata` function.
This would reset the postdata to the post ID of the queries post, page
or whatever, invalidating any custom query that might run in the context
of the same page.
