### PR TITLE
fix(WPML) ensure duplicates update the custom tables

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Tweak - Add support for opt-in direct deletion of EA older records using the `tec_event_aggregator_direct_record_deletion` filter or setting the `TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION` constant. [EA-446]
+* Fix - Ensure custom tables data is correctly updated when duplicating an Event using WPML. [TEC-4651]
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -223,4 +223,26 @@ class Tribe__Events__Integrations__WPML__Meta {
 
 		return array_unique( array_filter( array_merge( ...$buffer ) ) );
 	}
+
+	/**
+	 * Filters the meta keys tracked by the Custom Tables v1 implementation to detect a request
+	 * to update an event to add the meta key used by WPML to indicate a post is a duplicate
+	 * of another.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string> $meta_keys The list of meta keys tracked by the Custom Tables v1 implementation.
+	 *
+	 * @return array<string> The list of meta keys tracked by the Custom Tables v1 implementation, including
+	 *                       the one used by WPML to indicate a post is a duplicate of another.
+	 */
+	public static function filter_ct1_update_meta_keys( $meta_keys ) {
+		if ( ! is_array( $meta_keys ) ) {
+			return $meta_keys;
+		}
+
+		$meta_keys[] = '_icl_lang_duplicate_of';
+
+		return $meta_keys;
+	}
 }

--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -110,6 +110,11 @@ class Tribe__Events__Integrations__WPML__WPML {
 		if ( tribe()->getVar( 'ct1_fully_activated' ) ) {
 			// Handle the translation of the Events permalinks in Views v2 and Custom Tables V1 context.
 			add_filter( 'tribe_events_views_v2_view_template_vars', [ Views_V2_Filters::class, 'translate_events_permalinks' ] );
+			// Filter the tracked meta keys to trigger the update of the custom tables when duplicating events.
+			add_filter( 'tec_events_custom_tables_v1_tracked_meta_keys', [
+				Tribe__Events__Integrations__WPML__Meta::class,
+				'filter_ct1_update_meta_keys'
+			] );
 		}
 	}
 


### PR DESCRIPTION
Ticket: [TEC-4651](https://theeventscalendar.atlassian.net/browse/TEC-4651)

[Screencast](https://share.cleanshot.com/M7HPPNWv)

This updates the WPML integration code to make sure the Duplicate
function provided by WPML, not the one provided by ECP, works correctly
when duplicating an Event to another language.

The issue is that the duplicate function is not going through the usual
flow, but using AJAX. This would make it so that no default tracked meta
key is found (date-related ones) and custom tables data is not updated.

The fix consists in filtering the list of tracked meta keys to include
the `_icl_lang_duplicate_of` one used by WPML to indicate a duplicate
operation.


[BTRIA-1577]: https://theeventscalendar.atlassian.net/browse/BTRIA-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TEC-4651]: https://theeventscalendar.atlassian.net/browse/TEC-4651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ