### PR TITLE
Avoid fatal error when calling is_main_query on null

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Avoid fatal error in the `tribe_is_events_front_page` when called before global query object is initialized. [TBD]
+* Fix - Avoid fatal error in the `tribe_is_events_front_page` when called before global query object is initialized. [BTRIA-1556]
 
 = [6.0.5] 2022-11-29 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Avoid fatal error in the `tribe_is_events_front_page` when called before global query object is initialized. [TBD]
+
 = [6.0.5] 2022-11-29 =
 
 * Fix - Fix for scenarios where fatal `Call to a member function get() on null in... the-events-calendar/src/Tribe/Query.php(46)` would occur when `$wp_query` global was not set. [TEC-4566]

--- a/src/Events/Integrations/Plugins/WordPress_SEO/Events_Schema.php
+++ b/src/Events/Integrations/Plugins/WordPress_SEO/Events_Schema.php
@@ -271,6 +271,11 @@ class Events_Schema extends Abstract_Schema_Piece {
 	 */
 	private function get_month_events() {
 		$wp_query = tribe_get_global_query_object();
+
+		if ( ! $wp_query instanceof \WP_Query ) {
+			return [];
+		}
+
 		$event_date = $wp_query->get( 'eventDate' );
 
 		$month = $event_date;

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1922,6 +1922,10 @@ function tribe_is_events_home() {
 
 	$wp_query = tribe_get_global_query_object();
 
+	if ( ! $wp_query instanceof WP_Query ) {
+		return false;
+	}
+
 	if ( tribe_is_events_front_page() ) {
 		return true;
 	}

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1889,6 +1889,10 @@ function tribe_is_events_front_page() {
 
 	$wp_query = tribe_get_global_query_object();
 
+	if ( ! $wp_query instanceof WP_Query ) {
+		return false;
+	}
+
 	$events_as_front_page = tribe_get_option( 'front_page_event_archive', false );
 
 	// If the reading option has an events page as front page and we are on that page is on the home of events.

--- a/tests/wpunit/functions/template-tags/generalTest.php
+++ b/tests/wpunit/functions/template-tags/generalTest.php
@@ -292,4 +292,16 @@ HTML;
 		$wp_rewrite->init();
 		$wp_rewrite->flush_rules( true );
 	}
+
+	/**
+	 * It should return false if global query object not WP_Query
+	 *
+	 * @test
+	 */
+	public function should_return_false_if_global_query_object_not_wp_query(): void {
+		$this->uopz_set_return( 'tribe_get_global_query_object', null );
+
+		$this->assertFalse( tribe_is_events_front_page() );
+		$this->assertFalse( tribe_is_events_home() );
+	}
 }


### PR DESCRIPTION
From user report:

```
[14-Dec-2022 15:59:47 UTC] PHP Fatal error:  Uncaught Error: Call to a member function is_main_query() on null in /home/website/public_html/wp-content/plugins/the-events-calendar/src/functions/template-tags/general.php:1896
Stack trace:
#0 /home/website/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Query.php(130): tribe_is_events_front_page()
#1 /home/website/public_html/wp-includes/class-wp-hook.php(308): Tribe__Events__Query::parse_query(Object(WP_Query))
#2 /home/website/public_html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#3 /home/website/public_html/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#4 /home/website/public_html/wp-includes/class-wp-query.php(1127): do_action_ref_array('parse_query', Array)
#5 /home/website/public_html/wp-includes/class-wp-query.php(1820): WP_Query->parse_query()
#6 /home/website/public_html/wp-includes/class-wp-query.php(3749): WP_Query->get_posts()
#7 /home/website/public_html/wp-inclu in /home/website/public_html/wp-content/plugins/the-events-calendar/src/functions/template-tags/general.php on line 1896
```

The fatal comes from the `Tribe__Query::parse_query` method being called early.
