### PR TITLE
Add target blank and rel noopener to our external (evnt.is) links.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,9 +231,12 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.5] TBD =
 
-* Tweak - Added ability to filter v2 repository args on all View queries. [ECP-1372]
 * Fix - Fix for stuck migrations when duplicate meta exists. [TEC-4547]
+* Tweak - Added ability to filter v2 repository args on all View queries. [ECP-1372]
 * Tweak - Reorganize the General and Display settings tab content. [TCMN-149]
+* Tweak - New headers for the General and Display settings tabs. [TEC-4573]
+* Tweak - Add view upsells for ECP [TEC-4572]
+* Tweak - Add settings info boxes. [TEC-4574]
 
 = [6.0.4] 2022-11-15 =
 

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -45,7 +45,7 @@ $tec_events_display_fields = [
 				  . __( 'The settings below control the display of your calendar. If things don\'t look right, try switching between the two style sheet options or pick a page template from your theme (not available on block themes). ', 'the-events-calendar' )
 				  . sprintf(
 						  /* Translators: %s: URL to knowledgebase. Please continue to use &#37; for % to avoid PHP warnings. */
-					  __( ' Check out our <a href="%s">customization guide</a> for instructions on template modifications.', 'the-events-calendar' ),
+					  __( ' Check out our <a href="%s" rel="noopener" target="_blank">customization guide</a> for instructions on template modifications.', 'the-events-calendar' ),
 					  esc_url( 'https://evnt.is/1bbs' )
 				  )
 				  . '</p>',
@@ -183,7 +183,7 @@ $tec_events_display_template = [
 		'type'            => 'text',
 		'label'           => __( 'Month view events per day', 'the-events-calendar' ),
 		'tooltip'         => sprintf(
-			__( 'Change the default 3 events per day in month view. To impose no limit, you may specify -1. Please note there may be performance issues if you allow too many events per day. <a href="%s">Read more</a>.', 'the-events-calendar' ),
+			__( 'Change the default 3 events per day in month view. To impose no limit, you may specify -1. Please note there may be performance issues if you allow too many events per day. <a href="%s" rel="noopener" target="_blank">Read more</a>.', 'the-events-calendar' ),
 			'https://evnt.is/rh'
 		),
 		'validation_type' => 'int',
@@ -368,7 +368,7 @@ $tec_events_display_currency = [
 	],
 	'tec-tickets-infobox-link' => [
 		'type' => 'html',
-		'html' => '<a href="' . esc_url( 'https://evnt.is/1bbx' ) . '">' . __( 'Learn more.', 'the-events-calendar' ) . '</a>',
+		'html' => '<a href="' . esc_url( 'https://evnt.is/1bbx' ) . '" rel="noopener" target="_blank">' . __( 'Learn more.', 'the-events-calendar' ) . '</a>',
 		'conditional' => $is_missing_event_tickets_plus && ! $should_hide_upsell,
 	],
 	'tec-tickets-infobox-end' => [
@@ -429,14 +429,10 @@ $tec_events_display_maps = [
 			/* Translators: %1$s - opening paragraph tag, %2$s - opening anchor tag, %3$s - closing anchor tag, %4$s - closing paragraph tag */
 			__( '%1$sThe Events Calendar comes with a default API key for basic maps functionality. If you’d like to use more advanced features like custom map pins or dynamic map loads, you’ll need to get your own %2$sGoogle Maps API key%3$s.%4$s', 'the-events-calendar' ),
 			'<p>',
-			'<a href="' . esc_url( 'https://evnt.is/1bbu' ) . '">',
+			'<a href="' . esc_url( 'https://evnt.is/1bbu' ) . '" rel="noopener" target="_blank">',
 			'</a>',
 			'</p>'
 		),
-	],
-	'tec-maps-infobox-link' => [
-		'type' => 'html',
-		'html' => '<a href="' . esc_url( 'https://evnt.is/1bbu' ) . '">' . __( 'Read more.', 'the-events-calendar' ) . '</a>',
 	],
 	'tec-maps-infobox-end' => [
 		'type' => 'html',

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -49,14 +49,14 @@ $general_tab_fields = [
 	'tec-documentation-section-getting-started-link' => [
 		'type' => 'html',
 		'html' => '<li><a href="'
-			. esc_url( 'https://evnt.is/1bbv' ) . '">'
+			. esc_url( 'https://evnt.is/1bbv' ) . '" rel="noopener" target="_blank">'
 			. esc_html__( 'Getting started guide', 'the-events-calendar' )
 			. '</a></li>',
 	],
 	'tec-documentation-section-knowledgebase-link'   => [
 		'type' => 'html',
 		'html' => '<li><a href="'
-			. esc_url( 'https://evnt.is/1bbw' ) . '">'
+			. esc_url( 'https://evnt.is/1bbw' ) . '" rel="noopener" target="_blank">'
 			. esc_html__( 'Knowledgebase', 'the-events-calendar' )
 			. '</a></li>',
 	],
@@ -271,7 +271,7 @@ $tec_events_general_viewing = [
 	'enable_month_view_cache'                   => [
 		'type'            => 'checkbox_bool',
 		'label'           => __( 'Enable the Month View Cache', 'the-events-calendar' ),
-		'tooltip'         => sprintf( __( 'Check this to cache your month view HTML in transients, which can help improve calendar speed on sites with many events. <a href="%s">Read more</a>.', 'the-events-calendar' ), 'https://evnt.is/18di' ),
+		'tooltip'         => sprintf( __( 'Check this to cache your month view HTML in transients, which can help improve calendar speed on sites with many events. <a href="%s" rel="noopener" target="_blank">Read more</a>.', 'the-events-calendar' ), 'https://evnt.is/18di' ),
 		'default'         => true,
 		'validation_type' => 'boolean',
 	],
@@ -310,7 +310,7 @@ $tec_events_general_editing = [
 	],
 	'tec-aggregator-infobox-link' => [
 		'type' => 'html',
-		'html' => '<a href="' . esc_url( 'https://evnt.is/1bby' ) . '">' . __( 'Learn more.', 'the-events-calendar' ) . '</a>',
+		'html' => '<a href="' . esc_url( 'https://evnt.is/1bby' ) . '" rel="noopener" target="_blank">' . __( 'Learn more.', 'the-events-calendar' ) . '</a>',
 		'conditional' => $is_missing_aggregator_license_key && ! $should_hide_upsell,
 	],
 	'tec-aggregator-infobox-end' => [


### PR DESCRIPTION
Also remove the redundant "Read More" link from the maps infobox.

[TEC-4573]

[TEC-4573]: https://theeventscalendar.atlassian.net/browse/TEC-4573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ