### PR TITLE
Convert all uses of `filter_var( 'FILTER_SANITIZE_STRING' )`

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -223,7 +223,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				$htmlElement = ltrim( $tag, '_' );
 				if ( isset( $data[ $htmlElement ] ) && $tag != Tribe__Events__Main::EVENTSERROROPT ) {
 					if ( is_string( $data[ $htmlElement ] ) ) {
-						$data[ $htmlElement ] = filter_var( $data[ $htmlElement ], FILTER_SANITIZE_STRING );
+						$data[ $htmlElement ] = htmlspecialchars( $data[ $htmlElement ], ENT_QUOTES );
 					}
 					// Fields with multiple values per key
 					if ( is_array( $data[ $htmlElement ] ) ) {

--- a/src/Tribe/Aggregator/Processes/Import_Events.php
+++ b/src/Tribe/Aggregator/Processes/Import_Events.php
@@ -207,7 +207,8 @@ class Tribe__Events__Aggregator__Processes__Import_Events extends Tribe__Process
 
 		$record_id             = $this->record_id = $item['record_id'];
 		$data                  = (array) $item['data'];
-		$this->transitional_id = filter_var( $item['transitional_id'], FILTER_SANITIZE_STRING );
+		$this->transitional_id = htmlspecialchars( $item['transitional_id'], ENT_QUOTES );
+
 
 		/*
 		 * Make sure the import is happening in the context of the same site that started it.

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -108,7 +108,7 @@ class Rest_Endpoint {
 					return is_string( $view );
 				},
 				'sanitize_callback' => static function ( $view ) {
-					return filter_var( $view, FILTER_SANITIZE_STRING );
+					return htmlspecialchars( $view, ENT_QUOTES );
 				},
 			],
 			'_wpnonce' => [
@@ -117,7 +117,7 @@ class Rest_Endpoint {
 					return is_string( $nonce );
 				},
 				'sanitize_callback' => static function ( $nonce ) {
-					return filter_var( $nonce, FILTER_SANITIZE_STRING );
+					return htmlspecialchars( $nonce, ENT_QUOTES );
 				},
 			],
 			'view_data' => [
@@ -138,7 +138,7 @@ class Rest_Endpoint {
 				return is_string( $action );
 			},
 			'sanitize_callback' => static function ( $action ) {
-				return filter_var( $action, FILTER_SANITIZE_STRING );
+				return htmlspecialchars( $action, ENT_QUOTES );
 			},
 		];
 


### PR DESCRIPTION
to `htmlspecialchars()` for PHP8 compatibility.

Related: https://github.com/the-events-calendar/tribe-common/pull/1887