### PR TITLE
Add test coverage for CT1 get_posts filtering

### DIFF
--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Only_ModifierTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Modifiers/Events_Only_ModifierTest.php
@@ -2,9 +2,14 @@
 
 namespace TEC\Events\Custom_Tables\V1\WP_Query\Modifiers;
 
+use TEC\Events\Custom_Tables\V1\Models\Event;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Events__Main as TEC;
 
 class Events_Only_ModifierTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
 	/**
 	 * It should not apply to query in admin context
 	 *
@@ -52,5 +57,103 @@ class Events_Only_ModifierTest extends \Codeception\TestCase\WPTestCase {
 		$applies  = $modifier->applies_to( $query );
 
 		$this->assertTrue( $applies );
+	}
+
+	/**
+	 * It should correctly filter get_posts queries in admin or AJAX context
+	 *
+	 * @test
+	 */
+	public function should_correctly_filter_get_posts_queries_in_admin_or_ajax_context(): void {
+		// To avoid test flakiness, fix a moment in time as "now"; this will be used by the TEC query.
+		add_filter( 'tec_events_query_current_moment', static fn() => '2020-03-02 08:00:00' );
+		// Simulate a /wp-admin request.
+		$this->set_fn_return( 'is_admin', true );
+		// Create 1 past event and 2 future single events.
+		$events   = [];
+		$timezone = get_option( 'timezone_string' );
+		foreach (
+			[
+				'2020-03-04 08:00:00',
+				'2020-03-14 08:00:00',
+				'2020-02-20 08:00:00',
+			] as $start_date
+		) {
+			$event = tribe_events()->set_args( [
+				'title'      => $start_date . ' test event',
+				'status'     => 'publish',
+				'start_date' => $start_date,
+				'duration'   => 2 * HOUR_IN_SECONDS,
+				'timezone'   => $timezone,
+			] )->create();
+			$this->assertInstanceOf( Event::class, Event::find( $event->ID, 'post_id' ) );
+			$this->assertInstanceOf( Occurrence::class, Occurrence::find( $event->ID, 'post_id' ) );
+			$this->assertEquals( 1, Occurrence::where( 'post_id', '=', $event->ID )->count() );
+			$events[] = $event->ID;
+		}
+
+		$args = [
+			'posts_per_page'         => 20,
+			'paged'                  => 1,
+			'post_type'              => 'tribe_events',
+			'orderby'                => 'menu_order title',
+			'order'                  => 'ASC',
+			'post_status'            => 'any',
+			'suppress_filters'       => false,
+			'update_post_meta_cache' => false,
+		];
+
+		$found = get_posts( $args );
+
+		// We do not care about the order here, just that no date filtering is applied.
+		$this->assertEqualSets( $events, wp_list_pluck( $found, 'ID' ) );
+	}
+
+	/**
+	 * It should correctly filter get_posts queries in front-end context
+	 *
+	 * @test
+	 */
+	public function should_correctly_filter_get_posts_queries_in_front_end_context(): void {
+		// To avoid test flakiness, fix a moment in time as "now"; this will be used by the TEC query.
+		add_filter( 'tec_events_query_current_moment', static fn() => '2020-03-02 08:00:00' );
+		// This request does not come from an admin context.
+		// Create 1 past event and 2 future single events.
+		$events   = [];
+		$timezone = get_option( 'timezone_string' );
+		foreach (
+			[
+				'2020-03-14 08:00:00',
+				'2020-02-20 08:00:00',
+				'2020-03-04 08:00:00',
+			] as $start_date
+		) {
+			$event = tribe_events()->set_args( [
+				'title'      => $start_date . ' test event',
+				'status'     => 'publish',
+				'start_date' => $start_date,
+				'duration'   => 2 * HOUR_IN_SECONDS,
+				'timezone'   => $timezone,
+			] )->create();
+			$this->assertInstanceOf( Event::class, Event::find( $event->ID, 'post_id' ) );
+			$this->assertInstanceOf( Occurrence::class, Occurrence::find( $event->ID, 'post_id' ) );
+			$this->assertEquals( 1, Occurrence::where( 'post_id', '=', $event->ID )->count() );
+			$events[] = $event->ID;
+		}
+
+		$args = [
+			'posts_per_page'         => 20,
+			'paged'                  => 1,
+			'post_type'              => 'tribe_events',
+			'orderby'                => 'menu_order title',
+			'order'                  => 'ASC',
+			'post_status'            => 'any',
+			'suppress_filters'       => false,
+			'update_post_meta_cache' => false,
+		];
+
+		$found = get_posts( $args );
+
+		$this->assertEquals( [ $events[2], $events[0] ], wp_list_pluck( $found, 'ID' ) );
 	}
 }


### PR DESCRIPTION
This PR just adds coverage, in the `ct1_integration` suite, for the filtering of `get_posts` call in CT1 context.

The issue tracked by [the ticket](https://theeventscalendar.atlassian.net/browse/TEC-4621) is dealt with in an [ECP PR](https://github.com/the-events-calendar/events-pro/pull/2194).
