### PR TITLE
Allow filtering the redirection nature of a request

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Ensure all Google Map iframes have a title attribute to improve accessibility. [TEC-4243]
 * Fix - Ensure custom tables data is correctly updated when duplicating an Event using WPML. [TEC-4651]
 * Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page. [TEC-4634]
+* Tweak - Allow filtering the redirected nature of a Views v2 request using the `tec_events_views_v2_redirected` filter. [TEC-4511]
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -611,11 +611,21 @@ class Hooks extends \tad_DI52_ServiceProvider {
 
 		$parsed = \Tribe__Events__Rewrite::instance()->parse_request( $redirect_url );
 
-		if (
-			empty( $parsed['tribe_redirected'] )
-			&& $view !== Arr::get( (array) $parsed, 'eventDisplay' )
-		) {
+		// Event Tickets will set this to flag a redirected request.
+		$is_redirected = ! empty( $parsed['tribe_redirected'] );
 
+		/**
+		 * Filters whether the current request is being redirectedor not.
+		 *
+		 * The initial value is set by looking up the `tribe_redirected` query argument.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $is_redirected Whether the current request is being redirected by TEC or not.
+		 */
+		$is_redirected = apply_filters( 'tec_events_views_v2_redirected', $is_redirected );
+
+		if ( ! $is_redirected && $view !== Arr::get( (array) $parsed, 'eventDisplay' ) ) {
 			/*
 			 * If we're here we know we should be looking at a View URL.
 			 * If the proposed URL does not resolve to a View, do not redirect.

--- a/tests/views_wpunit/Tribe/Events/Views/V2/HooksTest.php
+++ b/tests/views_wpunit/Tribe/Events/Views/V2/HooksTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tribe\Events\Views\V2;
+
+
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__Context as Context;
+
+class HooksTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
+	public function test_filter_redirect_canonical() {
+		$this->set_fn_return( 'doing_filter', 'redirect_canonical' );
+		$mock_context = new Context();
+		$mock_context->set_locations( [
+			'tec_post_type' => true,
+			'view_request'  => 'month',
+		] );
+		$this->set_fn_return( 'tribe_context', $mock_context );
+
+		$hooks    = new Hooks( tribe() );
+		$filtered = $hooks->filter_redirect_canonical( 'http://example.com/events/month/', 'http://example.com/events/list/' );
+
+		$this->assertEquals( 'http://example.com/events/month/', $filtered );
+	}
+
+	public function filter_redirect_canonical_data(): array {
+		return [
+			'not TEC post type'                           => [
+				[
+					'tec_post_type' => false,
+					'view_request'  => 'month',
+				],
+				'http://example.com/some-page/',
+				'http://example.com/some-page/',
+			],
+			'embed of TEC post type'                      => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => 'embed',
+				],
+				'http://example.com/some-page/',
+				false
+			],
+			'single view of Event'                        => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => 'single-event',
+				],
+				'http://example.com/events/some-event/',
+				'http://example.com/events/some-event/',
+			],
+			'TEC post type by empty view'                 => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => '',
+				],
+				'http://example.com/some/event/path/',
+				'http://example.com/some/event/path/',
+			],
+			'redirected with tribe_redirected'            => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => 'month',
+				],
+				'http://example.com/events/list/?tribe_redirected=1',
+				'http://example.com/events/list/?tribe_redirected=1',
+			],
+			'not redirected, eventDisplay match'          => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => 'month',
+				],
+				'http://example.com/events/month/',
+				'http://example.com/events/month/',
+			],
+			'not redirected, eventDisplay does not match' => [
+				[
+					'tec_post_type' => true,
+					'view_request'  => 'list',
+				],
+				'http://example.com/events/month/',
+				false
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider filter_redirect_canonical_data
+	 */
+	public function test_filter_redirect_canonical_will_not_redirect_embed( array $context, string $redirect_url, $expected ): void {
+		// Mock just the month rewreite rules to have `Rewrite::parse_request` work correctly.
+		update_option( 'rewrite_rules', [
+			'(?:events)/(?:month)/?$'                                                    => 'index.php?post_type=tribe_events&eventDisplay=month',
+			'(?:events)/(?:month)/(?:featured)/?$'                                       => 'index.php?post_type=tribe_events&eventDisplay=month&featured=1',
+			'(?:events)/(?:month)/(\\d{4}-\\d{2})/?$'                                    => 'index.php?post_type=tribe_events&eventDisplay=month&eventDate=$matches[1]',
+			'(?:events)/(\\d{4}-\\d{2})/?$'                                              => 'index.php?post_type=tribe_events&eventDisplay=month&eventDate=$matches[1]',
+			'(?:events)/(\\d{4}-\\d{2})/(?:featured)/?$'                                 => 'index.php?post_type=tribe_events&eventDisplay=month&eventDate=$matches[1]&featured=1',
+			'(?:events)/(?:category)/(?:[^/]+/)*([^/]+)/(?:month)/?$'                    => 'index.php?post_type=tribe_events&tribe_events_cat=$matches[1]&eventDisplay=month',
+			'(?:events)/(?:category)/(?:[^/]+/)*([^/]+)/(?:month)/(?:featured)/?$'       => 'index.php?post_type=tribe_events&tribe_events_cat=$matches[1]&eventDisplay=month&featured=1',
+			'(?:events)/(?:category)/(?:[^/]+/)*([^/]+)/(\\d{4}-\\d{2})/?$'              => 'index.php?post_type=tribe_events&tribe_events_cat=$matches[1]&eventDisplay=month&eventDate=$matches[2]',
+			'(?:events)/(?:category)/(?:[^/]+/)*([^/]+)/(\\d{4}-\\d{2})/(?:featured)/?$' => 'index.php?post_type=tribe_events&tribe_events_cat=$matches[1]&eventDisplay=month&eventDate=$matches[2]&featured=1',
+			'(?:events)/(?:tag)/([^/]+)/(?:month)/?$'                                    => 'index.php?post_type=tribe_events&tag=$matches[1]&eventDisplay=month',
+			'(?:events)/(?:tag)/([^/]+)/(?:month)/(?:featured)/?$'                       => 'index.php?post_type=tribe_events&tag=$matches[1]&eventDisplay=month&featured=1',
+			'(?:events)/(?:tag)/([^/]+)/(\\d{4}-\\d{2})/?$'                              => 'index.php?post_type=tribe_events&tag=$matches[1]&eventDisplay=month&eventDate=$matches[2]',
+			'(?:events)/(?:tag)/([^/]+)/(\\d{4}-\\d{2})/(?:featured)/?$'                 => 'index.php?post_type=tribe_events&tag=$matches[1]&eventDisplay=month&eventDate=$matches[2]&featured=1',
+		] );
+		$mock_context = tribe_context()->alter( $context );
+		$this->set_fn_return( 'tribe_context', $mock_context );
+
+		$hooks    = new Hooks( tribe() );
+		$filtered = $hooks->filter_redirect_canonical( $redirect_url );
+
+		$this->assertEquals( $expected, $filtered );
+	}
+}


### PR DESCRIPTION
Ticket: [TEC-4511](https://theeventscalendar.atlassian.net/browse/TEC-4511)

This PR is the companion to the [ECP one](https://github.com/the-events-calendar/events-pro/pull/2182) to allow detecting a redirected request only by means of the `tribe_redirected` query var.
The support for the `tribe_redirected` query variable cannot be removed due to its use in the Event Tickets PayPal gateway, but adding a filter allows the request lifecycle to mark the current request as a redirected one without requiring its use.


[TEC-4511]: https://theeventscalendar.atlassian.net/browse/TEC-4511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ