### PR TITLE
Fix query property setting during parse

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -39,7 +39,8 @@ class Tribe__Events__Query {
 		$is_event_query = (array) $query->get( 'post_type' ) === [ TEC::POSTTYPE ];
 		$any_post_type  = (array) $query->get( 'post_type' ) === [ 'any' ];
 		$is_main_query  = $query->is_main_query();
-		$query_post_types = (array) $query->get( 'post_type' );
+		$query_post_types = self::get_query_post_types( $query );
+
 		$tec_post_types   = [ TEC::POSTTYPE, Venue::POSTTYPE, Organizer::POSTTYPE ];
 
 		if ( $is_main_query ) {
@@ -534,6 +535,26 @@ class Tribe__Events__Query {
 	}
 
 	/**
+	 * Returns the query post type(s) in array format.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Query $query The query object to read the post type entry from.
+	 *
+	 * @return array<string> The post type(s) read from the query.
+	 */
+	protected static function get_query_post_types( WP_Query $query ): array {
+		$query_post_types = (array) $query->get( 'post_type' );
+
+		// A query for the main posts page will not have a `post_type` set: let's correct that now.
+		if ( $query_post_types === [ '' ] ) {
+			$query_post_types = [ 'post' ];
+		}
+
+		return $query_post_types;
+	}
+
+	/**
 	 * Updates the query post count to include the specified ones.
 	 *
 	 * @since TBD
@@ -544,13 +565,11 @@ class Tribe__Events__Query {
 	 * @return void The query object is modified by reference.
 	 */
 	protected static function add_post_type_to_query( WP_Query $query, string ...$post_types ): void {
-		$updated_post_types = array_unique(
-			array_merge(
-				$post_types,
-				(array) $query->get( 'post_type' )
-			)
-		);
+		$query_post_types = self::get_query_post_types( $query );
+
+		$updated_post_types = array_unique( array_merge( $post_types, $query_post_types ) );
+
 		$query->set( 'post_type', $updated_post_types );
-		$query->query['post_types'] = $updated_post_types;
+		$query->query['post_type'] = $updated_post_types;
 	}
 }

--- a/tests/_support/_generated/WpunitTesterActions.php
+++ b/tests/_support/_generated/WpunitTesterActions.php
@@ -12,7 +12,7 @@ trait WpunitTesterActions
      */
     abstract protected function getScenario();
 
-
+    
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -39,7 +39,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('getPluginsFolder', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -63,7 +63,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('factory', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -87,7 +87,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('getContentFolder', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -116,7 +116,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('startWpFiltersDebug', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -140,7 +140,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('stopWpFiltersDebug', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -168,7 +168,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('debugWpFilterInitial', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -196,7 +196,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('debugWpFilterFinal', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -224,7 +224,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('debugWpActionInitial', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -252,7 +252,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('debugWpActionFinal', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -276,7 +276,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueries', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -301,7 +301,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueries', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -332,7 +332,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertCountQueries', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -358,7 +358,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByStatement', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -384,7 +384,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -410,7 +410,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByStatement', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -439,7 +439,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByStatement', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -465,7 +465,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -493,7 +493,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -517,7 +517,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -542,7 +542,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -568,7 +568,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -595,7 +595,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByStatementAndMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -622,7 +622,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByStatementAndMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -652,7 +652,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByStatementAndMethod', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -678,7 +678,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByStatementAndFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -705,7 +705,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByStatementAndFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -734,7 +734,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByStatementAndFunction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -762,7 +762,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -790,7 +790,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -821,7 +821,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -851,7 +851,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByStatementAndAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -881,7 +881,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByStatementAndAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -915,7 +915,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByStatementAndAction', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -947,7 +947,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -979,7 +979,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -1014,7 +1014,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -1048,7 +1048,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesByStatementAndFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -1082,7 +1082,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertNotQueriesByStatementAndFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -1121,7 +1121,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('assertQueriesCountByStatementAndFilter', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
@@ -1145,7 +1145,7 @@ trait WpunitTesterActions
         return $this->getScenario()->runStep(new \Codeception\Step\Action('countQueries', func_get_args()));
     }
 
-
+ 
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -4,8 +4,10 @@ namespace Tribe\Events;
 
 use Spatie\Snapshots\MatchesSnapshots;
 use Tribe\Events\Test\Testcases\Events_TestCase;
+use Tribe\Events\Test\Traits\With_Uopz;
 use Tribe__Events__Main as Main;
 use Tribe__Events__Query as Query;
+use Tribe__Events__Organizer as Organizer;
 use Tribe__Events__Venue as Venue;
 use WP_Query;
 
@@ -18,6 +20,7 @@ use WP_Query;
  */
 class QueryTest extends Events_TestCase {
 	use MatchesSnapshots;
+	use With_Uopz;
 
 	/**
 	 * It should allow getting found posts for arguments
@@ -185,5 +188,93 @@ class QueryTest extends Events_TestCase {
 		] );
 
 		$this->assertMatchesSnapshot( $query->request );
+	}
+
+	/**
+	 * It should not throw when trying to parse non query object
+	 *
+	 * @test
+	 */
+	public function should_not_throw_when_trying_to_parse_non_query_object(): void {
+		Query::parse_query( 'test' );
+	}
+
+	/**
+	 * It should not parse query in admin context
+	 *
+	 * @test
+	 */
+	public function should_not_parse_query_in_admin_context() {
+		// Simulate an admin context request.
+		$this->uopz_set_return( 'is_admin', true );
+		// Disconnect the query to make sure it will parse when explicitly called.
+		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
+
+		$wp_query = new WP_Query( [ 'post_type' => 'tribe_events' ] );
+
+		Query::parse_query( $wp_query );
+
+		$this->assertFalse( isset( $wp_query->tribe_is_event ) );
+	}
+
+	/**
+	 * It should not parse a query if TEC query filters are suppressed
+	 *
+	 * @test
+	 */
+	public function should_not_parse_a_query_if_tec_query_filters_are_suppressed() {
+		// Disconnect the query to make sure it will parse when explicitly called.
+		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
+
+		$wp_query = new WP_Query( [ 'post_type' => 'tribe_events', 'tribe_suppress_query_filters' => true ] );
+
+		Query::parse_query( $wp_query );
+
+		$this->assertFalse( isset( $wp_query->tribe_is_event ) );
+	}
+
+	/**
+	 * It should not filter main query for post or page
+	 *
+	 * @test
+	 */
+	public function should_not_filter_main_query_for_post_or_page() {
+		// Disconnect the query to make sure it will parse when explicitly called.
+		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
+		// Simulate a main query to fetch a post.
+		global $wp_the_query;
+		$id       = $this->factory()->post->create();
+		$wp_the_query = new WP_Query( [ 'p' => $id ] );
+
+		Query::parse_query( $wp_the_query );
+
+		$this->assertFalse( isset( $wp_the_query->tribe_is_event ) );
+	}
+
+	public function tec_post_types_data_provider(): array {
+		return [
+			'Event'     => [ Main::POSTTYPE ],
+			'Organizer' => [ Organizer::POSTTYPE ],
+			'Venue'     => [ Venue::POSTTYPE ],
+		];
+	}
+
+	/**
+	 * It should set TEC post type main query paged prop based on Events paged query var
+	 *
+	 * @test
+	 * @dataProvider tec_post_types_data_provider
+	 */
+	public function should_set_TEC_post_type_main_query_paged_prop_based_on_events_paged_query_var(string $tec_post_type): void {
+		// Disconnect the query to make sure it will parse when explicitly called.
+		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
+		// Simulate a main query to fetch a post.
+		global $wp_the_query;
+		$id       = $this->factory()->post->create();
+		$wp_the_query = new WP_Query( [ 'post_type' => $tec_post_type ] );
+
+		Query::parse_query( $wp_the_query );
+
+		$this->assertFalse( isset( $wp_the_query->tribe_is_event ) );
 	}
 }

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -10,6 +10,7 @@ use Tribe__Events__Query as Query;
 use Tribe__Events__Organizer as Organizer;
 use Tribe__Events__Venue as Venue;
 use WP_Query;
+use Tribe__Admin__Helpers as Admin_Helpers;
 
 /**
  * Test that the Event Queries behave as expected
@@ -23,20 +24,27 @@ class QueryTest extends Events_TestCase {
 	use With_Uopz;
 
 	/**
+	 * @before
+	 */
+	public function reset_screen(): void {
+		unset( $GLOBALS['current_screen'] );
+	}
+
+	/**
 	 * It should allow getting found posts for arguments
 	 *
 	 * @test
 	 */
-	public function should_allow_getting_found_posts_for_arguments() {
+	public function should_allow_getting_found_posts_for_arguments(): void {
 		$this->factory()->event->create_many( 5 );
 
-		$args = [ 'found_posts' => true ];
+		$args        = [ 'found_posts' => true ];
 		$found_posts = Query::getEvents( $args );
 
 		$this->assertEquals( 5, $found_posts );
 	}
 
-	public function truthy_and_falsy_values() {
+	public function truthy_and_falsy_values(): array {
 		return [
 			[ 'true', true ],
 			[ 'true', true ],
@@ -54,7 +62,7 @@ class QueryTest extends Events_TestCase {
 	 * @test
 	 * @dataProvider truthy_and_falsy_values
 	 */
-	public function should_allow_truthy_and_falsy_values_for_the_found_posts_argument( $found_posts, $bool ) {
+	public function should_allow_truthy_and_falsy_values_for_the_found_posts_argument( $found_posts, $bool ): void {
 		$this->factory()->event->create_many( 5 );
 
 		$this->assertEquals( Query::getEvents( [ 'found_posts' => $found_posts ] ), Query::getEvents( [ 'found_posts' => $bool ] ) );
@@ -65,10 +73,10 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @test
 	 */
-	public function should_override_posts_per_page_and_paged_arguments_when_using_found_posts() {
+	public function should_override_posts_per_page_and_paged_arguments_when_using_found_posts(): void {
 		$this->factory()->event->create_many( 5 );
 
-		$args = [ 'found_posts' => true, 'posts_per_page' => 3, 'paged' => 2 ];
+		$args        = [ 'found_posts' => true, 'posts_per_page' => 3, 'paged' => 2 ];
 		$found_posts = Query::getEvents( $args );
 
 		$this->assertEquals( 5, $found_posts );
@@ -79,8 +87,8 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @test
 	 */
-	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set() {
-		$args = [ 'found_posts' => true ];
+	public function should_return_0_when_no_posts_are_found_and_found_posts_is_set(): void {
+		$args        = [ 'found_posts' => true ];
 		$found_posts = Query::getEvents( $args );
 
 		$this->assertEquals( 0, $found_posts );
@@ -93,7 +101,7 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @since 4.6.10
 	 */
-	public function should_allow_queries_to_ignore_hidden_events() {
+	public function should_allow_queries_to_ignore_hidden_events(): void {
 		// Create 4 events, of which 1 will be marked as "hidden from event listings"
 		$this->factory()->event->create_many( 3 );
 		$this->factory()->event->create( [ 'meta_input' => [ '_EventHideFromUpcoming' => 'yes' ] ] );
@@ -121,7 +129,7 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @since 4.6.10
 	 */
-	public function should_allow_queries_to_fetch_hidden_events() {
+	public function should_allow_queries_to_fetch_hidden_events(): void {
 		// Create 4 events, of which 1 will be marked as "hidden from event listings"
 		$this->factory()->event->create_many( 3 );
 		$this->factory()->event->create( [ 'meta_input' => [ '_EventHideFromUpcoming' => 'yes' ] ] );
@@ -140,7 +148,7 @@ class QueryTest extends Events_TestCase {
 	 * @test
 	 * @link https://moderntribe.atlassian.net/browse/TEC-3530
 	 */
-	public function should_bail_out_of_all_filtering_if_tribe_suppress_query_filters_set() {
+	public function should_bail_out_of_all_filtering_if_tribe_suppress_query_filters_set(): void {
 		// Run a Venue query first, this will hook the filters and is the condition that would trigger the issue.
 		new \WP_Query( [ 'post_type' => Venue::POSTTYPE ] );
 
@@ -204,15 +212,10 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @test
 	 */
-	public function should_not_parse_query_in_admin_context() {
+	public function should_not_parse_query_in_admin_context(): void {
 		// Simulate an admin context request.
 		$this->uopz_set_return( 'is_admin', true );
-		// Disconnect the query to make sure it will parse when explicitly called.
-		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
-
 		$wp_query = new WP_Query( [ 'post_type' => 'tribe_events' ] );
-
-		Query::parse_query( $wp_query );
 
 		$this->assertFalse( isset( $wp_query->tribe_is_event ) );
 	}
@@ -222,13 +225,8 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @test
 	 */
-	public function should_not_parse_a_query_if_tec_query_filters_are_suppressed() {
-		// Disconnect the query to make sure it will parse when explicitly called.
-		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
-
+	public function should_not_parse_a_query_if_tec_query_filters_are_suppressed(): void {
 		$wp_query = new WP_Query( [ 'post_type' => 'tribe_events', 'tribe_suppress_query_filters' => true ] );
-
-		Query::parse_query( $wp_query );
 
 		$this->assertFalse( isset( $wp_query->tribe_is_event ) );
 	}
@@ -238,43 +236,298 @@ class QueryTest extends Events_TestCase {
 	 *
 	 * @test
 	 */
-	public function should_not_filter_main_query_for_post_or_page() {
-		// Disconnect the query to make sure it will parse when explicitly called.
-		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
+	public function should_not_filter_main_query_for_post_or_page(): void {
 		// Simulate a main query to fetch a post.
 		global $wp_the_query;
-		$id       = $this->factory()->post->create();
-		$wp_the_query = new WP_Query( [ 'p' => $id ] );
+		$id           = $this->factory()->post->create();
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'p' => $id ] );
 
-		Query::parse_query( $wp_the_query );
 
-		$this->assertFalse( isset( $wp_the_query->tribe_is_event ) );
-	}
-
-	public function tec_post_types_data_provider(): array {
-		return [
-			'Event'     => [ Main::POSTTYPE ],
-			'Organizer' => [ Organizer::POSTTYPE ],
-			'Venue'     => [ Venue::POSTTYPE ],
-		];
+		$this->assertNull( $wp_the_query->tribe_is_event );
 	}
 
 	/**
 	 * It should set TEC post type main query paged prop based on Events paged query var
 	 *
 	 * @test
-	 * @dataProvider tec_post_types_data_provider
 	 */
-	public function should_set_TEC_post_type_main_query_paged_prop_based_on_events_paged_query_var(string $tec_post_type): void {
-		// Disconnect the query to make sure it will parse when explicitly called.
-		remove_action( 'parse_query', [ Query::class, 'parse_query' ], 50 );
-		// Simulate a main query to fetch a post.
+	public function should_set_TEC_post_type_main_query_paged_prop_based_on_events_paged_query_var(): void {
+		// Simulate a request to $_GET the `tribe_paged=3`.
+		$_GET['tribe_paged'] = 3;
+		// Simulate a main query to fetch Events.
 		global $wp_the_query;
-		$id       = $this->factory()->post->create();
-		$wp_the_query = new WP_Query( [ 'post_type' => $tec_post_type ] );
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Main::POSTTYPE ] );
 
-		Query::parse_query( $wp_the_query );
+		$this->assertEquals( 3, $wp_the_query->get( 'paged' ) );
+		$this->assertTrue( $wp_the_query->tribe_is_event );
+		$this->assertFalse( $wp_the_query->tribe_is_event_venue );
+		$this->assertFalse( $wp_the_query->tribe_is_event_organizer );
 
-		$this->assertFalse( isset( $wp_the_query->tribe_is_event ) );
+		// Simulate a main query to fetch Venues.
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Venue::POSTTYPE ] );
+
+		$this->assertEquals( 3, $wp_the_query->get( 'paged' ) );
+		$this->assertFalse( $wp_the_query->tribe_is_event );
+		$this->assertTrue( $wp_the_query->tribe_is_event_venue );
+		$this->assertFalse( $wp_the_query->tribe_is_event_organizer );
+
+		// Simulate a main query to fetch Organizers.
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Organizer::POSTTYPE ] );
+
+		$this->assertEquals( 3, $wp_the_query->get( 'paged' ) );
+		$this->assertFalse( $wp_the_query->tribe_is_event );
+		$this->assertFalse( $wp_the_query->tribe_is_event_venue );
+		$this->assertTrue( $wp_the_query->tribe_is_event_organizer );
+	}
+
+	/**
+	 * It should filter query on front for home queries
+	 *
+	 * @test
+	 */
+	public function should_filter_query_on_front_for_home_queries(): void {
+		// Start with the default setting of "Your latest posts".
+		update_option( 'page_on_front', 0 );
+
+		$this->assertFalse(
+			has_filter( 'option_page_on_front', [ Query::class, 'default_page_on_front' ] ),
+			'To start, the query should not filtering the `page_on_front` option.'
+		);
+
+		// Simulate a main query for the home page.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => 'posts' ] );
+
+		// To start, the query should not filtering the `page_on_front` option.
+		$this->assertEquals(
+			10,
+			has_filter( 'option_page_on_front', [ Query::class, 'default_page_on_front' ] ),
+			'Page on front should be filterd for home queries.'
+		);
+	}
+
+	/**
+	 * It should correctly add Event post type to home queries depending on events show in loop option
+	 *
+	 * @test
+	 */
+	public function should_correctly_add_event_post_type_to_home_queries_depending_on_events_show_in_loop_option(): void {
+		// Start with the default setting of "Your latest posts".
+		update_option( 'page_on_front', 0 );
+
+		// Events should not show in the loop.
+		tribe_update_option( 'showEventsInMainLoop', false );
+
+		// Simulate a main query for the home page targeting posts.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => 'post' ] );
+
+		$this->assertEquals( 'post', $wp_the_query->get( 'post_type' ) );
+		$this->assertFalse( $wp_the_query->tribe_is_multi_posttype );
+
+		// Events should appear in the loop.
+		tribe_update_option( 'showEventsInMainLoop', true );
+
+		// Simulate a main query for the home page targeting posts.
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => 'post' ] );
+
+		$this->assertEquals( [ Main::POSTTYPE, 'post' ], $wp_the_query->get( 'post_type' ) );
+		$this->assertTrue( $wp_the_query->tribe_is_multi_posttype );
+
+		// Simulate a main query for home targeting any post (already filtered, probably by a plugin).
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => 'any' ] );
+
+		$this->assertEquals( 'any', $wp_the_query->get( 'post_type' ) );
+		$this->assertTrue( $wp_the_query->tribe_is_multi_posttype );
+	}
+
+	/**
+	 * It should not add events to tag archives when looking at admin screen for posts
+	 *
+	 * @test
+	 */
+	public function should_not_add_events_to_tag_archives_when_looking_at_admin_screen_for_posts(): void {
+		// Simulate the fact we're looking at an admin tag archive for posts.
+		$this->uopz_set_return( Admin_Helpers::class, 'instance', new class extends Admin_Helpers {
+			public function is_post_type_screen( $post_type = null ) {
+				return true;
+			}
+		} );
+
+		// Create a query for a tag archive.
+		$tag   = static::factory()->tag->create();
+		$query = new WP_Query( [ 'post_type' => 'post', 'tag_id' => $tag ] );
+
+		$this->assertEquals( 'post', $query->get( 'post_type' ) );
+	}
+
+	/**
+	 * It should add events to tag archives when not looking at admin screen for posts
+	 *
+	 * @test
+	 */
+	public function should_add_events_to_tag_archives_when_not_looking_at_admin_screen_for_posts(): void {
+		// Simulate the fact we're looking at an admin tag archive for posts.
+		$this->uopz_set_return( Admin_Helpers::class, 'instance', new class extends Admin_Helpers {
+			public function is_post_type_screen( $post_type = null ) {
+				return false;
+			}
+		} );
+
+		// Create a query for a tag archive.
+		$tag   = static::factory()->tag->create();
+		$query = new WP_Query( [ 'post_type' => 'post', 'tag_id' => $tag ] );
+
+		$this->assertEquals( [ Main::POSTTYPE, 'post' ], $query->get( 'post_type' ) );
+
+		// Create a query for tag archive for any post (already filtered, probably by a plugin).
+		$tag   = static::factory()->tag->create();
+		$query = new WP_Query( [ 'post_type' => 'any', 'tag_id' => $tag ] );
+
+		$this->assertEquals( 'any', $query->get( 'post_type' ) );
+	}
+
+	/**
+	 * It should prevent 404 on Month View
+	 *
+	 * @test
+	 */
+	public function should_prevent_404_on_month_view(): void {
+		// Simulate a main query for Events, there are none in the database.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Main::POSTTYPE, 'eventDisplay' => 'month' ] );
+
+		$this->assertTrue( $wp_the_query->is_post_type_archive );
+		$this->assertInstanceOf( \WP_Post_Type::class, $wp_the_query->queried_object );
+		$this->assertEquals( Main::POSTTYPE, $wp_the_query->queried_object->name );
+		$this->assertEquals( 0, $wp_the_query->queried_object_id );
+	}
+
+	/**
+	 * It should set past flag correctly
+	 *
+	 * @test
+	 */
+	public function should_set_past_flag_correctly() {
+		// Start with a non-main query for Events.
+		$query = new WP_Query( [ 'post_type' => Main::POSTTYPE ] );
+
+		$this->assertFalse( $query->tribe_is_past );
+
+		// A main query for Events.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Main::POSTTYPE ] );
+
+		$this->assertFalse( $wp_the_query->tribe_is_past );
+
+		// A main query for Events specifying `eventDisplay=past`.
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Main::POSTTYPE, 'eventDisplay' => 'past' ] );
+
+		$this->assertTrue( $wp_the_query->tribe_is_past );
+
+		// A main query for Events where the event display comes from the context.
+		add_filter( 'tribe_context_pre_event_display', static function () {
+			return 'past';
+		} );
+
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query( [ 'post_type' => Main::POSTTYPE ] );
+
+		$this->assertTrue( $wp_the_query->tribe_is_past );
+	}
+
+	public function flag_properties_data_provider(): \Generator {
+		yield 'events query' => [
+			[ 'post_type' => Main::POSTTYPE ],
+			[
+				'tribe_is_event'           => true,
+				'tribe_is_multi_posttype'  => false,
+				'tribe_is_event_category'  => false,
+				'tribe_is_event_venue'     => false,
+				'tribe_is_event_organizer' => false,
+				'tribe_is_event_query'     => true,
+				'tribe_is_past'            => false,
+			]
+		];
+
+		yield 'past events query from query argument' => [
+			[ 'post_type' => Main::POSTTYPE, 'eventDisplay' => 'past' ],
+			[
+				'tribe_is_event'           => true,
+				'tribe_is_multi_posttype'  => false,
+				'tribe_is_event_category'  => false,
+				'tribe_is_event_venue'     => false,
+				'tribe_is_event_organizer' => false,
+				'tribe_is_event_query'     => true,
+				'tribe_is_past'            => true,
+			]
+		];
+
+		yield 'venues and organizers' => [
+			[ 'post_type' => [ Venue::POSTTYPE, Organizer::POSTTYPE ] ],
+			[
+				'tribe_is_event'           => false,
+				'tribe_is_multi_posttype'  => false,
+				'tribe_is_event_category'  => false,
+				'tribe_is_event_venue'     => false,
+				'tribe_is_event_organizer' => false,
+				'tribe_is_event_query'     => false,
+				'tribe_is_past'            => false,
+			]
+		];
+
+		yield 'venues query' => [
+			[ 'post_type' => Venue::POSTTYPE ],
+			[
+				'tribe_is_event'           => false,
+				'tribe_is_multi_posttype'  => false,
+				'tribe_is_event_category'  => false,
+				'tribe_is_event_venue'     => true,
+				'tribe_is_event_organizer' => false,
+				'tribe_is_event_query'     => true,
+				'tribe_is_past'            => false,
+			]
+		];
+
+		yield 'organizers query' => [
+			[ 'post_type' => Organizer::POSTTYPE ],
+			[
+				'tribe_is_event'           => false,
+				'tribe_is_multi_posttype'  => false,
+				'tribe_is_event_category'  => false,
+				'tribe_is_event_venue'     => false,
+				'tribe_is_event_organizer' => true,
+				'tribe_is_event_query'     => true,
+				'tribe_is_past'            => false,
+			]
+		];
+	}
+
+	/**
+	 * It should correctly set query flag properties
+	 *
+	 * @test
+	 * @dataProvider flag_properties_data_provider
+	 */
+	public function should_correctly_set_query_flag_properties( array $query_args, array $expected_props ): void {
+		$query = new WP_Query( $query_args );
+
+		foreach ( $expected_props as $prop => $expected ) {
+			$this->assertEquals(
+				$expected, $query->{$prop},
+				"Expected {$prop} to be {$expected} but it was {$query->{$prop}}"
+			);
+		}
 	}
 }

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -530,4 +530,26 @@ class QueryTest extends Events_TestCase {
 			);
 		}
 	}
+
+	/**
+	 * It should correctly add Events to main query for posts.
+	 *
+	 * This is the logic underlying the "Included Events in main blog loop" option in Events > Settings.
+	 *
+	 * @test
+	 */
+	public function should_correctly_add_events_to_main_query_for_postst(): void {
+		// Simulate a main query for posts, WordPress would NOT specify the `post_type`.
+		global $wp_the_query;
+		$wp_the_query = new WP_Query();
+		$wp_the_query->query([]);
+
+		$this->assertEquals( [ Main::POSTTYPE, 'post' ], $wp_the_query->get( 'post_type' ) );
+		$this->assertFalse( $wp_the_query->tribe_is_event );
+		$this->assertTrue( $wp_the_query->tribe_is_multi_posttype );
+		$this->assertFalse( $wp_the_query->tribe_is_event_category );
+		$this->assertFalse( $wp_the_query->tribe_is_event_venue );
+		$this->assertFalse( $wp_the_query->tribe_is_event_organizer );
+		$this->assertFalse( $wp_the_query->tribe_is_event_query );
+	}
 }

--- a/tests/wpunit/Tribe/Events/__snapshots__/QueryTest__should_not_add_date_based_orderby_clauses_when_not_required with data set none__1.php
+++ b/tests/wpunit/Tribe/Events/__snapshots__/QueryTest__should_not_add_date_based_orderby_clauses_when_not_required with data set none__1.php
@@ -1,7 +1,7 @@
 <?php return '
 					SELECT SQL_CALC_FOUND_ROWS  test_posts.ID
 					FROM test_posts 
-					WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' OR test_posts.post_status = \'future\' OR test_posts.post_status = \'draft\' OR test_posts.post_status = \'pending\')))
+					WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
 					
 					
 					LIMIT 0, 10

--- a/tests/wpunit/Tribe/Events/__snapshots__/QueryTest__should_not_add_date_based_orderby_clauses_when_not_required with data set rand__1.php
+++ b/tests/wpunit/Tribe/Events/__snapshots__/QueryTest__should_not_add_date_based_orderby_clauses_when_not_required with data set rand__1.php
@@ -1,7 +1,7 @@
 <?php return '
 					SELECT SQL_CALC_FOUND_ROWS  test_posts.ID
 					FROM test_posts 
-					WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' OR test_posts.post_status = \'future\' OR test_posts.post_status = \'draft\' OR test_posts.post_status = \'pending\')))
+					WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
 					
 					ORDER BY RAND()
 					LIMIT 0, 10


### PR DESCRIPTION
Ticket: [TEC-4588](https://theeventscalendar.atlassian.net/browse/TEC-4588)

This updates the removed, then restored, then refactored, then removed,
then refactored and restored `Tribe__Events__Query::parse_query` method
to reference the current parsed query to set its properties, and not the
context.

The context instance, provided by the `tribe_context()` function, will
model the whole request context and setting any query properties using
the whole request context would create a number of issues with secondary
queries.
