### PR TITLE
Ensure the `Prev` button when using the `Event View` Elementor widget…

### DIFF
--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -310,7 +310,7 @@ tribe.events.views.manager = {};
 
 		var $link = $( this );
 		var url = $link.attr( 'href' );
-		var currentUrl = containerData.url;
+		var currentUrl = containerData.prev_url;
 		var nonce = $link.data( 'view-rest-nonce' );
 		var shouldManageUrl = obj.shouldManageUrl( $container );
 		var shortcodeId = $container.data( 'view-shortcode' );


### PR DESCRIPTION
Ticket: [FBAR-273](https://theeventscalendar.atlassian.net/browse/FBAR-273)

This PR ensures that the `prev` button when using the `Event View` widget works as expected. 

Artifact:
https://www.loom.com/share/e6a87441906d49ffad97e23fd9157556

