### PR TITLE
Prevent fatal on tribe_get_event_cat_slugs with bad type for array_filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -240,11 +240,11 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Ensure the Subscribe to Calendar Dropdown opens and closes consistently across all themes. [TEC-4388]
 * Fix - Ensure the date tags for recurring events are displayed correctly in the `Events List` widget. [ECP-1382]
 * Fix - Fix an issue that stopped the default venue values from populating when submitting a Community Event. [CE-178]
+* Fix - Prevent fatal on PHP 8+ for `tribe_get_event_cat_slugs` with bad typing around `array_filter` [TEC-4725]
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Add empty alt tag to featured images across all views when a user doesn't explicitly define one to improve SEO. [ECP-1454]
 * Tweak - Modified single-event.php to use `tribe_get_formatted_cost` instead of `tribe_get_cost` to display the event cost. [TEC-4699]
-
 
 = [6.0.9] 2023-02-09 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -459,16 +459,20 @@ function tribe_is_past_event( $event = null ) {
 }
 
 /**
- * Event Category ID's
+ * Returns an array terms `term_id` from the taxonomy `tribe_cat` for a given event.
  *
- * Display the event category ID as a class for events wrapper
+ * @since 3.0.0
+ * @since TBD Type hinting the return to array.
  *
  * @uses     wp_get_object_terms()
- * @category Events
+ *
+ * @param int|string|WP_Post $post_id
+ *
+ * @return array<int>
  */
-function tribe_get_event_cat_ids( $post_id = 0 ) {
-	$post_id  = Tribe__Events__Main::postIdHelper( $post_id );
-	$terms = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
+function tribe_get_event_cat_ids( $post_id = 0 ): array {
+	$post_id = Tribe__Events__Main::postIdHelper( $post_id );
+	$terms   = get_the_terms( $post_id, Tribe__Events__Main::TAXONOMY );
 
 	if ( $terms instanceof WP_Error ) {
 		return [];

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -474,6 +474,11 @@ function tribe_get_event_cat_ids( $post_id = 0 ) {
 		return [];
 	}
 
+	// Makes sure we are not throwing fatals on PHP 8.0.
+	if ( empty( $terms ) ) {
+		return [];
+	}
+
 	$terms = array_values( array_filter( $terms, static function ( $term ) {
 		return $term instanceof WP_Term;
 	} ) );
@@ -496,9 +501,9 @@ function tribe_get_event_cat_slugs( $post_id = 0 ) {
 	/**
 	 * Returns an empty array on events that aren't assigned
 	 * to any category or when $terms generates an error.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @return array
 	 */
 	if (  empty ( $terms ) || $terms instanceof WP_Error ) {


### PR DESCRIPTION
🎫 [TEC-4725]
---
Resolves the fatal, super simple change.

[TEC-4725]: https://theeventscalendar.atlassian.net/browse/TEC-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ