### PR TITLE
Ensure that when we hit a single-event iCal URL we get a the correct single event.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Avoid errors when third-party plugins reference or use the `Tribe__Events__Query::pre_get_posts` method. [TEC-4540]
 * Fix - Prevent Serializable interface deprecated error in PHP 8.1 when migrating events. [ECP-1319]
 * Fix - Ensure the `Previous Events` button when using the `Event View` Elementor widget navigates correctly to the previous page. [FBAR-273]
+* Fix - Ensure that when we hit a single-event ical endpoint we get a the correct single event. [TEC-4469]
 * Tweak - Add aria label to Google Maps iFrame embed to improve accessibility. [TEC-4404]
 * Tweak - Prevent unbound query for previous URL on list based views, improving performance.
 * Tweak - Additional views setup no longer run extra Database Query unnecessarily, improving performance.

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -69,7 +69,7 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 						Tribe__Context::FUNC             => [
 							static function () {
-								if ( 1 === (int) get_query_var( 'ical', 0 ) && is_singular( TEC::POSTTYPE) ) {
+								if ( 1 === (int) tribe_get_request_var( 'ical', 0 ) && is_singular( TEC::POSTTYPE) ) {
 									return 'single-event';
 								}
 

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -69,7 +69,7 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
 						Tribe__Context::FUNC             => [
 							static function () {
-								if ( 1 === (int) tribe_get_request_var( 'ical', 0 ) && is_singular( TEC::POSTTYPE) ) {
+								if ( 1 === (int) tribe_get_request_var( 'ical', 0 ) && is_singular( TEC::POSTTYPE ) ) {
 									return 'single-event';
 								}
 

--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -67,6 +67,15 @@ class Context extends \tad_DI52_ServiceProvider {
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
 						Tribe__Context::REQUEST_VAR      => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
 						Tribe__Context::QUERY_VAR        => [ 'tribe_view', 'eventDisplay' ],
+						Tribe__Context::FUNC             => [
+							static function () {
+								if ( 1 === (int) get_query_var( 'ical', 0 ) && is_singular( TEC::POSTTYPE) ) {
+									return 'single-event';
+								}
+
+								return Tribe__Context::NOT_FOUND;
+							}
+						],
 						Tribe__Context::TRIBE_OPTION     => 'viewOption',
 					],
 					'write' => [

--- a/src/Tribe/Views/V2/iCalendar/Request.php
+++ b/src/Tribe/Views/V2/iCalendar/Request.php
@@ -12,7 +12,6 @@ namespace Tribe\Events\Views\V2\iCalendar;
 use Tribe\Events\Views\V2\View;
 use Tribe__Context as Context;
 use Tribe__Events__iCal as iCal;
-use Tribe__Events__Main as Main;
 
 /**
  * Class Request

--- a/src/Tribe/Views/V2/iCalendar/Request.php
+++ b/src/Tribe/Views/V2/iCalendar/Request.php
@@ -12,6 +12,7 @@ namespace Tribe\Events\Views\V2\iCalendar;
 use Tribe\Events\Views\V2\View;
 use Tribe__Context as Context;
 use Tribe__Events__iCal as iCal;
+use Tribe__Events__Main as Main;
 
 /**
  * Class Request
@@ -66,13 +67,13 @@ class Request {
 	public function get_event_ids() {
 		$view_slug = $this->context->get( 'view', 'default' );
 
-		if ( 'single-event' !== $view_slug ) {
+		if ( 'single-event' !== $view_slug && ! is_singular( Main::POSTTYPE ) ) {
 			$view      = View::make( $view_slug, $this->context );
 			$event_ids = $view->get_ical_ids( $this->ical->feed_posts_per_page() );
 		} else {
 			$event_ids = [ $this->context->get( 'post_id' ) ];
-		}
 
+		}
 
 		return $event_ids;
 	}

--- a/src/Tribe/Views/V2/iCalendar/Request.php
+++ b/src/Tribe/Views/V2/iCalendar/Request.php
@@ -67,7 +67,7 @@ class Request {
 	public function get_event_ids() {
 		$view_slug = $this->context->get( 'view', 'default' );
 
-		if ( 'single-event' !== $view_slug && ! is_singular( Main::POSTTYPE ) ) {
+		if ( 'single-event' !== $view_slug ) {
 			$view      = View::make( $view_slug, $this->context );
 			$event_ids = $view->get_ical_ids( $this->ical->feed_posts_per_page() );
 		} else {

--- a/src/Tribe/Views/V2/iCalendar/Request.php
+++ b/src/Tribe/Views/V2/iCalendar/Request.php
@@ -72,7 +72,6 @@ class Request {
 			$event_ids = $view->get_ical_ids( $this->ical->feed_posts_per_page() );
 		} else {
 			$event_ids = [ $this->context->get( 'post_id' ) ];
-
 		}
 
 		return $event_ids;


### PR DESCRIPTION
[TEC-4469]

Per conversation with @bordoni I have changed to altering the Context object to recognize a single iCal URL as `single-event`

[TEC-4469]: https://theeventscalendar.atlassian.net/browse/TEC-4469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ