### PR TITLE
Moved pro logic to pro - removing here.

### DIFF
--- a/src/Events/Custom_Tables/V1/WP_Query/Provider.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Provider.php
@@ -86,6 +86,7 @@ class Provider extends \tad_DI52_ServiceProvider implements Serializable, Provid
 	 * @param  Repository  $repository  A reference to the instance of the repository that is initializing.
 	 */
 	public function replace_repository_query_filters( Repository $repository ) {
+		// NOTE: this hook is overwritten in Events Calendar Pro with Pro related query filters.
 		$custom_tables_query_filters = $this->container->make( Custom_Tables_Query_Filters::class );
 		add_filter( 'posts_groupby', [ $custom_tables_query_filters, 'group_by_occurrence_id' ], 200, 2 );
 		$repository->filter_query = $custom_tables_query_filters;

--- a/src/Events/Custom_Tables/V1/WP_Query/Provider.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Provider.php
@@ -86,7 +86,6 @@ class Provider extends \tad_DI52_ServiceProvider implements Serializable, Provid
 	 * @param  Repository  $repository  A reference to the instance of the repository that is initializing.
 	 */
 	public function replace_repository_query_filters( Repository $repository ) {
-		// NOTE: this hook is overwritten in Events Calendar Pro with Pro related query filters.
 		$custom_tables_query_filters = $this->container->make( Custom_Tables_Query_Filters::class );
 		add_filter( 'posts_groupby', [ $custom_tables_query_filters, 'group_by_occurrence_id' ], 200, 2 );
 		$repository->filter_query = $custom_tables_query_filters;

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -348,41 +348,6 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 	}
 
 	/**
-	 * Overrides the base method to handle requests based on the post parent, usually coming from PRO.
-	 *
-	 * @since 6.0.0
-	 *
-	 * @param string      $where_clause The original WHERE clause the repository is adding to the query.
-	 * @param string|null $id           An optional unique identifier for the query.
-	 * @param bool        $override     Whether to override a pre-existing WHERE clause with this one, if present, or
-	 *                                  not. This will only apply if the `$id` is provided.
-	 */
-	public function where( $where_clause, $id = null, $override = false ) {
-		global $wpdb;
-
-		// @see Tribe__Events__Pro__Repositories__Event::filter_by_in_series for the origin of this statement.
-		$is_in_series_where = preg_match(
-			'/^' . preg_quote( "{$wpdb->posts}.post_parent", '/' ) . '\\s?=\\s?(?<id>\\d+)/',
-			$where_clause,
-			$m );
-
-		// TODO: Move into PRO?
-		if ( $is_in_series_where && isset( $m['id'] ) ) {
-			$occurrences   = Occurrences::table_name( true );
-			$occurrence_id = Occurrence::normalize_id( absint( $m['id'] ) );
-			$occurrence    = Occurrence::find( $occurrence_id, 'occurrence_id' );
-
-			if ( ! $occurrence instanceof Occurrence ) {
-				return;
-			}
-
-			$where_clause = (string) $wpdb->prepare( "{$occurrences}.post_id = %d", $occurrence->post_id );
-		}
-
-		parent::where( $where_clause, $id, $override );
-	}
-
-	/**
 	 * Sets the mask value for a query var, or a list of query vars, that should be applied at filtering time.
 	 *
 	 * The mask will NOT change the value and content of each query var, it will just prevent the `filter_` methods
@@ -437,7 +402,7 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			// Nothing to deduplicate.
 			return $query_join;
 		}
-		
+
 		// Break each current JOIN clause into a set of couples in the shape `['JOIN' 'table on ...']`.
 		$query_vars_join_couples = [];
 		$preg_split_flags = PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE;


### PR DESCRIPTION
This is some cleanup related to: https://github.com/the-events-calendar/events-pro/pull/2134

Had some "series" logic that was fleshed out in Pro, it was removed from TEC repo.

Tests cover changes. See artifacts in [PRO PR](https://github.com/the-events-calendar/events-pro/pull/2134).