### PR TITLE
Fix the home_url() comparison when WPML is installed

### DIFF
--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -139,8 +139,8 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 
 		global $wp;
 
-		$current_url = home_url( $wp->request );
-		$allowed_rest_url = rest_url( 'wp/v2' );
+		$current_url      = home_url( $wp->request );
+		$allowed_rest_url = home_url( trailingslashit( rest_get_url_prefix() ) . 'wp/v2' );
 
 		// Only this overwrite on the Tribe Events Endpoint.
 		if ( false === strpos( $current_url, $allowed_rest_url ) ) {


### PR DESCRIPTION
WPML appends the language code to the result of home_url, ie: http://localhost/es/wp-json

This breaks the comparison with the result of rest_url and won't let us save events using the block editor.

One way of solving it is to put together the rest URL using home_url() too, but you might have a better solution in mind.

# Test steps

Fresh setup with The Events Calendar and WPML
Enable the block editor for events
In admin, switch to second language
Add a new event with just a title
Publish it
You'll see an error in the WP editor

If you don't see the error, switch back to default language, then to secondary language and try again.

The problem was originally reported in our support forum: https://wpml.org/forums/topic/conflict-with-event-calendar-2/