### PR TITLE
Fix ACF integration

### DIFF
--- a/src/Events/Custom_Tables/V1/Integrations/ACF/Controller.php
+++ b/src/Events/Custom_Tables/V1/Integrations/ACF/Controller.php
@@ -111,13 +111,12 @@ class Controller extends Service_Provider {
 	 * @return void Actions and filters are removed.
 	 */
 	public function unregister() {
+		// Unhook the same action twice for each supported field type; see the `register` method.
 		foreach ( self::get_supported_field_types() as $supported_field_type ) {
-			// Detect the start of a specific ACF field type to boot the handling.
 			remove_action( 'acf/render_field/type=' . $supported_field_type, [
 				$this,
 				'start_acf_handling'
 			], self::EARLY_PRIORITY );
-			// Hook again reasonably late to stop the handling.
 			remove_action( 'acf/render_field/type=' . $supported_field_type, [
 				$this,
 				'stop_acf_handling'

--- a/src/Events/Custom_Tables/V1/Integrations/ACF/Controller.php
+++ b/src/Events/Custom_Tables/V1/Integrations/ACF/Controller.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Handles the integration of the Custom Tables v1 implementation with the Advanced Custom Fields plugin.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
+ */
+
+namespace TEC\Events\Custom_Tables\V1\Integrations\ACF;
+
+use tad_DI52_ServiceProvider as Service_Provider;
+
+/**
+ * Class Controller.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
+ */
+class Controller extends Service_Provider {
+	/**
+	 * The priority at which the ACF field handling will start.
+	 *
+	 * @since TBD
+	 */
+	public const EARLY_PRIORITY = 0;
+
+	/**
+	 * The priority at which the ACF field handling will end.
+	 *
+	 * @since TBD
+	 */
+	public const LATE_PRIORITY = 1000;
+
+	/**
+	 * The priority at which the ACF field handling will start for AJAX queries.
+	 *
+	 * @since TBD
+	 */
+	public const AJAX_QUERY_PRIORITY = 10;
+
+	/**
+	 * A flag property indicating whether an ACF field of the supported type is being rendered or not.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	private bool $rendering_acf_field = false;
+
+	/**
+	 * Returns the list of supported field types.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string> The list of supported field types.
+	 */
+	public static function get_supported_field_types(): array {
+		return [
+			'post_object',
+			'relationship',
+		];
+	}
+
+	/**
+	 * Registers the implementations, actions and filters required by the Custom Tables implementation to work with
+	 * the Advanced Custom Fields plugin.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->container->singleton( self::class, $this );
+
+		foreach ( self::get_supported_field_types() as $supported_field_type ) {
+			// Detect the start of a specific ACF field type to boot the handling.
+			add_action( 'acf/render_field/type=' . $supported_field_type, [
+				$this,
+				'start_acf_handling'
+			], self::EARLY_PRIORITY, 0 );
+			// Hook again reasonably late to stop the handling.
+			add_action( 'acf/render_field/type=' . $supported_field_type, [
+				$this,
+				'stop_acf_handling'
+			], self::LATE_PRIORITY, 0 );
+		}
+
+		// Hook to redirect queries in the context of AJAX queries. The below filter is used only in AJAX context.
+		add_filter( 'acf/fields/post_object/query', [
+			$this,
+			'redirect_post_ajax_query'
+		], self::AJAX_QUERY_PRIORITY, 2 );
+
+		// Register a dedicated query modified implementation, pull the flag from the provider.
+		$this->container->bind(
+			Query_Modifier::class, fn() => ( new Query_Modifier() )->set_handling( $this->rendering_acf_field )
+		);
+		add_filter( 'tec_events_custom_tables_v1_query_modifier_implementations', [
+			$this,
+			'add_query_modifier_implementation'
+		] );
+	}
+
+	/**
+	 * Removes the actions and filters added by the provider.
+	 *
+	 * @since TBD
+	 *
+	 * @return void Actions and filters are removed.
+	 */
+	public function unregister() {
+		foreach ( self::get_supported_field_types() as $supported_field_type ) {
+			// Detect the start of a specific ACF field type to boot the handling.
+			remove_action( 'acf/render_field/type=' . $supported_field_type, [
+				$this,
+				'start_acf_handling'
+			], self::EARLY_PRIORITY );
+			// Hook again reasonably late to stop the handling.
+			remove_action( 'acf/render_field/type=' . $supported_field_type, [
+				$this,
+				'stop_acf_handling'
+			], self::LATE_PRIORITY );
+		}
+
+		remove_filter( 'tec_events_custom_tables_v1_query_modifier_implementations', [
+			$this,
+			'add_query_modifier_implementation'
+		] );
+		remove_filter( 'acf/fields/post_object/query', [
+			$this,
+			'redirect_post_ajax_query'
+		], self::AJAX_QUERY_PRIORITY );
+
+		$this->rendering_acf_field = false;
+	}
+
+	/**
+	 * Raises the flag indicating that an ACF field of the supported type is being rendered.
+	 *
+	 * @since TBD
+	 *
+	 * @return void The method does not return anything, the flag is raised.
+	 */
+	public function start_acf_handling(): void {
+		$this->rendering_acf_field = true;
+	}
+
+	/**
+	 * Lowers the flag indicating that an ACF field of the supported type is being rendered.
+	 *
+	 * @since TBD
+	 *
+	 * @return void The method does not return anything, the flag is lowered.
+	 */
+	public function stop_acf_handling(): void {
+		$this->rendering_acf_field = false;
+	}
+
+	/**
+	 * Adds the query modifier implementation to the list of implementations.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string> $implementations The list of implementations of the `Query_Modifier_Interface`.
+	 *
+	 * @return array<string> The filtered list of `Query_Modifier_Interface` implementations.
+	 */
+	public function add_query_modifier_implementation( $implementations ) {
+		if ( ! is_array( $implementations ) ) {
+			return $implementations;
+		}
+
+		// Build it now and hold a reference to it.
+		$implementations[] = Query_Modifier::class;
+
+		return $implementations;
+	}
+
+	/**
+	 * Redirect supported type queries to the custom tables.
+	 *
+	 * Note: the method hooks, but never unhooks, to the `acf/fields/post_object/query` filter.
+	 * The is because there is not action/filter to hook to that is fired when the AJAX query is done,
+	 * and because the request will send the JSON data and die.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $args  The input query argument, left unmodified.
+	 * @param array<string,mixed> $field The field data.
+	 *
+	 * @return array<string,mixed> The query arguments, left unmodified.
+	 */
+	public function redirect_post_ajax_query( $args, $field ) {
+		if ( ! (
+			is_array( $args )
+			&& is_array( $field )
+			&& isset( $field['type'] )
+			&& in_array( $field['type'], self::get_supported_field_types(), true ) )
+		) {
+			return $args;
+		}
+		$this->start_acf_handling();
+
+		return $args;
+	}
+}

--- a/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
+++ b/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * An extension of the Events-only modifier to redirect Event queries to the custom tables
+ * while rendering ACF fields.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
+ */
+
+namespace TEC\Events\Custom_Tables\V1\Integrations\ACF;
+
+use TEC\Events\Custom_Tables\V1\WP_Query\Custom_Tables_Query;
+use TEC\Events\Custom_Tables\V1\WP_Query\Modifiers\Events_Only_Modifier;
+use WP_Query;
+use Tribe__Events__Main as TEC;
+
+/**
+ * Class Query_Modifier.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
+ */
+class Query_Modifier extends Events_Only_Modifier {
+	/**
+	 * ${CARET}
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	private bool $handle = false;
+
+	/**
+	 * Whether this query modifier should handle the query or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Query|null $query The query object that will be modified.
+	 *
+	 * @return bool Whether this query modifier should handle the query or not.
+	 */
+	public function applies_to( WP_Query $query = null ) {
+		return $this->handle
+		       && $query !== null
+		       && ! $query instanceof Custom_Tables_Query
+		       && $this->is_query_for_post_type( $query, TEC::POSTTYPE );
+	}
+
+	/**
+	 * Sets whether the query modifier should handle the query or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $handling Whether the query modifier should handle the query or not.
+	 *
+	 * @return $this This query modifier instance.
+	 */
+	public function set_handling( bool $handling ): self {
+		$this->handle = $handling;
+
+		return $this;
+	}
+}

--- a/src/Events/Custom_Tables/V1/Integrations/Provider.php
+++ b/src/Events/Custom_Tables/V1/Integrations/Provider.php
@@ -11,6 +11,7 @@ namespace TEC\Events\Custom_Tables\V1\Integrations;
 
 
 use tad_DI52_ServiceProvider as Service_Provider;
+use TEC\Events\Custom_Tables\V1\Integrations\ACF\Controller as ACF_Controller;
 
 /**
  * Class Provider
@@ -29,6 +30,11 @@ class Provider extends Service_Provider {
 		// Class defined by the Event Events plugin.
 		if ( class_exists( '\\TEC\\Event_Tickets\\Custom_Tables\\V1\\Provider' ) ) {
 			$this->container->register( \TEC\Tickets\Custom_Tables\V1\Provider::class );
+		}
+
+		// Class defined by the Advanced Custom Fields plugin.
+		if ( class_exists( 'ACF' ) ) {
+			$this->container->register( ACF_Controller::class );
 		}
 	}
 }

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Integrations/ACF/ControllerTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Integrations/ACF/ControllerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace TEC\Events\Custom_Tables\V1\Integrations\ACF;
+
+use Tribe\Events\Views\V2\Query\Event_Query_Controller;
+use Tribe__Events__Main as TEC;
+use TEC\Events\Custom_Tables\V1\Integrations\ACF\Controller as ACF_Controller;
+
+class ControllerTest extends \Codeception\TestCase\WPTestCase {
+	public function setUp() {
+		parent::setUp();
+		tribe()->register( ACF_Controller::class );
+	}
+
+	public function tearDown(): void {
+		tribe( ACF_Controller::class )->unregister();
+		parent::tearDown();
+	}
+
+	/**
+	 * It should not handle Event queries by default
+	 *
+	 * @test
+	 */
+	public function should_not_handle_event_queries_by_default(): void {
+		$query = new \WP_Query( [ 'post_type' => TEC::POSTTYPE ] );
+
+		$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+	}
+
+	/**
+	 * It should handle Event queries while rendering a non supported field
+	 *
+	 * The Controller will hook early to redirect queries and late to stop handling them.
+	 * Due to this particular arrangement, the test method phases are labeled.
+	 *
+	 * @test
+	 */
+	public function should_handle_event_queries_while_rendering_a_non_supported_field(): void {
+		// Assert
+		$assert = function () {
+			// Create a query for Events the modifier should apply to.
+			$query = new \WP_Query( [ 'post_type' => TEC::POSTTYPE ] );
+
+			$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+		};
+
+		// Arrange
+		$between_priority = ( ACF_Controller::LATE_PRIORITY - ACF_Controller::EARLY_PRIORITY ) / 2;
+		add_action( 'acf/render_field/type=some_type', $assert, $between_priority );
+
+		// Act
+		do_action( 'acf/render_field/type=some_type' );
+	}
+
+	public function supported_field_types(): \Generator {
+		foreach ( ACF_Controller::get_supported_field_types() as $field_type ) {
+			yield $field_type => [ $field_type ];
+		}
+	}
+
+	/**
+	 * It should handle Event queries while rendering a supported field
+	 *
+	 * @test
+	 * @dataProvider supported_field_types
+	 */
+	public function should_handle_event_queries_while_rendering_a_supported_field( string $field_type ): void {
+		// Assert
+		$assert = function () {
+			// Create a query for Events the modifier should apply to.
+			$query = new \WP_Query( [ 'post_type' => TEC::POSTTYPE ] );
+
+			$this->assertTrue( tribe( Query_Modifier::class )->applies_to( $query ) );
+		};
+
+		// Arrange
+		$between_priority = ( ACF_Controller::LATE_PRIORITY - ACF_Controller::EARLY_PRIORITY ) / 2;
+		add_action( "acf/render_field/type=$field_type", $assert, $between_priority );
+
+		// Act
+		do_action( "acf/render_field/type=$field_type" );
+	}
+
+	/**
+	 * It should not handle queries for multiple post types including Event
+	 *
+	 * @test
+	 * @dataProvider supported_field_types
+	 */
+	public function should_not_handle_queries_for_multiple_post_types_including_event( string $field_type ): void {
+		// Assert
+		$assert = function () {
+			// Create a query for Events the modifier should apply to.
+			$query = new \WP_Query( [ 'post_type' => [ TEC::POSTTYPE, 'post' ] ] );
+
+			$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+		};
+
+		// Arrange
+		$between_priority = ( ACF_Controller::LATE_PRIORITY - ACF_Controller::EARLY_PRIORITY ) / 2;
+		add_action( "acf/render_field/type=$field_type", $assert, $between_priority );
+
+		// Act
+		do_action( "acf/render_field/type=$field_type" );
+	}
+
+	/**
+	 * It should not redirect AJAX queries not for Event
+	 *
+	 * @test
+	 */
+	public function should_not_redirect_ajax_queries_not_for_event(): void {
+		// Assert
+		$assert = function ( $args ) {
+			$this->assertEquals( [], $args );
+			$query = new \WP_Query( [ 'post_type' => 'post' ] );
+			$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+
+			return $args;
+		};
+
+		// Arrange
+		add_filter( 'acf/fields/post_object/query', $assert, ACF_Controller::AJAX_QUERY_PRIORITY + 10 );
+
+		// Act
+		$filtered = apply_filters( 'acf/fields/post_object/query', [], [
+			'type' => ACF_Controller::get_supported_field_types()[0],
+		] );
+
+		// Assert more.
+		$this->assertEquals( [], $filtered );
+	}
+
+	/**
+	 * It should not redirect AJAX queries for Event when field type not supported
+	 *
+	 * @test
+	 */
+	public function should_not_redirect_ajax_queries_for_event_when_field_type_not_supported(): void {
+		// Assert
+		$assert = function ( $args ) {
+			$this->assertEquals( [], $args );
+			$query = new \WP_Query( [ 'post_type' => 'post' ] );
+			$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+
+			return $args;
+		};
+
+		// Arrange
+		add_filter( 'acf/fields/post_object/query', $assert, ACF_Controller::AJAX_QUERY_PRIORITY + 10 );
+
+		// Act
+		$filtered = apply_filters( 'acf/fields/post_object/query', [], [
+			'type' => 'not_supported',
+		] );
+
+		// Assert more.
+		$this->assertEquals( [], $filtered );
+	}
+
+	/**
+	 * It should redirect AJAX queries for Events for supported field types
+	 *
+	 * @test
+	 * @dataProvider supported_field_types
+	 */
+	public function should_redirect_ajax_queries_for_events_for_supported_field_types( string $field_type ): void {
+		// Assert
+		$assert = function ( $args ) {
+			$this->assertEquals( [], $args );
+			$query = new \WP_Query( [ 'post_type' => TEC::POSTTYPE ] );
+			$this->assertTrue( tribe( Query_Modifier::class )->applies_to( $query ) );
+
+			return $args;
+		};
+
+		// Arrange
+		add_filter( 'acf/fields/post_object/query', $assert, ACF_Controller::AJAX_QUERY_PRIORITY + 10 );
+
+		// Act
+		$filtered = apply_filters( 'acf/fields/post_object/query', [], [
+			'type' => $field_type,
+		] );
+
+		// Assert more.
+		$this->assertEquals( [], $filtered );
+	}
+
+	/**
+	 * It should not redirect AJAX queries for Events and other post types
+	 *
+	 * @test
+	 * @dataProvider supported_field_types
+	 */
+	public function should_not_redirect_ajax_queries_for_events_and_other_post_types( string $field_type ): void {
+		// Assert
+		$assert = function ( $args ) {
+			$this->assertEquals( [], $args );
+			$query = new \WP_Query( [ 'post_type' => [ TEC::POSTTYPE, 'post' ] ] );
+			$this->assertFalse( tribe( Query_Modifier::class )->applies_to( $query ) );
+
+			return $args;
+		};
+
+		// Arrange
+		add_filter( 'acf/fields/post_object/query', $assert, ACF_Controller::AJAX_QUERY_PRIORITY + 10 );
+
+		// Act
+		$filtered = apply_filters( 'acf/fields/post_object/query', [], [
+			'type' => $field_type,
+		] );
+
+		// Assert more.
+		$this->assertEquals( [], $filtered );
+	}
+}


### PR DESCRIPTION
[TEC-4621](https://theeventscalendar.atlassian.net/browse/TEC-4621) 

Fix the query side of the ACF integration code to handle both initial PHP state queries for Events, and AJAX-based queries.

> Multiple post-type queries are not supported.

Artifacts:
* tests
* [screencast](https://share.cleanshot.com/HZ5pJZG2) 


[TEC-4621]: https://theeventscalendar.atlassian.net/browse/TEC-4621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ