### PR TITLE
fix(resources/js) correctly call the addAction method

### DIFF
--- a/src/resources/js/admin/notice-install-event-tickets.js
+++ b/src/resources/js/admin/notice-install-event-tickets.js
@@ -53,6 +53,7 @@ tribe.events.admin.noticeInstall = {};
 	obj.ready = function() {
 		wp.hooks.addAction(
 			'stellarwp_installer_tec_error',
+			'tec/eventTicketsInstallerError',
 			function( selector, slug, action, message ) {
 				const $button = $( selector );
 				const $description = $button.siblings( obj.selectors.noticeDescription );


### PR DESCRIPTION
The `wp.hooks.addAction` method requires a namespace to uniquely
identify the callback (see [doc](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-hooks/#the-global-instance)).
This adds it.

* [before](https://share.cleanshot.com/CM9KlD3Z) 
* [after](https://share.cleanshot.com/hYJtYh37) 
