### PR TITLE
Fix the pagination styling on the Aggregator import preview data table.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix: Add a default Schema eventStatus value for JSON LD output of events. [TEC-4609]
+* Fix - Fix the pagination styling on the Aggregator import preview data table. [TEC-4698]
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 

--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -190,7 +190,7 @@ class Tribe__Events__Aggregator__Page {
 			$plugin,
 			'tribe-ea-styles',
 			'aggregator-page.css',
-			[],
+			[ 'datatables-css' ],
 			'admin_enqueue_scripts',
 			[
 				'conditionals' => [


### PR DESCRIPTION
Ticket : [TEC-4698](https://theeventscalendar.atlassian.net/browse/TEC-4698)

I'm adding the `datatables-css` stylesheet as a dependancy for `tribe-ea-styles` in order to fix the borked pagination stying on the Aggregator import preview data table.

For context, the stylesheet was previously registered [here](https://github.com/the-events-calendar/tribe-common/blob/cca67a481cff1f12942cfc1cc64d7e83cbbf8e59/src/Tribe/Main.php#L231) but was never enqueued.

Note that I've not updated the artifacts from the [previous pr](https://github.com/the-events-calendar/tribe-common/pull/1881) as they're still valid. I've however retested with the new updates to confirm the fix works as intended.

**Artifacts 📸**

Here we can see the pagination UI is borked prior to enqueuing the styles.

![image](https://user-images.githubusercontent.com/22029087/218877712-20c73cd6-c89b-4edb-a109-429b72412aa8.png)

Here the UI is fixed.

![image](https://user-images.githubusercontent.com/22029087/218877498-d710f754-fd67-4048-ba72-8a5e00915ffb.png)


[TCMN-163]: https://theeventscalendar.atlassian.net/browse/TCMN-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TEC-4698]: https://theeventscalendar.atlassian.net/browse/TEC-4698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ