### PR TITLE
PHP Fatal error when there are no Event Categories

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -493,7 +493,7 @@ function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	$post_id = Tribe__Events__Main::postIdHelper( $post_id );
 	$terms   = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
 
-	if ( $terms instanceof WP_Error ) {
+	if ( $terms instanceof WP_Error || !$terms ) {
 		return [];
 	}
 


### PR DESCRIPTION
Test with PHP 8.0.10
PHP Fatal error:  Uncaught TypeError: array_filter(): Argument 1 ($array) must be of type array, bool given In function tribe_get_event_cat_slugs, in case of no categories get_the_terms returns also false not only WP_Error.
In this scenario array_filter(): Argument 1 is false.