### PR TITLE
`tribe_events_event_classes` fatal error.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Display Venue correctly in List-like views when using WPML. [ECP-1443]
 * Fix - Link to the correct Occurrence when using CT1 and WPML. [TEC-4632]
 * Fix - Fix the pagination styling on the Aggregator import preview data table. [TEC-4698]
+* Fix - Avoid fatal error in `tribe_events_event_classes` when called on events that don't have a category assigned to them. [TEC-4709]
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Modified single-event.php to use `tribe_get_formatted_cost` instead of `tribe_get_cost` to display the event cost. [TEC-4699]

--- a/readme.txt
+++ b/readme.txt
@@ -235,7 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Display Venue correctly in List-like views when using WPML. [ECP-1443]
 * Fix - Link to the correct Occurrence when using CT1 and WPML. [TEC-4632]
 * Fix - Fix the pagination styling on the Aggregator import preview data table. [TEC-4698]
-* Fix - Avoid fatal error in `tribe_events_event_classes` when called on events that don't have a category assigned to them. [TEC-4709]
+* Fix - Avoid fatal error in `tribe_events_event_classes` when called on events that aren't assigned to any category. [TEC-4709]
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Modified single-event.php to use `tribe_get_formatted_cost` instead of `tribe_get_cost` to display the event cost. [TEC-4699]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -494,8 +494,8 @@ function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	$terms   = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
 
 	/**
-	 * Returns an empty array when there are no categories
-	 * assigned to an event or when $terms generates an error.
+	 * Returns an empty array on events that aren't assigned
+	 * to any category or when $terms generates an error.
 	 */
 	if (  empty ( $terms ) || $terms instanceof WP_Error ) {
 		return [];

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -493,7 +493,11 @@ function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	$post_id = Tribe__Events__Main::postIdHelper( $post_id );
 	$terms   = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
 
-	if ( $terms instanceof WP_Error ) {
+	/**
+	 * Returns an empty array when there are no categories
+	 * assigned to an event or when $terms generates an error.
+	 */
+	if (  empty ( $terms ) || $terms instanceof WP_Error ) {
 		return [];
 	}
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -496,6 +496,10 @@ function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	/**
 	 * Returns an empty array on events that aren't assigned
 	 * to any category or when $terms generates an error.
+	 * 
+	 * @since TBD
+	 * 
+	 * @return array
 	 */
 	if (  empty ( $terms ) || $terms instanceof WP_Error ) {
 		return [];


### PR DESCRIPTION
Ticket : [TEC-4709](https://theeventscalendar.atlassian.net/browse/TEC-4709)

Avoid fatal error when the `tribe_events_event_classes` method is called on events that aren't assigned to any category.

**Screencast 🎥**

https://www.loom.com/share/0370c51962724267af1e81f556563830

[TEC-4709]: https://theeventscalendar.atlassian.net/browse/TEC-4709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ