### PR TITLE
fix(Front_Page_View) set main page to custom link

### DIFF
--- a/src/Tribe/Front_Page_View.php
+++ b/src/Tribe/Front_Page_View.php
@@ -30,6 +30,7 @@ class Tribe__Events__Front_Page_View {
 			// Implement front page view
 			add_action( 'parse_query', [ $this, 'parse_query' ], 5 );
 			add_filter( 'tribe_events_get_link', [ $this, 'main_event_page_links' ] );
+			add_filter( 'pre_option_page_on_front', [ $this, 'hydrate_virtual_page_cache' ] );
 		}
 
 		add_action( 'parse_query', [ $this, 'parse_customizer_query' ] );
@@ -235,6 +236,8 @@ class Tribe__Events__Front_Page_View {
 			return $output;
 		}
 
+		$this->hydrate_virtual_page_cache();
+
 		$label = sprintf(
 			esc_html_x( 'Main %s Page', 'Customizer static front page setting', 'the-events-calendar' ),
 			tribe_get_event_label_plural()
@@ -243,6 +246,7 @@ class Tribe__Events__Front_Page_View {
 		$selected = $this->is_page_on_front() ? 'selected' : '';
 		$option = '<option class="level-0" value="' . $this->get_virtual_id() . '" ' . $selected . '>' . $label . '</option></select>';
 		return str_replace( '</select>', $option, $output );
+
 	}
 
 	/**
@@ -268,6 +272,7 @@ class Tribe__Events__Front_Page_View {
 		} elseif ( 'page' === $value && $this->is_virtual_page_on_front() ) {
 			tribe_update_option( 'front_page_event_archive', true );
 		}
+
 		return $value;
 	}
 
@@ -348,5 +353,25 @@ class Tribe__Events__Front_Page_View {
 	 */
 	public function get_virtual_id() {
 		return $this->home_virtual_ID;
+	}
+
+	/**
+	 * Hydrates the post cache for the post that should represent the virtual page.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed|null $input The first iput of the method, when used as a filter.
+	 *
+	 * @return mixed|null The first input of the method, when used as a filter, unmodified.
+	 */
+	public function hydrate_virtual_page_cache( $input = null ) {
+		if ( wp_cache_get( $this->home_virtual_ID, 'posts' ) instanceof WP_Post ) {
+			return $input;
+		}
+
+		// Since the page is a virtual one, do not set the post ID, it will be set to `0` by default.
+		wp_cache_set( $this->home_virtual_ID, new WP_Post( (object) [ 'post_type' => 'page' ] ), 'posts' );
+
+		return $input;
 	}
 }


### PR DESCRIPTION
Ticket: [BTRIA-1545](https://theeventscalendar.atlassian.net/browse/BTRIA-1545)

[Screencast not using object cache](https://share.cleanshot.com/WNd6LC)
[Screencast using object cache](https://share.cleanshot.com/5HHDFF) 

This fixes an issue where setting the site to use the Main Events Page as front page would cause fatals on PHP 8.0+ and above when navigating to some settings pages.
On lower PHP version it would cause a notice, but it would still be the same issue.

The fix hooks on the actions and filters that run before the page is used by WordPress to hydrate the posts cache and provide a real post objec to WordPress when it gets the page using `get_post( $page_id )`.
