### PR TITLE
Ensure we don't try to use a WP_ERROR as an event category.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -239,7 +239,9 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Avoid the issue of events which have venues assigned not being able to be updated successfuly on some browsers. [TEC-4596]
 * Fix - Handle the case where rewrite rules map to arrays avoiding fatal errors. [TEC-4567]
 * Fix - Fix a primary cause of MySQL `Deadlock` errors in 6.0 event migration and added `Deadlock` error catching in our lock/fetch event queue. [TEC-4548]
+* Fix - Ensure we did not get an error object back when requesting event category. [TEC-4619]
 * Tweak - Convert all uses of (view)->get_slug() to (view)::get_view_slug(). [TEC-4586]
+* Tweak - Change some labelling of event settings in the admin. [TEC-4626]
 * Tweak - Add canonical tag to the head of all calendar views to prevent Google and other search engines from indexing URLs with custom URL parameters. [TEC-4538]
 
 = [6.0.6.2] 2022-12-16 =

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -732,7 +732,7 @@ class Tribe__Events__iCal {
 		// Add categories if available.
 		$event_cats = (array) wp_get_object_terms( $event_post->ID, Tribe__Events__Main::TAXONOMY, [ 'fields' => 'names' ] );
 
-		if ( ! empty( $event_cats ) ) {
+		if ( ! empty( $event_cats ) && ! is_wp_error( $event_cats ) ) {
 			$item['CATEGORIES'] = 'CATEGORIES:' . $this->html_decode( join( ',', $event_cats ) );
 		}
 


### PR DESCRIPTION
If a requested category has been unregistered, `wp_get_object_terms()` will throw an error. Check for the error as well as for empty().

Readme entry already in place: https://github.com/the-events-calendar/the-events-calendar/blob/fix/TEC-4619-event-category--cal-error/readme.txt#L242

[TEC-4619]

[TEC-4619]: https://theeventscalendar.atlassian.net/browse/TEC-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ