### PR TITLE
feat(Event_Aggregator) allow direct deletion of older records

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add support for opt-in direct deletion of EA older records using the `tec_event_aggregator_direct_record_deletion` filter or setting the `TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION` constant. [EA-446]
+
 = [6.0.7.1] 2023-01-19 =
 
 * Fix - Prevent fatal when using The Events Calendar with Event Tickets due to Common library not being updated.

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -587,9 +587,37 @@ class Tribe__Events__Aggregator__Cron {
 	 */
 	public function purge_expired_records() {
 		global $wpdb;
+		$records        = Records::instance();
+		$statuses       = Records::$status;
+		$deletable_statuses = [
+			$statuses->pending,
+			$statuses->success,
+			$statuses->failed,
+			$statuses->draft,
+		];
+		$date_threshold = date( 'Y-m-d H:i:s', time() - $records->get_retention() );
 
-		$records  = Records::instance();
-		$statuses = Records::$status;
+		// Check the constant to see if we should purge records using direct queries or not.
+		$direct_deletion = defined( 'TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION' )
+		                   && TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION;
+
+		/**
+		 * Filters whether to use direct deletion of Event Aggregator records during cleanup or not.
+		 *
+		 * Note the filtered value will override the value defined by the
+		 * `TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION` constant.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $direct_deletion Whether to use direct deletion of Event Aggregator records during cleanup or not.
+		 */
+		$direct_deletion = apply_filters( 'tec_event_aggregator_direct_record_deletion', $direct_deletion );
+
+		if ( $direct_deletion ) {
+			$this->purge_expired_records_directly( $deletable_statuses, $date_threshold );
+
+			return;
+		}
 
 		$sql = "
 			SELECT
@@ -613,15 +641,10 @@ class Tribe__Events__Aggregator__Cron {
 		);
 
 		$args = [
-			'post_status'    => [
-				$statuses->pending,
-				$statuses->success,
-				$statuses->failed,
-				$statuses->draft,
-			],
+			'post_status'    => $deletable_statuses,
 			'date_query'     => [
 				[
-					'before' => date( 'Y-m-d H:i:s', time() - $records->get_retention() ),
+					'before' => $date_threshold,
 					'column' => 'post_date_gmt',
 				],
 			],
@@ -692,5 +715,132 @@ class Tribe__Events__Aggregator__Cron {
 
 		tribe( 'logger' )->log_debug( sprintf( 'Import %s data available: processing immediately', $record->id ), 'EA Cron' );
 		$record->process_posts( $import_data, true );
+	}
+
+	/**
+	 * Deletes expired records from the database using direct queries, bypassing the filters and actions associated
+	 * with WordPress posts functions.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string> $deletable_statuses The statuses to use to fetch the records that should be purged.
+	 * @param string        $date_threshold     The date threshold to use to determine if a record should be purged or not.
+	 *
+	 * @return int The number of records purged.
+	 */
+	private function purge_expired_records_directly( array $deletable_statuses, string $date_threshold ): int {
+		global $wpdb;
+		$deleteable_statuses_interval = $wpdb->prepare(
+			implode( ', ', array_fill( 0, count( $deletable_statuses ), '%s' ) ),
+			...$deletable_statuses
+		);
+
+		/*
+		 * Calculate how many of the post ID with the most digits would fit in the current database
+		 * `max_allowed_packet` value with some margin.
+		 */
+		$max_allowed_packet = (int) ( $wpdb->get_var( 'SELECT @@max_allowed_packet' ) );
+		if ( $max_allowed_packet > 1000 ) {
+			// Fetch the ID with the most digits from the wp_posts table, aka the ID of the last post.
+			$post_id            = $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} ORDER BY ID DESC LIMIT 1" );
+			$strlen             = strlen( $post_id ) || 1;
+			$dynamic_batch_size = (int) floor( ( $max_allowed_packet - 1000 ) / $strlen );
+		}
+		// Set a default batch size of 100.
+		$batch_size = empty( $dynamic_batch_size ) ? 100 : $dynamic_batch_size;
+		// Set a maximum batch size of 50000.
+		$batch_size = min( $batch_size, 50000 );
+
+		/**
+		 * Filters the number of records to be deleted in a single query when purging Event Aggregator records
+		 * using the direct deletion method.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $batch_size The number of records to be deleted in a single query. Calculated from the current
+		 *                        `max_allowed_packet` value set in the database.
+		 */
+		$batch_size = apply_filters( 'tec_event_aggregator_direct_record_deletion_batch_size', $batch_size );
+
+		/*
+		 * Get the IDs to flush the cache for a number of IDs at a time, with a reasonable chance of not running
+		 * into the `max_allowed_packet` limit.
+		 * Do this before the records are deleted from the database.
+		 */
+		$records_post_ids = (array) $wpdb->get_col(
+			$wpdb->prepare(
+				"
+				SELECT ID
+				FROM {$wpdb->posts}
+				WHERE post_type = %s
+				AND post_status IN ( $deleteable_statuses_interval )
+				AND post_date_gmt < %s
+				ORDER BY ID DESC
+				LIMIT %d",
+				Records::$post_type,
+				$date_threshold,
+				$batch_size
+			)
+		);
+
+		foreach ( $records_post_ids as $post_id ) {
+			clean_post_cache( $post_id );
+		}
+
+		// ORDER BY ID DESC is important here to make sure the run will insist on the same set of records.
+
+		// Use a sub-query to avoid running into the max_allowed_packet limit.
+		if ( $wpdb->query( $wpdb->prepare( "
+				DELETE FROM {$wpdb->comments}
+				WHERE comment_post_ID IN (
+					SELECT ID
+					FROM {$wpdb->posts}
+					WHERE post_type = %s
+					AND post_status in ( $deleteable_statuses_interval )
+					AND post_date_gmt < %s
+					ORDER BY ID DESC
+				) LIMIT %d",
+				Tribe__Events__Aggregator__Records::$post_type,
+				$date_threshold,
+				$batch_size
+			) ) === false ) {
+			tribe( 'logger' )->log_error( 'Failed to delete expired records comments using direct delete: ' . $wpdb->last_error, 'EA Cron' );
+		}
+
+		// Use a sub-query to avoid running into the max_allowed_packet limit.
+		if ( $wpdb->query( $wpdb->prepare( "
+				DELETE FROM {$wpdb->postmeta}
+				WHERE post_id IN (
+					SELECT ID
+					FROM {$wpdb->posts}
+					WHERE post_type = %s
+					AND post_status in ( $deleteable_statuses_interval )
+					AND post_date_gmt < %s
+					ORDER BY ID DESC
+				) LIMIT %d",
+				Tribe__Events__Aggregator__Records::$post_type,
+				$date_threshold,
+				$batch_size
+			) ) === false ) {
+			tribe( 'logger' )->log_error( 'Failed to delete expired records postmeta using direct delete: ' . $wpdb->last_error, 'EA Cron' );
+		}
+
+		$deleted = $wpdb->query( $wpdb->prepare( "
+				DELETE FROM {$wpdb->posts}
+				WHERE post_type = %s
+				AND post_status in ( $deleteable_statuses_interval )
+				AND post_date_gmt < %s
+				ORDER BY ID DESC
+				LIMIT %d",
+			Tribe__Events__Aggregator__Records::$post_type,
+			$date_threshold,
+			$batch_size
+		) );
+
+		if ( $deleted === false ) {
+			tribe( 'logger' )->log_error( 'Failed to delete expired records using direct delete: ' . $wpdb->last_error, 'EA Cron' );
+		}
+
+		return $deleted;
 	}
 }


### PR DESCRIPTION
Ticket: [EA-446](https://theeventscalendar.atlassian.net/browse/EA-446)

Artifacts:
* tests
* [screencast](https://share.cleanshot.com/PlBbQryw)

This adds an opt-in way of deleting older records that, on cron, will
delete a significantly larger portion of them using direct database
queries.

The trade-off is the WordPress `wp_delete_post` function will not be
used and its filters and actions will not be triggered.

Users can opt-in into the alternate deletion system by either filtering
the `tec_event_aggregator_direct_record_deletion` filter or by setting
the `TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION` constant in the
site `wp-config.php` file.


[EA-446]: https://theeventscalendar.atlassian.net/browse/EA-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ