### PR TITLE
fix/tec 4664 support events cat unregister

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Ensure all Google Map iframes have a title attribute to improve accessibility. [TEC-4243]
 * Fix - Ensure custom tables data is correctly updated when duplicating an Event using WPML. [TEC-4651]
 * Fix - Ensure the zoom level set under `Events → Settings → Display → Google Maps default zoom level` is applied to the single events page. [TEC-4634]
+* Fix - Ensure the code will work correctly when the Events' category taxonomy is unregistered. [TEC-4664]
 
 = [6.0.7.1] 2023-01-19 =
 

--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -348,6 +348,10 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 		public static function custom_columns( $column_id, $post_id ) {
 			switch ( $column_id ) {
 				case 'events-cats':
+					if ( ! taxonomy_exists( Tribe__Events__Main::TAXONOMY ) ) {
+						return [];
+					}
+
 					$event_cats = wp_get_post_terms(
 						$post_id,
 						Tribe__Events__Main::TAXONOMY,

--- a/src/Tribe/Admin_List.php
+++ b/src/Tribe/Admin_List.php
@@ -361,6 +361,10 @@ if ( ! class_exists( 'Tribe__Events__Admin_List' ) ) {
 					);
 					$categories_list = '-';
 					if ( is_array( $event_cats ) ) {
+						$event_cats = array_values( array_filter( $event_cats, static function ( $event_cat ) {
+							return is_string( $event_cat ) && $event_cat !== '';
+						} ) );
+
 						$categories_list = implode( ', ', $event_cats );
 					}
 					echo esc_html( $categories_list );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1834,7 +1834,16 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		public function post_class( $classes ) {
 			global $post;
 			if ( is_object( $post ) && isset( $post->post_type ) && $post->post_type == self::POSTTYPE && $terms = get_the_terms( $post->ID, self::TAXONOMY ) ) {
+				if ( $terms instanceof WP_Error ) {
+					// IF the taxonomy is not registered, we get a WP_Error object.
+					return $classes;
+				}
+
 				foreach ( $terms as $term ) {
+					if ( ! $term instanceof WP_Term ) {
+						continue;
+					}
+
 					$classes[] = 'cat_' . sanitize_html_class( $term->slug, $term->term_taxonomy_id );
 				}
 			}
@@ -1865,35 +1874,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// Setup Linked Posts singleton after we've set up the post types that we care about
 			Tribe__Events__Linked_Posts::instance();
 
-			$taxonomy_args = [
-				'hierarchical'          => true,
-				'update_count_callback' => '',
-				'rewrite'               => [
-					'slug'         => $this->rewriteSlug . '/' . $this->category_slug,
-					'with_front'   => false,
-					'hierarchical' => true,
-				],
-				'public'                => true,
-				'show_ui'               => true,
-				'labels'                => $this->taxonomyLabels,
-				'capabilities'          => [
-					'manage_terms' => 'publish_tribe_events',
-					'edit_terms'   => 'publish_tribe_events',
-					'delete_terms' => 'publish_tribe_events',
-					'assign_terms' => 'edit_tribe_events',
-				],
-			];
-
-			/**
-			 * Filter the event category taxonomy arguments used in register_taxonomy.
-			 *
-			 * @param array $taxonomy_args
-			 *
-			 * @since 4.5.5
-			 */
-			$taxonomy_args = apply_filters( 'tribe_events_register_event_cat_type_args', $taxonomy_args );
-
-			register_taxonomy( self::TAXONOMY, self::POSTTYPE, $taxonomy_args );
+			$this->register_taxonomy();
 
 			if ( Tribe__Settings_Manager::get_option( 'showComments', 'no' ) == 'yes' ) {
 				add_post_type_support( self::POSTTYPE, 'comments' );
@@ -4057,6 +4038,46 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			];
 
 			$this->get_autoloader_instance()->register_prefixes( $prefixes );
+		}
+
+		/**
+		 * Registers the Events' category taxonomy in WordPress.
+		 *
+		 * @since TBD
+		 *
+		 * @return WP_Taxonomy|WP_Error The registered taxonomy object on success, WP_Error object on failure.
+		 */
+		public function register_taxonomy() {
+			$taxonomy_args = [
+					'hierarchical'          => true,
+					'update_count_callback' => '',
+					'rewrite'               => [
+							'slug'         => $this->rewriteSlug . '/' . $this->category_slug,
+							'with_front'   => false,
+							'hierarchical' => true,
+					],
+					'public'                => true,
+					'show_ui'               => true,
+					'labels'                => $this->taxonomyLabels,
+					'capabilities'          => [
+							'manage_terms' => 'publish_tribe_events',
+							'edit_terms'   => 'publish_tribe_events',
+							'delete_terms' => 'publish_tribe_events',
+							'assign_terms' => 'edit_tribe_events',
+					],
+			];
+
+			/**
+			 * Filter the event category taxonomy arguments used in register_taxonomy.
+			 *
+			 * @since 4.5.5
+			 *
+			 * @param array $taxonomy_args
+			 *
+			 */
+			$taxonomy_args = apply_filters( 'tribe_events_register_event_cat_type_args', $taxonomy_args );
+
+			return register_taxonomy( self::TAXONOMY, self::POSTTYPE, $taxonomy_args );
 		}
 	}
 }

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -575,6 +575,14 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 	public function get_terms( $event_id, $taxonomy ) {
 		$terms = wp_get_post_terms( $event_id, $taxonomy );
 
+		if ( $terms instanceof WP_Error ) {
+			return [];
+		}
+
+		$terms = array_values( array_filter( $terms, static function ( $term ) {
+			return $term instanceof WP_Term;
+		} ) );
+
 		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			return array();
 		}

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -467,8 +467,16 @@ function tribe_is_past_event( $event = null ) {
  * @category Events
  */
 function tribe_get_event_cat_ids( $post_id = 0 ) {
-	$post_id = Tribe__Events__Main::postIdHelper( $post_id );
-	$terms   = array_filter( (array) get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY ) );
+	$post_id  = Tribe__Events__Main::postIdHelper( $post_id );
+	$terms = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
+
+	if ( $terms instanceof WP_Error ) {
+		return [];
+	}
+
+	$terms = array_values( array_filter( $terms, static function ( $term ) {
+		return $term instanceof WP_Term;
+	} ) );
 
 	return wp_list_pluck( $terms, 'term_id' );
 }
@@ -483,13 +491,19 @@ function tribe_get_event_cat_ids( $post_id = 0 ) {
  */
 function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	$post_id = Tribe__Events__Main::postIdHelper( $post_id );
-	$terms   = (array) get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
-	$terms   = array_filter(
+	$terms   = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
+
+	if ( $terms instanceof WP_Error ) {
+		return [];
+	}
+
+	$terms = array_values( array_filter(
 		$terms,
 		static function ( $term ) {
 			return $term instanceof WP_Term;
 		}
-	);
+	) );
+
 	$slugs   = wp_list_pluck( $terms, 'slug' );
 
 	return apply_filters( 'tribe_get_event_cat_slugs', $slugs, $post_id );
@@ -682,9 +696,13 @@ if ( ! function_exists( 'tribe_meta_event_archive_tags' ) ) {
 
 		$terms = get_the_terms( get_the_ID(), 'post_tag' );
 
-		if ( is_wp_error( $terms ) ) {
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			return;
 		}
+
+		$terms = array_values( array_filter( $terms, static function ( $term ) {
+			return $term instanceof WP_Term;
+		} ) );
 
 		if ( empty( $terms ) ) {
 			return;

--- a/tests/wpunit/TEC/Events/APITest.php
+++ b/tests/wpunit/TEC/Events/APITest.php
@@ -7,6 +7,13 @@ use Tribe__Events__Main as TEC;
 
 class APITest extends \Codeception\TestCase\WPTestCase {
 	/**
+	 * @after
+	 */
+	public function reregister_taxonomies(): void {
+		TEC::instance()->register_taxonomy();
+	}
+
+	/**
 	 * It should correctly handle daylight saving hours
 	 *
 	 * @test
@@ -56,5 +63,24 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		] );
 
 		$this->assertEquals( 3 * HOUR_IN_SECONDS, (int) get_post_meta( $id, '_EventDuration', true ) );
+	}
+
+	public function get_event_terms_will_work_when_cat_tax_unregistered(): void {
+		unregister_taxonomy( TEC::TAXONOMY );
+		$post_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2018-01-01 08:00:00',
+			'end_date'   => '2018-01-01 10:00:00',
+			'tax_input'  => [
+				'post_tag' => [ 'tag1', 'tag2' ],
+			]
+		] )->create()->ID;
+
+		$event_terms = API::get_event_terms( $post_id );
+
+		$this->assertEquals( [
+			'post_tag' => [ 'tag-1', 'tag-2' ]
+		], $event_terms );
 	}
 }

--- a/tests/wpunit/Tribe__Events__Admin_ListTest.php
+++ b/tests/wpunit/Tribe__Events__Admin_ListTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Events__Admin_List as Admin_List;
 use Tribe__Events__Main as TEc;
 
 class Tribe__Events__Admin_ListTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
 	/**
 	 * @after
 	 */
@@ -20,9 +23,28 @@ class Tribe__Events__Admin_ListTest extends \Codeception\TestCase\WPTestCase {
 		] )->create()->ID;
 		unregister_taxonomy( TEC::TAXONOMY );
 
-		$admin_list = new Admin_List();
-		$columns    = $admin_list->custom_columns( 'events-cats', $post_id );
+		$this->expectOutputString( '' );
 
-		$this->assertEquals( [], $columns );
+		$admin_list = new Admin_List();
+		$admin_list->custom_columns( 'events-cats', $post_id );
+	}
+
+	public function test_custom_columns_with_bad_terms(): void {
+		$post_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2018-01-01 08:00:00',
+			'end_date'   => '2018-01-01 10:00:00',
+		] )->create()->ID;
+		$this->set_fn_return( 'wp_get_post_terms', [
+			null,
+			'Good Term',
+			new WP_Error( 'bad term', 'bad term' ),
+		] );
+
+		$this->expectOutputString( 'Good Term' );
+
+		$admin_list = new Admin_List();
+		$admin_list->custom_columns( 'events-cats', $post_id );
 	}
 }

--- a/tests/wpunit/Tribe__Events__Admin_ListTest.php
+++ b/tests/wpunit/Tribe__Events__Admin_ListTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Tribe__Events__Admin_List as Admin_List;
+use Tribe__Events__Main as TEc;
+
+class Tribe__Events__Admin_ListTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @after
+	 */
+	public function reregister_taxonomies(): void {
+		TEC::instance()->register_taxonomy();
+	}
+
+	public function test_custom_columns_w_deregistered_cat_tax(): void {
+		$post_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2018-01-01 08:00:00',
+			'end_date'   => '2018-01-01 10:00:00',
+		] )->create()->ID;
+		unregister_taxonomy( TEC::TAXONOMY );
+
+		$admin_list = new Admin_List();
+		$columns    = $admin_list->custom_columns( 'events-cats', $post_id );
+
+		$this->assertEquals( [], $columns );
+	}
+}

--- a/tests/wpunit/Tribe__Events__MainTest.php
+++ b/tests/wpunit/Tribe__Events__MainTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__Events__Main as TEC;
+
+class Tribe__Events__MainTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * @after
+	 */
+	public function reregister_taxonomies(): void {
+		TEC::instance()->register_taxonomy();
+	}
+
+	public function test_post_class_will_work_when_cat_tax_unregistered(): void {
+		global $post;
+		$post = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2018-01-01 08:00:00',
+			'end_date'   => '2018-01-01 10:00:00',
+		] )->create();
+		unregister_taxonomy( TEC::TAXONOMY );
+
+		$main       = TEC::instance();
+		$post_class = $main->post_class( [] );
+
+		$this->assertEquals( [], $post_class );
+	}
+
+	public function test_post_class_will_work_when_some_terms_are_not_valid(): void {
+		global $post;
+		$post = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2018-01-01 08:00:00',
+			'end_date'   => '2018-01-01 10:00:00',
+		] )->create();
+		$this->set_fn_return( 'get_the_terms', [
+			static::factory()->term->create_and_get( [
+				'taxonomy' => TEC::TAXONOMY,
+				'name'     => 'Test Category',
+			] ),
+			new WP_Error( 'invalid_term', 'Invalid term.' ),
+		] );
+
+		$main       = TEC::instance();
+		$post_class = $main->post_class( [] );
+
+		$this->assertEquals( [ 'cat_test-category' ], $post_class );
+	}
+}


### PR DESCRIPTION
Ticket: [TEC-4664](https://theeventscalendar.atlassian.net/browse/TEC-4664)

Artifacts: tests.

This updates the code to be robust to the unregistration of the custom Events' category.

I've checked all the places where the result of a `get_terms`, and similar, call is assumed to be a set of terms to check for:
* `WP_Error` response when the taxonomy is not registered
* bad terms, not instances of `WP_Term`

Smaller refactoring to `Tribe__Events__Main` to extract the `register_taxonomy` method; no functional changes.


[TEC-4664]: https://theeventscalendar.atlassian.net/browse/TEC-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ