### PR TITLE
ECP-1319 - prevent serialize notice during migration in PHP 8.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,7 +235,6 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Avoid query filtering issues where the Event post type would be incorrectly added to queries. [TEC-4588]
 * Fix - Incorrect results when including Events in the main blog loop. [TEC-4474]
 * Fix - Avoid errors when third-party plugins reference or use the `Tribe__Events__Query::pre_get_posts` method. [TEC-4540]
-* Fix - Ensure the `Previous Events` button when using the `Event View` Elementor widget navigates correctly to the previous page. [FBAR-273]
 * Fix - Prevent Serializable interface deprecated error in PHP 8.1 when migrating events. [ECP-1319]
 * Tweak - Add aria label to Google Maps iFrame embed to improve accessibility. [TEC-4404]
 

--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Incorrect results when including Events in the main blog loop. [TEC-4474]
 * Fix - Avoid errors when third-party plugins reference or use the `Tribe__Events__Query::pre_get_posts` method. [TEC-4540]
 * Fix - Ensure the `Previous Events` button when using the `Event View` Elementor widget navigates correctly to the previous page. [FBAR-273]
+* Fix - Prevent Serializable interface deprecated error in PHP 8.1 when migrating events. [ECP-1319]
 * Tweak - Add aria label to Google Maps iFrame embed to improve accessibility. [TEC-4404]
 
 = [6.0.5] 2022-11-29 =

--- a/src/Events/Custom_Tables/V1/Models/Event.php
+++ b/src/Events/Custom_Tables/V1/Models/Event.php
@@ -9,9 +9,6 @@
 
 namespace TEC\Events\Custom_Tables\V1\Models;
 
-use DateTime;
-use DateTimeZone;
-use Exception;
 use TEC\Events\Custom_Tables\V1\Models\Formatters\Date_Formatter;
 use TEC\Events\Custom_Tables\V1\Models\Formatters\End_Date_Formatter;
 use TEC\Events\Custom_Tables\V1\Models\Formatters\Integer_Key_Formatter;

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -532,24 +532,38 @@ abstract class Model implements Serializable {
 	 * If a model is cached, make sure only the important data is serialized, to reduce the amount of space that the
 	 * object uses when stored as a string.
 	 *
-	 * @since 6.0.0
+	 * @since TBD
+	 *
 	 * @return string The string representing the object.
 	 */
-	public function serialize() {
+	public function __serialize(): array {
 		$encode = wp_json_encode( $this->to_array() );
 
 		return is_string( $encode ) ? $encode : '';
 	}
 
 	/**
+	 * If a model is cached, make sure only the important data is serialized, to reduce the amount of space that the
+	 * object uses when stored as a string.
+	 *
+	 * @since 6.0.0
+	 * @since TBD - Utilize magic method for 8.1 support.
+	 *
+	 * @return string The string representing the object.
+	 */
+	public function serialize(): string {
+		return serialize( $this->__serialize() );
+	}
+
+	/**
 	 * If this object is constructed out of a `unserialize` call make sure the properties are set up correctly on the
 	 * object.
 	 *
-	 * @since 6.0.0
+	 * @since TBD
 	 *
 	 * @param  string  $serialized
 	 */
-	public function unserialize( $serialized ) {
+	public function __unserialize(array $serialized): void {
 		$data = json_decode( $serialized, true );
 
 		if ( ! is_array( $data ) ) {
@@ -559,6 +573,19 @@ abstract class Model implements Serializable {
 		foreach ( $data as $column => $value ) {
 			$this->{$column} = $value;
 		}
+	}
+
+	/**
+	 * If this object is constructed out of a `unserialize` call make sure the properties are set up correctly on the
+	 * object.
+	 *
+	 * @since 6.0.0
+	 * @since TBD - Utilize magic method for 8.1 support.
+	 *
+	 * @param  string  $serialized
+	 */
+	public function unserialize( $serialized ) {
+		$this->__unserialize( unserialize( $serialized ) );
 	}
 
 	/**


### PR DESCRIPTION
When on PHP 8.1 if you run the migration you can trigger a notice that stops the migration:

"[TECEventsCustom_TablesV1ModelsEvent implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)]"

This PR fixes that issue and retains backwards compatibility with PHP.

_Ref:_ [ECP-1319](https://theeventscalendar.atlassian.net/browse/ECP-1319)


Artifacts: None