### PR TITLE
Prevent the caching of occurrence queries

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Correct issues where early queries can interfere with View template redirects. [TEC-4554]
 * Fix - Serialization and unserialization issues related to caching of post models. [TEC-4379]
+* Fix - Prevent default WordPress occurrence query caching because we cache it ourselves. [TEC-4379]
 * Tweak - Add the `tribe_get_venue_object_after` and `tribe_get_organizer_object_after` filters. [TEC-4379]
 
 = [6.0.3] 2022-10-31 =

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -143,11 +143,12 @@ class Custom_Tables_Query extends WP_Query {
 		$monitor = tribe(Custom_Tables_Query_Monitor::class);
 		$monitor->attach( $this );
 
-        // This "parallel" query should not be manipulated from other query managers.
+		// This "parallel" query should not be manipulated from other query managers.
 		$this->set( 'tribe_suppress_query_filters', true );
 		$this->tribe_suppress_query_filters = true;
 		$this->set( 'tribe_include_date_meta', false );
 		$this->tribe_include_date_meta = false;
+		$this->set( 'cache_results', false );
 
 		/**
 		 * Fires before the Custom Tables query runs.


### PR DESCRIPTION
We do our own caching of occurrence results, so we don't need WordPress core to do it.