### PR TITLE
Resolve PHP 8+ issue with transposed implode call

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -243,6 +243,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Failures while saving Events from Blocks Editor while using WPML. [ECP-1429]
 * Fix - Fix an issue that stopped the default venue values from populating when submitting a Community Event. [CE-178]
 * Fix - Prevent fatal on PHP 8+ for `tribe_get_event_cat_slugs` with bad typing around `array_filter` [TEC-4725]
+* Fix - Prevent fatal on PHP 8+ during generation of the activation report when issues exist.
 * Tweak - Ensure all instances of the `tribe_get_events_title` filter have matching signatures. [TEC-3929]
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Add empty alt tag to featured images across all views when a user doesn't explicitly define one to improve SEO. [ECP-1454]

--- a/src/Events/Custom_Tables/V1/Activation.php
+++ b/src/Events/Custom_Tables/V1/Activation.php
@@ -189,7 +189,7 @@ class Activation {
 			$issue_reports[] = "`Occurrences` Table Missing";
 		}
 
-		$reports = empty( $issue_reports ) ? 'Good!' : implode( $issue_reports, ' | ' );
+		$reports = empty( $issue_reports ) ? 'Good!' : implode( ' | ', $issue_reports );
 
 		// Add health checks here.
 		$migration_health_check = [


### PR DESCRIPTION
This resolves an issue where `implode()` was being called with the wrong argument order.