### PR TITLE
Ensure the `Prev` button when using the `Event View` Elementor widget works as expected. [FBAR-273]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Avoid query filtering issues where the Event post type would be incorrectly added to queries. [TEC-4588]
 * Fix - Incorrect results when including Events in the main blog loop. [TEC-4474]
 * Fix - Avoid errors when third-party plugins reference or use the `Tribe__Events__Query::pre_get_posts` method. [TEC-4540]
+* Fix - Ensure the `Previous Events` button when using the `Event View` Elementor widget navigates correctly to the previous page. [FBAR-273]
 * Tweak - Add aria label to Google Maps iFrame embed to improve accessibility. [TEC-4404]
 
 = [6.0.5] 2022-11-29 =

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -310,7 +310,7 @@ tribe.events.views.manager = {};
 
 		var $link = $( this );
 		var url = $link.attr( 'href' );
-		var currentUrl = containerData.url;
+		var prevUrl = containerData.prev_url;
 		var nonce = $link.data( 'view-rest-nonce' );
 		var shouldManageUrl = obj.shouldManageUrl( $container );
 		var shortcodeId = $container.data( 'view-shortcode' );
@@ -321,7 +321,7 @@ tribe.events.views.manager = {};
 		}
 
 		var data = {
-			prev_url: encodeURI( decodeURI( currentUrl ) ),
+			prev_url: encodeURI( decodeURI( prevUrl ) ),
 			url: encodeURI( decodeURI( url ) ),
 			should_manage_url: shouldManageUrl,
 			_wpnonce: nonce,


### PR DESCRIPTION
Ticket: [FBAR-273](https://theeventscalendar.atlassian.net/browse/FBAR-273)

This PR ensures that the previous events url is passed correctly to the `Previous Events` navigation button in the `Event View` widget on initial page load. 

This fixes the issue where users weren't able to navigate to previous events without first navigating to the next events. 

Artifact 👇🏽

https://www.loom.com/share/e6a87441906d49ffad97e23fd9157556

