### PR TITLE
Changing UTC offsets to convert to localized timezone.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fix for a couple scenarios that would cause 404 pages on events. This addresses both an error from UTC offset validation failures and an issue where table renaming improperly created foreign keys that pointed to an invalid constraint target. [TEC-4578]
+
 = [6.0.5] 2022-11-29 =
 
 * Fix - Fix for scenarios where fatal `Call to a member function get() on null in... the-events-calendar/src/Tribe/Query.php(46)` would occur when `$wp_query` global was not set. [TEC-4566]

--- a/src/Events/Custom_Tables/V1/Models/Builder.php
+++ b/src/Events/Custom_Tables/V1/Models/Builder.php
@@ -412,7 +412,17 @@ class Builder {
 			$SQL             = $wpdb->prepare( $SQL, ...$validated['values'] );
 			$this->queries[] = $SQL;
 			if ( $this->execute_queries ) {
-				$result += (int) $wpdb->query( $SQL );
+				$query_result = $wpdb->query( $SQL );
+				$result       += (int) $query_result;
+			}
+			// Log our errors.
+			if ( $query_result === false && $wpdb->last_error ) {
+				do_action( 'tribe_log',
+					'error',
+					"ORM Builder mysql error while performing insert on {$this->model->table_name()}.", [
+						'source'      => __METHOD__ . ':' . __LINE__,
+						'mysql error' => $wpdb->last_error,
+					] );
 			}
 		} while ( count( $data ) );
 

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -257,8 +257,21 @@ abstract class Model implements Serializable {
 			static::$static_errors[ $name ] = $error_string;
 		}
 
+		if ( ! empty( $this->errors() ) ) {
+			// For debug purposes, log validation errors.
+			// These will fail update/insertions on the database.
+			do_action( 'tribe_log',
+				'debug',
+				"Model failed validation.", [
+					'source' => __METHOD__ . ':' . __LINE__,
+					'errors' => $this->errors(),
+				] );
+
+			return false;
+		}
+
 		// No errors were found.
-		return empty( $this->errors() );
+		return true;
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
@@ -49,9 +49,8 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 	 * immediately before the field creation or update.
 	 *
 	 * @since TBD
-	 *
 	 */
-	protected function before_update() {
+	protected function before_update() :void {
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
@@ -24,8 +24,8 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 	 * {@inheritdoc}
 	 */
 	public function update() {
+		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-
 		$results = (array) dbDelta( $this->get_update_sql() );
 		$this->sync_stored_version();
 		$results = $this->after_update( $results );
@@ -43,6 +43,16 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 	 *                by the `dbDelta` function.
 	 */
 	abstract protected function get_update_sql();
+
+	/**
+	 * Allows extending classes that require it to run some methods
+	 * immediately before the field creation or update.
+	 *
+	 * @since TBD
+	 *
+	 */
+	protected function before_update() {
+	}
 
 	/**
 	 * Allows extending classes that require it to run some methods

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -78,9 +78,8 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 * immediately before the table creation or update.
 	 *
 	 * @since TBD
-	 *
 	 */
-	protected function before_update() {
+	protected function before_update() :void {
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -163,7 +163,7 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 * @param string $this_field The field of the table that has the foreign key (not the target of the constraint).
 	 * @param string $this_table The table that has the foreign key (not the target of the constraint).
 	 *
-	 * @return stdClass|null
+	 * @return stdClass|null A stdClass with the INFORMATION_SCHEMA.key_column_usage or null if none found.
 	 */
 	public function get_schema_constraint( $this_field, $this_table ): ?stdClass {
 		global $wpdb;

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -9,6 +9,8 @@
 
 namespace TEC\Events\Custom_Tables\V1\Schema_Builder;
 
+use stdClass;
+
 /**
  * Class Base_Custom_Table
  *
@@ -51,6 +53,7 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 * {@inheritdoc}
 	 */
 	public function update() {
+		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$results = (array) dbDelta( $this->get_update_sql() );
 		$this->sync_stored_version();
@@ -69,6 +72,16 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 *                by the `dbDelta` function.
 	 */
 	abstract protected function get_update_sql();
+
+	/**
+	 * Allows extending classes that require it to run some methods
+	 * immediately before the table creation or update.
+	 *
+	 * @since TBD
+	 *
+	 */
+	protected function before_update() {
+	}
 
 	/**
 	 * Allows extending classes that require it to run some methods
@@ -127,6 +140,49 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 					$index
 				)
 			) >= 1;
+	}
+
+	/**
+	 * Checks if a constraint exists for a particular field.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $this_field The field of the table that has the foreign key (not the target of the constraint).
+	 * @param string $this_table The table that has the foreign key (not the target of the constraint).
+	 *
+	 * @return bool Whether this constraint exists.
+	 */
+	protected function has_constraint( $this_field, $this_table ): bool {
+		return ! empty( $this->get_schema_constraint( $this_field, $this_table ) );
+	}
+
+	/**
+	 * Fetches the constraint for a particular field.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $this_field The field of the table that has the foreign key (not the target of the constraint).
+	 * @param string $this_table The table that has the foreign key (not the target of the constraint).
+	 *
+	 * @return stdClass|null
+	 */
+	protected function get_schema_constraint( $this_field, $this_table ): ?stdClass {
+		global $wpdb;
+
+		$query = $wpdb->prepare(
+			"SELECT *
+		FROM INFORMATION_SCHEMA.key_column_usage
+		WHERE referenced_table_schema = DATABASE()
+			AND referenced_table_name IS NOT NULL
+			AND COLUMN_NAME= %s
+			AND TABLE_NAME = %s",
+			$this_field,
+			$this_table
+		);
+
+		$results = $wpdb->get_results( $query );
+
+		return ! empty( $results ) ? array_pop( $results ) : null;
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -152,7 +152,7 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 *
 	 * @return bool Whether this constraint exists.
 	 */
-	protected function has_constraint( $this_field, $this_table ): bool {
+	public function has_constraint( $this_field, $this_table ): bool {
 		return ! empty( $this->get_schema_constraint( $this_field, $this_table ) );
 	}
 
@@ -166,7 +166,7 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 *
 	 * @return stdClass|null
 	 */
-	protected function get_schema_constraint( $this_field, $this_table ): ?stdClass {
+	public function get_schema_constraint( $this_field, $this_table ): ?stdClass {
 		global $wpdb;
 
 		$query = $wpdb->prepare(

--- a/src/Events/Custom_Tables/V1/Tables/Occurrences.php
+++ b/src/Events/Custom_Tables/V1/Tables/Occurrences.php
@@ -85,27 +85,26 @@ class Occurrences extends Abstract_Custom_Table {
 	protected function after_update( array $results ) {
 		global $wpdb;
 		$this_table        = self::table_name( true );
-		$occurrences_table = self::table_name( true );
 		$updated           = false;
 		if (
 			$this->exists()
-			&& ! $this->has_index( 'event_id', $occurrences_table )
+			&& ! $this->has_index( 'event_id', $this_table )
 		) {
 			$SQL     = "ALTER TABLE {$this_table} ADD INDEX (event_id)";
 			$updated = $wpdb->query( $SQL );
 		} else if ( $this->exists()
-		            && $this->has_constraint( 'event_id', $occurrences_table ) ) {
+		            && $this->has_constraint( 'event_id', $this_table ) ) {
 			// We are moving away from foreign key constraints. If this is our old schema, find the FK name and drop it.
-			$constraint      = $this->get_schema_constraint( 'event_id', $occurrences_table );
+			$constraint      = $this->get_schema_constraint( 'event_id', $this_table );
 			$foreign_key_name = $constraint->CONSTRAINT_NAME ?? null;
 			if ( $foreign_key_name ) {
-				$updated = $wpdb->query( "ALTER TABLE {$occurrences_table} DROP FOREIGN KEY $foreign_key_name" );
+				$updated = $wpdb->query( "ALTER TABLE {$this_table} DROP FOREIGN KEY {$foreign_key_name}" );
 			}
 		}
 
 		$message = $updated
-			? "Added event_id as key in {$occurrences_table}"
-			: "Failed to add event_id as key in {$occurrences_table}";
+			? "Added event_id as key in {$this_table}"
+			: "Failed to add event_id as key in {$this_table}";
 
 		$results[ $this_table . '.event_id' ] = $message;
 

--- a/src/Events/Custom_Tables/V1/Tables/Occurrences.php
+++ b/src/Events/Custom_Tables/V1/Tables/Occurrences.php
@@ -25,9 +25,11 @@ class Occurrences extends Abstract_Custom_Table {
 	const SCHEMA_VERSION_OPTION = 'tec_ct1_occurrences_table_schema_version';
 
 	/**
+	 * @since TBD Will now simply create an `event_id` index, removes the foreign key from the previous version.
+	 *
 	 * @inheritDoc
 	 */
-	const SCHEMA_VERSION = '1.0.0';
+	const SCHEMA_VERSION = '1.0.1';
 
 	/**
 	 * @inheritDoc
@@ -74,32 +76,36 @@ class Occurrences extends Abstract_Custom_Table {
 	}
 
 	/**
-	 * Overrides the base method to add `event_id` as foreign key on the Events
-	 * custom table.
+	 * Overrides the base method to add `event_id` as key.
+	 *
+	 * @since TBD Will now create an `event_id` index, removes the foreign key from the previous version.
 	 *
 	 * {@inheritdoc}
 	 */
 	protected function after_update( array $results ) {
-		$this_table   = self::table_name( true );
-		$events_table = Events::table_name( true );
-
-		$updated = false;
+		global $wpdb;
+		$this_table        = self::table_name( true );
+		$occurrences_table = self::table_name( true );
+		$updated           = false;
 		if (
 			$this->exists()
-			&& $this->exists( Events::table_name( true ) )
-			&& ! $this->has_index( 'event_id', $events_table )
+			&& ! $this->has_index( 'event_id', $occurrences_table )
 		) {
-			global $wpdb;
-			$SQL = "ALTER TABLE {$this_table}
-				ADD FOREIGN KEY (event_id) REFERENCES {$events_table} (event_id)
-				ON DELETE CASCADE";
-
+			$SQL     = "ALTER TABLE {$this_table} ADD INDEX (event_id)";
 			$updated = $wpdb->query( $SQL );
+		} else if ( $this->exists()
+		            && $this->has_constraint( 'event_id', $occurrences_table ) ) {
+			// We are moving away from foreign key constraints. If this is our old schema, find the FK name and drop it.
+			$constraint      = $this->get_schema_constraint( 'event_id', $occurrences_table );
+			$foreign_key_name = $constraint->CONSTRAINT_NAME ?? null;
+			if ( $foreign_key_name ) {
+				$updated = $wpdb->query( "ALTER TABLE {$occurrences_table} DROP FOREIGN KEY $foreign_key_name" );
+			}
 		}
 
 		$message = $updated
-			? "Added event_id as foreign key from {$events_table}"
-			: "Failed to add event_id as foreign key from {$events_table}";
+			? "Added event_id as key in {$occurrences_table}"
+			: "Failed to add event_id as key in {$occurrences_table}";
 
 		$results[ $this_table . '.event_id' ] = $message;
 

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -452,12 +452,15 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				return $data;
 			}
 
+			$utc_tz = new DateTimeZone( 'UTC' );
+			$is_utc_offset = Tribe__Events__Timezones::is_utc_offset( $data['EventTimezone'] );
+
 			// Additionally store datetimes in UTC
 			if ( empty( $data['EventStartDateUTC'] ) ) {
-				if ( Tribe__Events__Timezones::is_utc_offset( $data['EventTimezone'] ) ) {
+				if ( $is_utc_offset ) {
 					// Convert a UTC offset timezone to a localized timezone, e.g. UTC-5 to America/New_York.
 					$data['EventStartDateUTC'] = Tribe__Date_Utils::immutable( $data['EventStartDate'], $data['EventTimezone'] )
-					                                              ->setTimezone( new DateTimeZone( 'UTC' ) )
+					                                              ->setTimezone( $utc_tz )
 					                                              ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 				} else {
 					$data['EventStartDateUTC'] = Tribe__Events__Timezones::to_utc( $data['EventStartDate'], $data['EventTimezone'] );
@@ -465,10 +468,10 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 			}
 
 			if ( empty( $data['EventEndDateUTC'] ) ) {
-				if ( Tribe__Events__Timezones::is_utc_offset( $data['EventTimezone'] ) ) {
+				if ( $is_utc_offset ) {
 					// Convert a UTC offset timezone to a localized timezone, e.g. UTC-5 to America/New_York.
 					$data['EventEndDateUTC'] = Tribe__Date_Utils::immutable( $data['EventEndDate'], $data['EventTimezone'] )
-					                                            ->setTimezone( new DateTimeZone( 'UTC' ) )
+					                                            ->setTimezone( $utc_tz )
 					                                            ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
 				} else {
 					$data['EventEndDateUTC'] = Tribe__Events__Timezones::to_utc( $data['EventEndDate'], $data['EventTimezone'] );

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -454,11 +454,25 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 
 			// Additionally store datetimes in UTC
 			if ( empty( $data['EventStartDateUTC'] ) ) {
-				$data['EventStartDateUTC'] = Tribe__Events__Timezones::to_utc( $data['EventStartDate'], $data['EventTimezone'] );
+				if ( Tribe__Events__Timezones::is_utc_offset( $data['EventTimezone'] ) ) {
+					// Convert a UTC offset timezone to a localized timezone, e.g. UTC-5 to America/New_York.
+					$data['EventStartDateUTC'] = Tribe__Date_Utils::immutable( $data['EventStartDate'], $data['EventTimezone'] )
+					                                              ->setTimezone( new DateTimeZone( 'UTC' ) )
+					                                              ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+				} else {
+					$data['EventStartDateUTC'] = Tribe__Events__Timezones::to_utc( $data['EventStartDate'], $data['EventTimezone'] );
+				}
 			}
 
 			if ( empty( $data['EventEndDateUTC'] ) ) {
-				$data['EventEndDateUTC']   = Tribe__Events__Timezones::to_utc( $data['EventEndDate'], $data['EventTimezone'] );
+				if ( Tribe__Events__Timezones::is_utc_offset( $data['EventTimezone'] ) ) {
+					// Convert a UTC offset timezone to a localized timezone, e.g. UTC-5 to America/New_York.
+					$data['EventEndDateUTC'] = Tribe__Date_Utils::immutable( $data['EventEndDate'], $data['EventTimezone'] )
+					                                            ->setTimezone( new DateTimeZone( 'UTC' ) )
+					                                            ->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+				} else {
+					$data['EventEndDateUTC'] = Tribe__Events__Timezones::to_utc( $data['EventEndDate'], $data['EventTimezone'] );
+				}
 			}
 
 			// sanity check that start date < end date

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/ControllerTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/ControllerTest.php
@@ -115,6 +115,6 @@ class ControllerTest extends \Codeception\TestCase\WPTestCase {
 		$controller = new Controller( new Meta_Watcher(), $requests, $events );
 		$affected   = $controller->delete_custom_tables_data( $event_id, $requests->from_http_request() );
 
-		$this->assertEquals( 1, $affected );
+		$this->assertEquals( 2, $affected );
 	}
 }

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/Post_Save_EventsTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/Post_Save_EventsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace TEC\Events\Custom_Tables\V1\Updates;
+
+use Codeception\TestCase\WPTestCase;
+use DateTime;
+use Tribe\Events\Test\Factories\Event as Event_Factory;
+use Tribe__Date_Utils;
+use Tribe__Events__Main;
+
+class Post_Save_EventsTest extends WPTestCase {
+
+	public function _setUp() {
+		parent::_setUp();
+		$_POST              = [];
+		$_POST['ecp_nonce'] = wp_create_nonce( Tribe__Events__Main::POSTTYPE );
+
+		add_filter( 'user_has_cap', [ $this, 'user_has_cap_filter' ], 10, 2 );
+	}
+
+	public function _tearDown() {
+		remove_filter( 'user_has_cap', [ $this, 'user_has_cap_filter' ], 10 );
+		$_POST = [];
+		parent::_tearDown();
+	}
+
+	public function integration_data_provider() {
+		// @todo meta_input
+		return [
+			'Testing UTC-5 with DST'             => [
+				[
+					'EventStartDate' => '2022-11-01',
+					'EventEndDate'   => '2022-11-01',
+					'EventTimezone'  => 'UTC-5',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+			'Testing UTC-5 w/out DST'            => [
+				[
+					'EventStartDate' => '2022-12-12',
+					'EventEndDate'   => '2022-12-12',
+					'EventTimezone'  => 'UTC-5',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+			'Testing UTC with DST'               => [
+				[
+					'EventStartDate' => '2022-11-01',
+					'EventEndDate'   => '2022-11-01',
+					'EventTimezone'  => 'UTC',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+			'Testing UTC w/out DST'              => [
+				[
+					'EventStartDate' => '2022-12-12',
+					'EventEndDate'   => '2022-12-12',
+					'EventTimezone'  => 'UTC',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+			'Testing America/New_York with DST'  => [
+				[
+					'EventStartDate' => '2022-11-01',
+					'EventEndDate'   => '2022-11-01',
+					'EventTimezone'  => 'America/New_York',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+			'Testing America/New_York w/out DST' => [
+				[
+					'EventStartDate' => '2022-12-12',
+					'EventEndDate'   => '2022-12-12',
+					'EventTimezone'  => 'America/New_York',
+					'EventStartTime' => '18:45:25',
+					'EventEndTime'   => '19:45:25',
+				]
+			],
+		];
+	}
+
+	public function user_has_cap_filter( $allcaps, $caps ) {
+		$caps['edit_tribe_events'] = true;
+
+		return $caps;
+	}
+
+	/**
+	 * Should more fully test our integration with Tribe__Events__API and CT1 insertion of events with various data.
+	 *
+	 * @dataProvider integration_data_provider
+	 * @test
+	 */
+	public function should_update_event_with_no_changes_after_creation( $vars ) {
+		$_POST = array_merge( $_POST, $vars );
+
+		// Build objects
+		$event_start_date = new DateTime( $_POST['EventStartDate'] . ' ' . $_POST['EventStartTime'] );
+		$event_end_date   = new DateTime( $_POST['EventEndDate'] . ' ' . $_POST['EventEndTime'] );
+
+		$event_id = ( new Event_Factory() )->create(
+			[
+				'when'     => $event_start_date->format( Tribe__Date_Utils::DBDATETIMEFORMAT ),
+				'duration' => $event_end_date->format( 'U' ) - $event_start_date->format( 'U' ),
+				'timezone' => $_POST['EventTimezone']
+			]
+		);
+
+		$events  = new Events();
+		$updated = $events->update( $event_id );
+		$this->assertTrue( $updated );
+	}
+}


### PR DESCRIPTION
[TEC-4578](https://theeventscalendar.atlassian.net/browse/TEC-4578)

This PR fixes two separate issues that caused 404's. The core issue is that CT1 table data is not being created, the reasons are completely unrelated.

1) We were creating UTC start/end dates different than legacy in our validators. This would fail to insert any data due to this inconsistency. Now using a consistent approach with how we handle offsets in Legacy and CT1 interpretation. Now DST will be respected when the offset is converted to the localized timezone.
2) There appears to have been some database "corruption" in some clients installations. Basically the foreign key association made in our occurrence table would point to a "missing" table, failing all insertions. Not sure how this happens, but we are removing the foreign key in this version. This will simplify support moving forward, plus is not necessary with our table cleanup.
3) Adding some logging. Both errors were not being logged even with `WP_DEBUG` flagged. Now these failure points will log on failure.

https://www.loom.com/share/eacf772113c644ef8d99b0b8152f085f