### PR TITLE
Fix for ECP-1411

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [6.0.4] TBD =
 
 * Feature - Include Yoast WordPress SEO OpenGraph integration. [TEC-4558]
+* Fix - Fix for fatal when adding Featured Venue Events widget on Appearance -> Widgets screen. [ECP-1411]
 * Fix - Fix for fatal error on Series page in PHP 7.3. [TEC-4549]
 * Fix - Prevent error around Free regular expression for JSON-LD on updated views. Props @jonkastonka @saleck @randon
 * Fix - Avoid fatal error when using PHP version 8.0 or above and the HyperDB plugin. [ECP-1360]

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -162,7 +162,7 @@ class Custom_Tables_Query extends WP_Query {
 
 		// This parallel query should be modified by custom tables query modifiers, if any.
 		/** @var Custom_Tables_Query_Monitor $monitor */
-		$monitor = tribe(Custom_Tables_Query_Monitor::class);
+		$monitor = tribe( Custom_Tables_Query_Monitor::class );
 		$monitor->attach( $this );
 
 		// This "parallel" query should not be manipulated from other query managers.

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -68,6 +68,10 @@ function tribe_get_venue_object( $venue = null, $output = OBJECT, $filter = 'raw
 		// No memoized value, build from properties.
 		$post = Venue::from_post( $venue )->to_post( $output, $filter );
 
+		if ( empty( $post ) ) {
+			return null;
+		}
+
 		/**
 		 * Filters the venue post object before caching it and returning it.
 		 *

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -211,6 +211,9 @@ class venueTest extends Events_TestCase {
 	 * Test tribe_get_venue_object returns null for non-existing venue
 	 */
 	public function test_tribe_get_venue_object_returns_null_for_non_existing_venue() {
+		add_filter( 'tribe_get_venue_object', function ( \WP_Post $wp_post ) {
+			// We should not be called with a null value, will fatal if we are called.
+		} );
 		// Sanity check: let's make sure this does not exist.
 		$this->assertNull( get_post( 23 ) );
 


### PR DESCRIPTION
[ECP-1411](https://theeventscalendar.atlassian.net/browse/ECP-1411)
Skips filters that require a WP_Post object when there is none to be found for a venue.

Artifact:
Screenshot of display when fix is in place.
![image](https://user-images.githubusercontent.com/2826045/201425568-a7049009-ca1f-4b1d-bd2f-192f9bb31175.png)
