### PR TITLE
[CE-178] Fix allow venue defaults to work with Community Events 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -239,6 +239,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Avoid fatal error in `tribe_events_event_classes` when called on events that aren't assigned to any category. [TEC-4709]
 * Fix - Ensure the Subscribe to Calendar Dropdown opens and closes consistently across all themes. [TEC-4388]
 * Fix - Ensure the date tags for recurring events are displayed correctly in the `Events List` widget. [ECP-1382]
+* Fix - Fix an issue that stopped the default venue values from populating when submitting a Community Event. [CE-178]
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Add empty alt tag to featured images across all views when a user doesn't explicitly define one to improve SEO. [ECP-1454]

--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -5,7 +5,7 @@ $post_id = Tribe__Events__Main::postIdHelper();
 $is_auto_draft = get_post_status( $post_id ) === 'auto-draft';
 
 // If not $_POST and if this is not an auto-draft then get the current values to edit
-if ( ! $_POST && is_admin() ) {
+if ( ! $_POST ) {
 
 	$venue_name             = tribe_get_venue();
 


### PR DESCRIPTION
This PR fixes an issue where the default venue information wasn't populating when using Community Events.

Screenshot within Admin
![image](https://user-images.githubusercontent.com/12241059/222208374-2c3e4c9e-307b-45c8-8f6d-f6affeeb7a76.png)


Screenshot from within Community Events
![image](https://user-images.githubusercontent.com/12241059/222208488-1a9ea396-3bbf-4d05-a472-6b45152e782d.png)

Showing the custom list of countries works as well
![image](https://user-images.githubusercontent.com/12241059/222208933-45c586ca-e19b-4780-996e-1d4924983381.png)

