### PR TITLE
Update manager.js

### DIFF
--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -496,7 +496,6 @@ tribe.events.views.manager = {};
 	obj.getAjaxSettings = function( $container ) {
 		var ajaxSettings = {
 			url: $container.data( 'view-rest-url' ),
-			accepts: 'html',
 			dataType: 'html',
 			method: $container.data( 'view-rest-method' ) || 'POST',
 			'async': true, // async is keyword


### PR DESCRIPTION
The  "accepts: 'html'" is harmful and results in buggy behaviour depending on the server.   Because it is invalid in this form, it actually causes the Accept header to be "undefined", which may result in server side errors.

From http://api.jquery.com/jquery.ajax/ : 

accepts (default: depends on dataType)
Type: PlainObject
A set of key/value pairs that map a given dataType to its MIME type, which gets sent in the Accept request header. This header tells the server what kind of response it will accept in return. For example, the following defines a custom type mycustomtype to be sent with the request:

So, if the accepts needs to be specified, it should be on the form: accepts: {
 'html': 'text/html'
}

This does not seem to add anything, and the KISS solution is to simply delete this line.