### PR TITLE
Fix more PHP 8.1 deprecation issues and PHP 7.4 fatal

### DIFF
--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -547,12 +547,10 @@ abstract class Model implements Serializable {
 	 *
 	 * @since TBD
 	 *
-	 * @return string The string representing the object.
+	 * @return array The array representation of the object.
 	 */
 	public function __serialize(): array {
-		$encode = wp_json_encode( $this->to_array() );
-
-		return is_string( $encode ) ? $encode : '';
+		return $this->to_array();
 	}
 
 	/**
@@ -574,16 +572,10 @@ abstract class Model implements Serializable {
 	 *
 	 * @since TBD
 	 *
-	 * @param  string  $serialized
+	 * @param  array  $serialized The array representation of the object.
 	 */
 	public function __unserialize(array $serialized): void {
-		$data = json_decode( $serialized, true );
-
-		if ( ! is_array( $data ) ) {
-			return;
-		}
-
-		foreach ( $data as $column => $value ) {
+		foreach ( $serialized as $column => $value ) {
 			$this->{$column} = $value;
 		}
 	}

--- a/src/Events/Custom_Tables/V1/WP_Query/Monitors/Query_Monitor.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Monitors/Query_Monitor.php
@@ -208,7 +208,8 @@ trait Query_Monitor {
 	/**
 	 * Return the number of Queries to which at least one modifier is attached.
 	 *
-	 * @since 6.0.0 *
+	 * @since 6.0.0 
+	 *
 	 * @return int The number of modifier instances.
 	 */
 	#[\ReturnTypeWillChange]

--- a/src/Events/Custom_Tables/V1/WP_Query/Monitors/Query_Monitor.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Monitors/Query_Monitor.php
@@ -208,10 +208,10 @@ trait Query_Monitor {
 	/**
 	 * Return the number of Queries to which at least one modifier is attached.
 	 *
-	 * @since 6.0.0
-	 *
+	 * @since 6.0.0 *
 	 * @return int The number of modifier instances.
 	 */
+	#[\ReturnTypeWillChange]
 	public function count() {
 		return $this->modifiers->count();
 	}

--- a/src/Events/Custom_Tables/V1/WP_Query/Provider.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Provider.php
@@ -109,11 +109,38 @@ class Provider extends \tad_DI52_ServiceProvider implements Serializable, Provid
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param string $data The dat
+	 * @param string $data The data to unserialize.
 	 *
 	 * @return void Return void to not spawn the object from serialized data.
 	 */
 	public function unserialize( $data ) {
 		return;
 	}
+
+	/**
+	 * Implements the method that is going to be invoked to serialize
+	 * the class to make sure the Container instance, that uses non-serializable
+	 * Closures, will not be part of the serialized data.
+	 *
+	 * @since TBD
+	 *
+	 * @return array An empty array, the object is not serializable.
+	 */
+	public function __serialize():array {
+		return [];
+	}
+
+	/**
+	 * Returns void to not spawn the object from serialized data.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The data to unserialize.
+	 *
+	 * @return void Return void to not spawn the object from serialized data.
+	 */
+	public function __unserialize( array $data ): void {
+		return;
+	}
+
 }

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -639,7 +639,11 @@ class Tribe__Events__Rewrite extends Tribe__Rewrite {
 			return $query_vars;
 		}
 
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $url_query_vars );
+		$query_string   = parse_url( $url, PHP_URL_QUERY );
+		$url_query_vars = [];
+		if ( ! empty( $query_string ) ) {
+			parse_str( $query_string, $url_query_vars );
+		}
 
 		if (
 			! isset( $query_vars['eventDisplay'], $url_query_vars['eventDisplay'] )


### PR DESCRIPTION
Ticket: [ECP-1319](https://theeventscalendar.atlassian.net/browse/ECP-1319)

[Screencast](https://share.cleanshot.com/jSiAGj)

This updates the original fix code to take care of a fatal on PHP 7.4 and remove more deprecated notices.

Note: when the class is updated to use the `__serialize` and `__unserialize` methods, then those will be used in place of the previously implemented `serialize` and `unserialize` ones; this means existing tests are already covering the changes.