### PR TITLE
Revert Venue Website Field Type to text. [TEC-4349]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -255,7 +255,6 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Added filter `tec_events_month_day_classes_comparison_date` to filter the date used for class determination comparisons. [TEC-4457]
 * Tweak - Added filter `tec_events_month_day_classes` to filter the actual class list before it gets passed to the template. [TEC-4457]
 * Tweak - Update the organizer website field to type URL. [TEC-4395]
-* Tweak - Update the venue website field to type URL. [TEC-4349]
 * Tweak - Add an event property for if the event is currently happening. [TEC-4454]
 * Tweak - Create a filterable function `tec_events_get_today_button_label()` for the text on the "Today" button on calendar views. [TEC-4458]
 * Tweak - Add a filter for the link title and aria-label so they match the button text more closely. [TEC-4458]

--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -196,7 +196,7 @@ if ( ! $_POST && is_admin() ) {
 	<td>
 		<input
 			tabindex="<?php tribe_events_tab_index(); ?>"
-			type='url'
+			type='text'
 			id='EventWebsite'
 			name='venue[URL][]'
 			size='14'

--- a/src/admin-views/venue-meta-box.php
+++ b/src/admin-views/venue-meta-box.php
@@ -191,7 +191,7 @@ do_action( 'tribe_events_venue_before_metabox', $post );
 			name='venue[URL]'
 			size='14'
 			tabindex="<?php tribe_events_tab_index(); ?>"
-			type='url'
+			type='text'
 			value='<?php echo ( isset( $_VenueURL ) ? esc_attr( $_VenueURL ) : '' ); ?>'
 		/>
 	</td>


### PR DESCRIPTION
This reverts a change that was made on this initial [PR](https://github.com/the-events-calendar/the-events-calendar/pull/3952)

We need to set the field type as `text` in order to prevent the error shown below when editing an Event using the classic editor. 

The error occurs because the venue website field is hidden to the user on the add/edit event page of the classic editor at the point of submission.

![image](https://user-images.githubusercontent.com/22029087/196450790-d6eff64b-e221-4413-ae79-a95a5979895c.png)

This won't affect validation as this is done in the Venue metabox [here](https://github.com/the-events-calendar/the-events-calendar/blob/949007824de6e399123d9a2d7bc8c60446fb84a5/src/admin-views/venue-meta-box.php#L194).


https://theeventscalendar.atlassian.net/browse/TEC-4349