### PR TITLE
Fix zoom level setting. [TEC-4634]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page.
+* Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page. [TEC-4634]
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is respected on the single events page.
+
 = [6.0.7.1] 2023-01-19 =
 
 * Fix - Prevent fatal when using The Events Calendar with Event Tickets due to Common library not being updated.

--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is respected on the single events page.
+* Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page.
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/src/functions/template-tags/google-map.php
+++ b/src/functions/template-tags/google-map.php
@@ -183,8 +183,9 @@ function tribe_get_basic_gmap_embed_url( $address_string ) {
 	$api_key = tribe_get_option( Tribe__Events__Google__Maps_API_Key::$api_key_option_name, Tribe__Events__Google__Maps_API_Key::$default_api_key );
 
 	$embed_url_args = [
-		'key' => $api_key,
-		'q'   => urlencode( $address_string ),
+		'key'  => $api_key,
+		'q'    => urlencode( $address_string ),
+		'zoom' => apply_filters( 'tribe_events_single_map_zoom_level', (int) tribe_get_option( 'embedGoogleMapsZoom', 8 ) ),
 	];
 
 	$embed_url = add_query_arg(

--- a/src/functions/template-tags/google-map.php
+++ b/src/functions/template-tags/google-map.php
@@ -185,7 +185,7 @@ function tribe_get_basic_gmap_embed_url( $address_string ) {
 	$embed_url_args = [
 		'key'  => $api_key,
 		'q'    => urlencode( $address_string ),
-		'zoom' => apply_filters( 'tribe_events_single_map_zoom_level', (int) tribe_get_option( 'embedGoogleMapsZoom', 8 ) ),
+		'zoom' => (int) tribe_get_option( 'embedGoogleMapsZoom', 15 ),
 	];
 
 	$embed_url = add_query_arg(


### PR DESCRIPTION
Ticket : [TEC-4634](https://theeventscalendar.atlassian.net/browse/TEC-4634)

Ensures the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page.

**Artifact 🎥**

https://www.loom.com/share/b402036022464ca1b10c3ebfe4a9689f

[TEC-4634]: https://theeventscalendar.atlassian.net/browse/TEC-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ