### PR TITLE
Fixing count.

### DIFF
--- a/src/Events/Custom_Tables/V1/Migration/Events.php
+++ b/src/Events/Custom_Tables/V1/Migration/Events.php
@@ -54,7 +54,7 @@ class Events {
 		// Atomic query.
 		// Fetch only those that were NOT previously touched.
 		$lock_query = "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value)
-	    SELECT p.ID, %s,%s
+	    SELECT DISTINCT p.ID, %s,%s
 	    FROM {$wpdb->posts} p
 			LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key IN (%s, %s)
 			LEFT JOIN {$wpdb->postmeta} created_by_migration ON p.ID = created_by_migration.post_id
@@ -265,7 +265,7 @@ class Events {
 		global $wpdb;
 		$total_events = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(ID) FROM {$wpdb->posts} p
+				"SELECT COUNT(DISTINCT `ID`) FROM {$wpdb->posts} p
 						LEFT JOIN {$wpdb->postmeta} created_by_migration ON p.ID = created_by_migration.post_id
 							AND created_by_migration.meta_key = %s
 						LEFT JOIN {$wpdb->postmeta} pm1 ON p.ID = pm1.post_id AND pm1.meta_key = '_EventStartDate'


### PR DESCRIPTION
Two queries potentially would pull duplicates, throwing off counts and potentially queueing too many events.