### PR TITLE
fix/tec 4536 ct1 tables updates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Tweak - Add support for opt-in direct deletion of EA older records using the `tec_event_aggregator_direct_record_deletion` filter or setting the `TEC_EVENT_AGGREGATOR_RECORDS_PURGE_DIRECT_DELETION` constant. [EA-446]
 * Fix - Ensure custom tables data is correctly updated when duplicating an Event using WPML. [TEC-4651]
+* Fix - Change the type of the date-related custom tables date fields to VARCHAR to avoid warnings on stricter SQL modes. [TEC-4536]
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/src/Events/Custom_Tables/V1/Tables/Events.php
+++ b/src/Events/Custom_Tables/V1/Tables/Events.php
@@ -27,7 +27,7 @@ class Events extends Abstract_Custom_Table {
 	/**
 	 * @inheritDoc
 	 */
-	const SCHEMA_VERSION = '1.0.0';
+	const SCHEMA_VERSION = '1.0.1';
 
 	/**
 	 * {@inheritdoc}
@@ -58,14 +58,15 @@ class Events extends Abstract_Custom_Table {
 		$table_name = self::table_name(true);
 		$charset_collate = $wpdb->get_charset_collate();
 
+		// VARCHAR(19) to store YYYY-MM-DD HH:MM:SS values as strings and allow partial compare.
 		return "CREATE TABLE `{$table_name}` (
 			`event_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 			`post_id` BIGINT(20) UNSIGNED NOT NULL,
-			`start_date` DATETIME NOT NULL,
-			`end_date` DATETIME DEFAULT NULL,
+			`start_date` VARCHAR(19) NOT NULL,
+			`end_date` VARCHAR(19) DEFAULT NULL,
 			`timezone` VARCHAR(30) NOT NULL DEFAULT 'UTC',
-			`start_date_utc` DATETIME NOT NULL,
-			`end_date_utc` DATETIME DEFAULT NULL,
+			`start_date_utc` VARCHAR(19) NOT NULL,
+			`end_date_utc` VARCHAR(19) DEFAULT NULL,
 			`duration` MEDIUMINT(30) DEFAULT 7200,
 			`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			`hash` varchar(40) NOT NULL,

--- a/src/Events/Custom_Tables/V1/Tables/Occurrences.php
+++ b/src/Events/Custom_Tables/V1/Tables/Occurrences.php
@@ -29,7 +29,7 @@ class Occurrences extends Abstract_Custom_Table {
 	 *
 	 * @inheritDoc
 	 */
-	const SCHEMA_VERSION = '1.0.1';
+	const SCHEMA_VERSION = '1.0.2';
 
 	/**
 	 * @inheritDoc
@@ -60,14 +60,15 @@ class Occurrences extends Abstract_Custom_Table {
 		$table_name      = self::table_name( true );
 		$charset_collate = $wpdb->get_charset_collate();
 
+		// VARCHAR(19) to store YYYY-MM-DD HH:MM:SS values as strings and allow partial compare.
 		return "CREATE TABLE `{$table_name}` (
 			`occurrence_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 			`event_id` BIGINT(20) UNSIGNED NOT NULL,
 			`post_id` BIGINT(20) UNSIGNED NOT NULL,
-			`start_date` DATETIME NOT NULL,
-			`start_date_utc` DATETIME NOT NULL,
-			`end_date` DATETIME NOT NULL,
-			`end_date_utc` DATETIME NOT NULL,
+			`start_date` VARCHAR(19) NOT NULL,
+			`start_date_utc` VARCHAR(19) NOT NULL,
+			`end_date` VARCHAR(19) NOT NULL,
+			`end_date_utc` VARCHAR(19) NOT NULL,
 			`duration` MEDIUMINT(30) DEFAULT 7200,
 			`hash` VARCHAR(40) NOT NULL,
 			`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/EventsTest.php
+++ b/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/EventsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace TEC\Events\Custom_Tables\V1\Tables;
+
+require_once __DIR__ . '/Tables_Test_Case.php';
+
+class EventsTest extends Tables_Test_Case {
+	protected function get_insert_query( object $data ): string {
+		$table_name = Events::table_name( true );
+
+		return "INSERT INTO $table_name (
+			event_id, post_id, start_date, start_date_utc, end_date, end_date_utc, timezone, duration, hash
+			) VALUES (
+			1,
+			1,
+			'$data->start_date',
+			'$data->start_date_utc',
+			'$data->end_date',
+			'$data->end_date_utc',
+			'America/New_York',
+			7200,
+			'random_hash'
+			)";
+	}
+}

--- a/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/OccurrencesTest.php
+++ b/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/OccurrencesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace TEC\Events\Custom_Tables\V1\Tables;
+
+class OccurrencesTest extends Tables_Test_Case {
+	protected function get_insert_query( object $data ): string {
+		$table_name = Occurrences::table_name( true );
+
+		return "INSERT INTO $table_name (
+			event_id, post_id, start_date, start_date_utc, end_date, end_date_utc, duration, hash
+			) VALUES (
+			1,
+			1,
+			'$data->start_date',
+			'$data->start_date_utc',
+			'$data->end_date',
+			'$data->end_date_utc',
+			7200,
+			'random_hash'
+			)";
+	}
+}

--- a/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/OccurrencesTest.php
+++ b/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/OccurrencesTest.php
@@ -2,6 +2,8 @@
 
 namespace TEC\Events\Custom_Tables\V1\Tables;
 
+require_once __DIR__ . '/Tables_Test_Case.php';
+
 class OccurrencesTest extends Tables_Test_Case {
 	protected function get_insert_query( object $data ): string {
 		$table_name = Occurrences::table_name( true );

--- a/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/Tables_Test_Case.php
+++ b/tests/ct1_migration/TEC/Events/Custom_Tables/V1/Tables/Tables_Test_Case.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace TEC\Events\Custom_Tables\V1\Tables;
+
+use stdClass;
+use PDO;
+
+abstract class Tables_Test_Case extends \CT1_Migration_Test_Case {
+	abstract protected function get_insert_query( stdClass $data ): string;
+
+	public function date_field_provider(): array {
+		return [
+			'start_date'     => [ 'start_date' ],
+			'end_date'       => [ 'end_date' ],
+			'start_date_utc' => [ 'start_date_utc' ],
+			'end_date_utc'   => [ 'end_date_utc' ],
+		];
+	}
+
+	/**
+	 * Test that an illegal DATETIME operation when sql_mode is set to no 'NO_ZERO_IN_DATE,NO_ZERO_DATE'
+	 * will not trigger a MySQL warning.
+	 *
+	 * Depending on the MySQL version and configuration, treating DATETIME fields like strings will
+	 * trigger a warning, which will cause the query to fail.
+	 * Here the warning is triggered on an INSERT query, but it could happen on a SELECT query too.
+	 * This test ensures that the warning is not triggered and that the date fields of the Occurrences table
+	 * will keep being VARCHAR fields.
+	 *
+	 * This test uses a PDO connection as the WordPress DB class does will set the sql_mode before this test
+	 * runs. The default sql_mode would remove the `NO_ZERO_DATE` flag, but it's filterable.
+	 *
+	 * @dataProvider date_field_provider
+	 */
+	public function test_partial_match_on_date_fields_does_not_generate_warnings( string $field ): void {
+
+		// Using the DB_ constants, open a PDO connection to the same database as WordPress.
+		$dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8';
+		$pdo = new PDO( $dsn, DB_USER, DB_PASSWORD );
+		// Cast warnings to exceptions.
+		$pdo->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+		// Add  SQL modes that will cause issues with the dates.
+		$sql_mode = $pdo->query( 'SELECT @@SESSION.sql_mode' )->fetchColumn();
+		// Debug the current sql_mode before the update.
+		codecept_debug( 'sql_mode before update:' . $sql_mode );
+		foreach (
+			[
+				'NO_ZERO_IN_DATE',
+				'NO_ZERO_DATE',
+			] as $add_sql_mode
+		) {
+			if ( strpos( $sql_mode, $add_sql_mode ) === false ) {
+				$sql_mode .= ',' . $add_sql_mode;
+			}
+		}
+		// Set the new sql_mode.
+		if ( $pdo->query( 'SET @@SESSION.sql_mode="' . $sql_mode . '"' ) === false ) {
+			$this->fail( 'Could not set PDO sql_mode to ' . $sql_mode );
+		}
+		// Debug the current sql_mode.
+		$sql_mode = $pdo->query( 'SELECT @@SESSION.sql_mode' )->fetchColumn();
+		codecept_debug( 'sql_mode after update: ' . $sql_mode );
+
+		// Insert a record in the Occurrences table using PDO, this should not fail.
+		$data         = (object) array_merge( [
+			'start_date'     => '2019-01-01 09:00:00',
+			'end_date'       => '2019-01-01 11:00:00',
+			'start_date_utc' => '2019-01-01 08:00:00',
+			'end_date_utc'   => '2019-01-01 10:00:00',
+		], [ $field => '0000-00-00 00:00:00' ] );
+		$insert_query = $this->get_insert_query( $data );
+		$inserted     = $pdo->query( $insert_query );
+
+		$this->assertNotFalse( $inserted );
+		$warnings = $pdo->query( 'SHOW WARNINGS' )->fetchAll( PDO::FETCH_ASSOC );
+		$this->assertEmpty( $warnings );
+	}
+}


### PR DESCRIPTION
Ticket: [TEC-4536](https://theeventscalendar.atlassian.net/browse/TEC-4536)

Artifacts: new and existing tests.

Initially, the MySQL type of the date fields in the Occurrences and Events tables was set to `DATETIME`.
While this makes sense, it will trigger warnings on MySQL implementations with stricter settings (`sql_mode="NO_ZERO_IN_DATE,NO_ZERO_DATE"`) in any operation including those fields and treating them like string fields.
Depending on the setting, those warnings could become `wpdb` errors preventing the query from executing completely.
There are a number of plugins out there assuming an operation like `SELECT ... where start_date LIKE '20220-10%` will work and will not trigger exceptions that will benefit from this change.

The existing tests will ensure that the CT1 implementation is fine with the update and is not relying on those fields to be actually `DATETIME` fields; the new tests will cover the regression of the type of those fields.

What will the effect on ECP be? [PR to find it out here](https://github.com/the-events-calendar/events-pro/pull/2179)

[TEC-4536]: https://theeventscalendar.atlassian.net/browse/TEC-4536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ