### PR TITLE
Fix HyperDB compatibility issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Avoid fatal error when using PHP version 8.0 or above and the HyperDB plugin. [ECP-1360]
+
 = [6.0.2] 2022-10-20 =
 
 * Feature - Add initial integration with Restrict Content Pro. This hides any events on the calendar views that the user is not allowed to view. [ [TEC-4457]]

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -133,6 +133,8 @@ class Custom_Tables_Query extends WP_Query {
 		add_filter( 'posts_where', [ $this, 'filter_by_date' ], 10, 2 );
 		add_filter( 'posts_where', [ $this, 'filter_where' ], 10, 2 );
 		add_filter( 'posts_join', [ $this, 'join_occurrences_table' ], 10, 2 );
+		// This is the last filter in the `WP_Query` class: use this as an action to clean up.
+		add_filter( 'the_posts', [ $this, 'remove_late_filters' ], 10, 2 );
 
 		// This "parallel" query should not be manipulated by the WP_Query_Monitor.
 		$monitor_ignore_flag          = WP_Query_Monitor::ignore_flag();
@@ -159,17 +161,9 @@ class Custom_Tables_Query extends WP_Query {
 		 */
 		do_action( 'tec_events_custom_tables_v1_custom_tables_query_pre_get_posts', $this );
 
-		$set_found_rows = empty( $this->get( 'no_found_rows', false ) );
-
-		if ( $set_found_rows ) {
-			add_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ], 10, 2 );
-		}
-
 		$results = parent::get_posts();
 
-		if ( $set_found_rows ) {
-			remove_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ] );
-		}
+		$this->remove_filters();
 
 		/**
 		 * Fires after the Custom Tables Query ran.
@@ -181,16 +175,19 @@ class Custom_Tables_Query extends WP_Query {
 		 */
 		do_action( 'tec_events_custom_tables_v1_custom_tables_query_results', $results, $this );
 
-		if (
-			$this->wp_query instanceof WP_Query
-			&& $set_found_rows
-		) {
-			$this->wp_query->found_posts = $this->found_posts;
-			$this->wp_query->max_num_pages = $this->max_num_pages;
-		}
+		$set_found_rows = empty( $this->get( 'no_found_rows', false ) );
 
-		// Set the request SQL that actually ran to allow easier debugging of the query.
-		$this->wp_query->request = $this->request;
+		if ( $this->wp_query instanceof WP_Query ) {
+			if ( $set_found_rows ) {
+				// Avoid `SELECT FOUND_ROWS()` running twice. See #ECP-1360.
+				add_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ], 10, 2 );
+				$this->wp_query->found_posts = $this->found_posts;
+				$this->wp_query->max_num_pages = $this->max_num_pages;
+			}
+
+			// Set the request SQL that actually ran to allow easier debugging of the query.
+			$this->wp_query->request = $this->request;
+		}
 
 		return $results;
     }
@@ -524,8 +521,14 @@ class Custom_Tables_Query extends WP_Query {
 	}
 
 	/**
-	 * Filters the query that would run to fill in the `found_posts` property of the `WP_Query` instance
-	 * to short-circuit and return the number of posts found by the Custom Tables Query.
+	 * Short-circuits the controlled `WP_Query` instance query to get the number of found results
+	 * to avoid it from running twice.
+	 *
+	 * The Custom Tables query will pre-fill the results on the `posts_pre_query` filter and will run,
+	 * in that context, a query to get the posts and the found rows. The `WP_Query` instance whose posts
+	 * are pre-filled, will attempt to run the query to get the found rows again. This method will intercept
+	 * that second `SELECT FOUND_ROWS()` query to pre-fill it with a result the Custom Tables query already
+	 * has.
 	 *
 	 * @since TBD
 	 *
@@ -537,13 +540,53 @@ class Custom_Tables_Query extends WP_Query {
 	 * @return string The filtered SQL query that will run to fill in the `found_posts` property of the `WP_Query`
 	 *                instance.
 	 */
-	protected function filter_found_posts_query( $found_posts_query, $query ) {
-		if ( $this !== $query ) {
+	public function filter_found_posts_query( $found_posts_query, $query ) {
+		if ( $this->wp_query !== $query ) {
 			return $found_posts_query;
 		}
 
 		remove_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ] );
 
 		return 'SELECT ' . $this->found_posts;
+	}
+
+	/**
+	 * Removes all the filters the Custom Tables Query has added to filter its own inner workings while
+	 * pre-filling the results in the `posts_pre_query` filter.
+	 *
+	 * @since TBD
+	 *
+	 * @return void Lingering filters will be removed.
+	 */
+	protected function remove_filters(): void {
+		remove_filter( 'posts_search', [ $this, 'replace_meta_query' ], 10 );
+		remove_filter( 'posts_fields', [ $this, 'redirect_posts_fields' ] );
+		remove_filter( 'posts_groupby', [ $this, 'group_posts_by_occurrence_id' ] );
+		remove_filter( 'posts_orderby', [ $this, 'order_by_occurrence_id' ], 100 );
+		remove_filter( 'posts_where', [ $this, 'filter_by_date' ], 10 );
+		remove_filter( 'posts_where', [ $this, 'filter_where' ], 10 );
+		remove_filter( 'posts_join', [ $this, 'join_occurrences_table' ], 10 );
+		remove_filter( 'the_posts', [ $this, 'remove_late_filters' ] );
+	}
+
+	/**
+	 * Removes late filters that are required after the `posts_pre_query` filter.
+	 *
+	 * @since TBD
+	 *
+	 * @param array    $the_posts The array of posts that will be returned by the `WP_Query` instance.
+	 * @param WP_Query $query     WP_Query The `WP_Query` instance that is currently filtering its `the_posts` property.
+	 *
+	 * @return array The filtered array of posts that will be returned by the `WP_Query` instance, not modified by
+	 *               this filter.
+	 */
+	public function remove_late_filters( $the_posts, $query ) {
+		if ( $query !== $this->wp_query ) {
+			return $the_posts;
+		}
+
+		remove_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ] );
+
+		return $the_posts;
 	}
 }

--- a/src/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Only_Modifier.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Only_Modifier.php
@@ -63,9 +63,10 @@ class Events_Only_Modifier extends Base_Modifier {
 			return $posts;
 		}
 
-		if ( null !== $posts ) {
-			$this->unhook();
+		// This modifier should stop filtering queries, since this is the one to filter.
+		$this->unhook();
 
+		if ( null !== $posts ) {
 			// If something already intervened in the filter, then bail and do not touch the query at all.
 			return $posts;
 		}

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -1,0 +1,13 @@
+<?php return array (
+  0 => 'SELECT SQL_CALC_FOUND_ROWS  test_posts.ID
+			FROM test_posts  INNER JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
+			WHERE 1=1  AND ( 
+  test_tec_occurrences.start_date > \'2022-10-01 08:00:00\'
+) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
+OR test_posts.post_status = \'private\')))
+			GROUP BY test_tec_occurrences.occurrence_id
+			ORDER BY test_posts.post_date DESC
+			LIMIT 0, 10',
+  1 => 'SELECT FOUND_ROWS()',
+  2 => 'SELECT 3',
+);


### PR DESCRIPTION
Ticket: [ECP-1360](https://theeventscalendar.atlassian.net/browse/ECP-1360) 

Artifacts:
* The code under change is already covered by numerous tests.
* [Screencast](https://share.cleanshot.com/scKAmx)

This fixes an issue where, in the context of PHP 8.0, a fatal would be thrown on Event archives when using CT1 and the HyperDB plugin.

The cause of the issue is a `SELECT FOUND_ROWS()` query running twice; when running a query for Events:
1. During `WP_Query::get_posts` the `posts_pre_query` filter is applied
2. The `Custom_Tables_Query` hooked on that filter ...
3. ... runs its own `get_post` to fetch the results
4. ... runs its own `set_found_posts` (that will run `SELECT FOUND_ROWS()`)
5. ... and returns the post results from the filter pre-filling
6. ... the original `WP_Query` object will run its own `set_found_posts` method that will run the `SELECT FOUND_ROWS()` a second time <<< here is the issue

In previous PHP versions, the query at 6 would just fail; in PHP 8 that query running a second time will fatal out.

The solution is to not run the query at 6, but pre-fill it with the `found_posts` value the Custom Table Query already has.
