### PR TITLE
Add removed method back

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Avoid errors when third-party plugins reference or use the `Tribe__Events__Query::pre_get_posts` method. [TEC-4540]
+
 = [6.0.5] 2022-11-29 =
 
 * Fix - Fix for scenarios where fatal `Call to a member function get() on null in... the-events-calendar/src/Tribe/Query.php(46)` would occur when `$wp_query` global was not set. [TEC-4566]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -11,6 +11,8 @@ use Tribe__Events__Organizer as Organizer;
 use Tribe__Admin__Helpers as Admin_Helpers;
 
 class Tribe__Events__Query {
+	use Tribe__Events__Query_Deprecated;
+
 	/**
 	 * @since 4.9.4
 	 *

--- a/src/deprecated/Traits/Tribe__Events__Query_Deprecated.php
+++ b/src/deprecated/Traits/Tribe__Events__Query_Deprecated.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Handles the `Tribe__Events__Query` class deprecated methods.
+ *
+ * This trait will only make sense in the context of the `Tribe__Events__Query` class
+ * and it should not be used elsewhere.
+ *
+ * @since TBD
+ */
+
+/**
+ * Trait Tribe__Events__Query_Deprecated.
+ *
+ * @since TBD
+ */
+trait Tribe__Events__Query_Deprecated {
+	/**
+	 * Is hooked by init() filter to parse the WP_Query arguments for main and alt queries.
+	 *
+	 * @deprecated 6.0.0 Query filtering is now handled in the Views v2 component or the Custom Tables v1 component.
+	 *
+	 * @param object $query WP_Query object args supplied or default
+	 *
+	 * @return WP_Query $query The query, unmodified.
+	 */
+	public static function pre_get_posts( $query ) {
+		_deprecated_function(
+			'Tribe__Events__Query::pre_get_posts',
+			'6.0.0',
+			'No replacement avaialble.'
+		);
+	}
+}


### PR DESCRIPTION
Ticket: [TEC-4540](https://theeventscalendar.atlassian.net/browse/TEC-4540) 

Artifacts: tests.

This re-introduces the `Tribe__Events__Query::pre_get_posts` method back
in the `Tribe__Events__Query` class by means of the
`Tribe__Events__Query_Deprecated` trait.

The method is used by some third-party plugins to deal with TEC
compatibility and its removal caused issues.
