### PR TITLE
Revert back code removed erroneously from V1 Removal

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Remember to always make a backup of your database and files before updating!
 = [6.0.2] TBD =
 
 * Feature - Add initial integration with Restrict Content Pro. This hides any events on the calendar views that the user is not allowed to view. [TBD]
+* Fix - Revert the code erroneous removed on legacy views removal around the "Show events with the site's other posts" setting.
 * Fix - Resolve problems with tribe_get_full_address() which was not properly returning venue address.
 * Fix - Correct a few misnamed custom prop references. [TEC-4445]
 * Fix - Add new function to properly escape event titles in URLs so they are better handled by rewrite rules. Props to @shisho585 for the fix! [TBD]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -35,7 +35,28 @@ class Tribe__Events__Query {
 
 		// These are only required for Main Query stuff.
 		if ( ! ( $context->is( 'is_main_query' ) && $context->is( 'tec_post_type' ) ) ) {
-			if ( ( (array) $query->get( 'post_type', [] ) ) === [ TEC::POSTTYPE ] ) {
+
+			if ( $query->is_home() ) {
+				/**
+				 * The following filter will remove the virtual page from the option page and return a 0 as it's not
+				 * set when the SQL query is constructed to avoid having a is_page() instead of a is_home().
+				 */
+				add_filter( 'option_page_on_front', [ __CLASS__, 'default_page_on_front' ] );
+				// check option for including events in the main wordpress loop, if true, add events post type
+				if ( tribe_get_option( 'showEventsInMainLoop', false ) && ! get_query_var( 'tribe_events_front_page' ) ) {
+					$query->query_vars['post_type']   = isset( $query->query_vars['post_type'] )
+						? ( array ) $query->query_vars['post_type']
+						: [ 'post' ];
+
+					if ( ! in_array( Tribe__Events__Main::POSTTYPE, $query->query_vars['post_type'], true ) ) {
+						$query->query_vars['post_type'][] = Tribe__Events__Main::POSTTYPE;
+					}
+					$query->tribe_is_multi_posttype   = true;
+				}
+			}
+
+
+			if ( ( (array) $query->get( 'post_type', [] ) ) === [  ] ) {
 				// Not the main query in Event context, but it's an event query: check back later.
 				add_filter( 'parse_query', [ __CLASS__, 'filter_and_order_by_date' ], 1000 );
 			}


### PR DESCRIPTION
I removed the code erroneously that removed a feature and caused many customers to have problems.

This needs to be included on Strudel. Not of QA needed as I just pulled code back from the original piece.

![Screenshot 2022-10-09 at 23-59-50 Korhal Calendar – Just another WordPress site](https://user-images.githubusercontent.com/236579/194797657-e5543713-06ab-47fa-9709-4df127526565.png)
