### PR TITLE
Update post type model code

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,11 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Serialization and unserialization issues related to caching of post models. [TEC-4379]
+* Tweak - Add the `tribe_get_venue_object_after` and `tribe_get_organizer_object_after` filters. [TEC-4379]
+
 = [6.0.2] 2022-10-20 =
 
 * Feature - Add initial integration with Restrict Content Pro. This hides any events on the calendar views that the user is not allowed to view. [ [TEC-4457]]

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@
 Contributors: theeventscalendar, borkweb, bordoni, brianjessee, aguseo, camwynsp, GeoffBel, jentheo, leahkoerper, lucatume, neillmcshea, vicskf, zbtirrell, juanfra
 Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
-Requires at least: 5.8.4
+Requires at least: 5.8.5
 Stable tag: 6.0.2
-Tested up to: 6.1.0
+Tested up to: 6.0.3
 Requires PHP: 7.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/Tribe/Collections/Lazy_Post_Collection.php
+++ b/src/Tribe/Collections/Lazy_Post_Collection.php
@@ -62,7 +62,9 @@ class Lazy_Post_Collection extends Lazy_Collection {
 	protected function before_serialize( array $items ) {
 		return [
 			'callback' => $this->unserialize_callback,
-			'ids'      => wp_list_pluck( $items, 'ID' ),
+			'ids'      => array_map( static function ( $item ): int {
+				return $item instanceof \WP_Post ? $item->ID : (int) $item;
+			}, $items ),
 		];
 	}
 

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -14,6 +14,8 @@ use DatePeriod;
 use DateTimeZone;
 use Tribe\Events\Collections\Lazy_Post_Collection;
 use Tribe\Models\Post_Types\Base;
+use Tribe\Utils\Date_I18n;
+use Tribe\Utils\Date_I18n_Immutable;
 use Tribe\Utils\Lazy_Boolean;
 use Tribe\Utils\Lazy_Collection;
 use Tribe\Utils\Lazy_String;
@@ -332,5 +334,60 @@ class Event extends Base {
 		$posts = array_unique( array_merge( $venue_ids, $organizer_ids, $attachment_ids ) );
 
 		_prime_post_caches( $posts );
+	}
+
+	/**
+	 * Overrides the base method to conver the I18n Dates to PHP built-in Date types.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $properties The properties to filter.
+	 *
+	 * @return array<string,mixed> The filtered properties.
+	 *
+	 * @throws \Exception If a date cannot be converted to a DateTime object.
+	 */
+	protected function scalar_serialize_properties( array $properties ): array {
+		// Convert the dates to built-in PHP date objects.
+		$properties['dates'] = array_map( static function ( $date ) {
+			if ( $date instanceof Date_I18n_Immutable ) {
+				return new \DateTimeImmutable( $date->format( 'Y-m-d H:i:s' ), $date->getTimezone() );
+			}
+
+			if ( $date instanceof Date_I18n ) {
+				return new \DateTime( $date->format( 'Y-m-d H:i:s' ), $date->getTimezone() );
+			}
+
+			return $date;
+		}, get_object_vars( $properties['dates'] ) );
+
+		return $properties;
+	}
+
+	/**
+	 * Overrides the base method to convert date properties to I18n Dates.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $properties The properties to filter.
+	 *
+	 * @return array<string,mixed> The filtered properties.
+	 *
+	 * @throws \Exception If a date cannot be converted to a I18n Date object.
+	 */
+	protected function scalar_unserialize_properties( array $properties ): array {
+		$properties['dates'] = (object) array_map( static function ( $date ) {
+			if ( $date instanceof \DateTimeImmutable ) {
+				return new Date_I18n_Immutable( $date->format( 'Y-m-d H:i:s' ), $date->getTimezone() );
+			}
+
+			if ( $date instanceof \DateTime ) {
+				return new Date_I18n( $date->format( 'Y-m-d H:i:s' ), $date->getTimezone() );
+			}
+
+			return $date;
+		}, $properties['dates'] ?? [] );
+
+		return $properties;
 	}
 }

--- a/src/Tribe/Updater.php
+++ b/src/Tribe/Updater.php
@@ -338,6 +338,7 @@ class Tribe__Events__Updater {
 
 			// Update reason to central source.
 			update_post_meta( $event_id, Event_Status_Meta::$key_status_reason, $reason );
+			clean_post_cache( $event_id );
 		}
 	}
 }

--- a/src/functions/template-tags/event.php
+++ b/src/functions/template-tags/event.php
@@ -98,16 +98,14 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			return $return;
 		}
 
-		$post = false;
-
-		/** @var Tribe__Cache $cache */
-		$cache = tribe( 'cache' );
-
 		$cache_post = get_post( $event );
 
 		if ( empty( $cache_post ) ) {
 			return null;
 		}
+
+		/** @var Tribe__Cache $cache */
+		$cache = tribe( 'cache' );
 
 		if ( ! isset( $cache['option_start_of_week'] ) ) {
 			$cache['option_start_of_week'] = get_option( 'start_of_week' );
@@ -119,6 +117,7 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			$cache['option_gmt_offset'] = get_option( 'gmt_offset' );
 		}
 
+		// Build a memoization cache key salted by the request parameters.
 		$key_fields = [
 			$cache_post->ID,
 			$cache_post->post_modified,
@@ -137,28 +136,12 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 
 		$cache_key = 'tribe_get_event_' . md5( wp_json_encode( $key_fields ) );
 
-		if ( ! $force ) {
-			$initial_unserialize_callback = ini_get( 'unserialize_callback_func' );
-			// Prevent warning from happening.
-			ini_set( 'unserialize_callback_func', '__return_false' );
+		// Try getting the memoized value.
+		$post = $cache[ $cache_key ];
 
-			$post = $cache->get( $cache_key, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
-
-			if ( ! $post instanceof WP_Post ) {
-				// If not a WP_Post we reset value, so it ignores cache.
-				$post = false;
-			}
-
-			// Revert to the original value.
-			ini_set( 'unserialize_callback_func', $initial_unserialize_callback );
-		}
-
-		if ( false === $post ) {
-			$post = Event::from_post( $event )->to_post( OBJECT, $filter );
-
-			if ( empty( $post ) ) {
-				return null;
-			}
+		if ( $post === false ) {
+			// No memoized value, build from properties.
+			$post = Event::from_post( $event )->to_post( OBJECT, $filter, $force );
 
 			/**
 			 * Filters the event post object before caching it and returning it.
@@ -175,10 +158,12 @@ if ( ! function_exists( 'tribe_get_event' ) ) {
 			 */
 			$post = apply_filters( 'tribe_get_event', $post, $output, $filter );
 
-			// Don't try to reset cache when forcing.
-			if ( ! $force ) {
-				$cache->set( $cache_key, $post, WEEK_IN_SECONDS, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
-			}
+			// Memoize the value.
+			$cache[ $cache_key ] = $post;
+		}
+
+		if ( empty( $post ) ) {
+			return null;
 		}
 
 		/**

--- a/src/functions/template-tags/organizer.php
+++ b/src/functions/template-tags/organizer.php
@@ -642,7 +642,7 @@ function tribe_get_organizer_object( $organizer = null, $output = OBJECT, $filte
 	 *
 	 * Note: this value will not be cached and the caching of this value is a duty left to the filtering function.
 	 *
-	 * @since 5.0.0
+	 * @since TBD
 	 *
 	 * @param WP_Post     $post        The organizer post object to filter and return.
 	 * @param int|WP_Post $organizer   The organizer object to fetch.

--- a/tests/event_status/Tribe/Events/Event_Status/Updater_Test.php
+++ b/tests/event_status/Tribe/Events/Event_Status/Updater_Test.php
@@ -49,6 +49,9 @@ class Updater_Test extends \Codeception\TestCase\WPTestCase {
 
 		$updater->migrate_event_status_reason_field();
 
+		// Flush the cache to remove cached and memoized artifacts.
+		wp_cache_flush();
+
 		$fetched_event = tribe_get_event( $event, OBJECT, 'raw', true );
 		$this->assertEquals( $status, $fetched_event->event_status );
 		$this->assertEquals( $reason, $fetched_event->event_status_reason );

--- a/tests/wpunit/functions/template-tags/eventTest.php
+++ b/tests/wpunit/functions/template-tags/eventTest.php
@@ -8,6 +8,7 @@ use Tribe\Events\Test\Factories\Event;
 use Tribe\Events\Test\Factories\Organizer;
 use Tribe\Events\Test\Factories\Venue;
 use Tribe\Test\PHPUnit\Traits\With_Filter_Manipulation;
+use Tribe__Cache_Listener as Cache_Listener;
 use Tribe__Events__Timezones as Timezones;
 
 class eventTest extends WPTestCase {
@@ -402,7 +403,7 @@ class eventTest extends WPTestCase {
 
 		$event = tribe_get_event( $post_id );
 
-		$cached_before = $cache->get( $cache_key, \Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+		$cached_before = $cache->get( $cache_key, Cache_Listener::TRIGGER_SAVE_POST );
 
 		$this->assertFalse( $cached_before );
 
@@ -410,12 +411,21 @@ class eventTest extends WPTestCase {
 			function () use ( $cache, $cache_key, $event ) {
 				$event->organizers->all();
 				do_action( 'shutdown' );
-				$cached = $cache->get( $cache_key, \Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+				$cached = $cache->get( $cache_key, Cache_Listener::TRIGGER_SAVE_POST );
 				$this->assertInternalType( 'array', $cached );
 				$this->assertNotEmpty( array_intersect_key( get_object_vars( $event ), $cached ) );
 			}
 		);
 
 		wp_using_ext_object_cache( $using_backup );
+	}
+
+	/**
+	 * It should type-cast dates to built-in classes during pre-caching serialization
+	 *
+	 * @test
+	 */
+	public function should_type_cast_dates_to_built_in_classes_during_pre_caching_serialization() {
+
 	}
 }


### PR DESCRIPTION
Ticket: [TEC-4379](https://theeventscalendar.atlassian.net/browse/TEC-4379)

Based on [Common PR](https://github.com/the-events-calendar/tribe-common/pull/1821) 

Artifacts: tests and [screencast](https://share.cleanshot.com/2ktUfb) 

This commit updates the code used to build and return decorated post
models for Events, Venues and Organizers when dealing with object
caching.

The update follows the one done in common in the branch by the same name
to avoid serialization and unserialization issues.
