### PR TITLE
fix(Integrations/WPML) correctly handle linked post cached value

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -248,6 +248,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Update the datepicker label on list-style views to `Upcoming` when no events are found. [TEC-3960]
 * Tweak - Add empty alt tag to featured images across all views when a user doesn't explicitly define one to improve SEO. [ECP-1454]
 * Tweak - Modified single-event.php to use `tribe_get_formatted_cost` instead of `tribe_get_cost` to display the event cost. [TEC-4699]
+* Fix - Correctly display Recurring Event Venue and Organizer details on the front-end and back-end when using WPML. [ECP-1442, ECP-1455]
 
 = [6.0.10] 2023-02-22 =
 

--- a/src/Tribe/Integrations/WPML/Meta.php
+++ b/src/Tribe/Integrations/WPML/Meta.php
@@ -51,7 +51,10 @@ class Tribe__Events__Integrations__WPML__Meta {
 		if ( isset( $cache[ $cache_key ] ) ) {
 			$cached = $cache[ $cache_key ];
 
-			return $single ? $cached : [ $cached ];
+			// The cached value must be an array.
+			if ( is_array( $cached ) ) {
+				return $single ? reset( $cached ) : $cached;
+			}
 		}
 
 		$original_value = $value;
@@ -96,7 +99,7 @@ class Tribe__Events__Integrations__WPML__Meta {
 			}
 		}
 
-		$cache[ $cache_key ] = $value[0];
+		$cache[ $cache_key ] = $value;
 
 		return $single ? $value[0] : $value;
 	}

--- a/tests/integration/Tribe/Events/Integrations/WPML/MetaTest.php
+++ b/tests/integration/Tribe/Events/Integrations/WPML/MetaTest.php
@@ -20,7 +20,7 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 				unset( $_POST );
 				$post_id = $this->given_an_event()->ID;
 
-				return [ 'input', $post_id, '_EventOrganizerID', true, 'input' ];
+				return [ 'input', $post_id, '_EventOrganizerID', true, 'input', 'input' ];
 			}
 		];
 		yield 'not a supported meta' => [
@@ -28,7 +28,7 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 				$_POST   = [];
 				$post_id = $this->given_an_event()->ID;
 
-				return [ 'input', $post_id, '_CustomField', true, 'input' ];
+				return [ 'input', $post_id, '_CustomField', true, 'input', 'input' ];
 			}
 		];
 		yield 'supported meta, null input value, single' => [
@@ -36,7 +36,7 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 				$_POST   = [];
 				$post_id = $this->given_an_event()->ID;
 
-				return [ null, $post_id, '_EventOrganizerID', true, null ];
+				return [ null, $post_id, '_EventOrganizerID', true, null, null ];
 			}
 		];
 		yield 'supported meta, null input value, multiple' => [
@@ -44,7 +44,7 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 				$_POST   = [];
 				$post_id = $this->given_an_event()->ID;
 
-				return [ null, $post_id, '_EventOrganizerID', false, null ];
+				return [ null, $post_id, '_EventOrganizerID', false, null, null ];
 			}
 		];
 		yield 'supported meta, db value is serialized set of post IDs' => [
@@ -65,7 +65,8 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 					$post_id,
 					'_EventOrganizerID',
 					true,
-					[ $organizer_1_id + 23, $organizer_2_id + 23 ]
+					[ $organizer_1_id + 23, $organizer_2_id + 23 ],
+					[[ $organizer_1_id + 23, $organizer_2_id + 23 ]]
 				];
 			}
 		];
@@ -87,7 +88,8 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 					$post_id,
 					'_EventOrganizerID',
 					false,
-					[ [ $organizer_1_id + 23, $organizer_2_id + 23 ] ]
+					[ [ $organizer_1_id + 23, $organizer_2_id + 23 ] ],
+					[ $organizer_1_id + 23, $organizer_2_id + 23 ]
 				];
 			}
 		];
@@ -106,7 +108,8 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 					$post_id,
 					'_EventOrganizerID',
 					true,
-					$organizer_1_id + 23
+					$organizer_1_id + 23,
+					[ $organizer_1_id + 23 ]
 				];
 			}
 		];
@@ -125,7 +128,58 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 					$post_id,
 					'_EventOrganizerID',
 					false,
-					[ $organizer_1_id + 23 ]
+					[ $organizer_1_id + 23 ],
+					$organizer_1_id + 23
+				];
+			}
+		];
+
+		yield 'supported meta, db value are multiple entries, single' => [
+			function () {
+				$_POST          = [];
+				$post_id        = $this->given_an_event()->ID;
+				$organizer_1_id = tribe_organizers()->set_args( [
+					'title' => 'Test Organizer',
+				] )->create()->ID;
+				$organizer_2_id = tribe_organizers()->set_args( [
+					'title' => 'Test Organizer 2',
+				] )->create()->ID;
+				add_post_meta( $post_id, '_EventOrganizerID', $organizer_1_id );
+				add_post_meta( $post_id, '_EventOrganizerID', $organizer_2_id );
+				add_filter( 'wpml_object_id', static fn( $id ) => $id + 23 );
+
+				return [
+					null,
+					$post_id,
+					'_EventOrganizerID',
+					true,
+					$organizer_1_id + 23,
+					[$organizer_1_id + 23,$organizer_2_id + 23]
+				];
+			}
+		];
+
+		yield 'supported meta, db value are multiple entries, multiple'=> [
+			function () {
+				$_POST          = [];
+				$post_id        = $this->given_an_event()->ID;
+				$organizer_1_id = tribe_organizers()->set_args( [
+					'title' => 'Test Organizer',
+				] )->create()->ID;
+				$organizer_2_id = tribe_organizers()->set_args( [
+					'title' => 'Test Organizer 2',
+				] )->create()->ID;
+				add_post_meta( $post_id, '_EventOrganizerID', $organizer_1_id );
+				add_post_meta( $post_id, '_EventOrganizerID', $organizer_2_id );
+				add_filter( 'wpml_object_id', static fn( $id ) => $id + 23 );
+
+				return [
+					null,
+					$post_id,
+					'_EventOrganizerID',
+					false,
+					[ $organizer_1_id + 23, $organizer_2_id + 23 ],
+					$organizer_1_id + 23
 				];
 			}
 		];
@@ -135,13 +189,19 @@ class MetaTest extends \Codeception\TestCase\WPTestCase {
 	 * @dataProvider translate_post_id_data
 	 */
 	public function test_translate_post_id( \Closure $fixture ): void {
-		[ $value, $object_id, $meta_key, $single, $expected ] = $fixture();
+		[ $value, $object_id, $meta_key, $single, $expected, $expected_2 ] = $fixture();
 
 		$meta                = tribe( Meta::class );
 		$filtered_meta_value = $meta->translate_post_id( $value, $object_id, $meta_key, $single );
 
 		$this->assertEquals( $expected, $filtered_meta_value );
+
+		// Run the fetch a second time to get the cached value.
 		$cached_value = $meta->translate_post_id( $value, $object_id, $meta_key, $single );
 		$this->assertEquals( $expected, $cached_value );
+
+		// Run the fetch a second time to get the cached value.
+		$cached_value_2 = $meta->translate_post_id( $value, $object_id, $meta_key, ! $single );
+		$this->assertEquals( $expected_2, $cached_value_2 );
 	}
 }


### PR DESCRIPTION
Fix another issue in the WPML integration where multiple Organizers could not be assigned to an Event.
Changelog already added in previous PR.

[ECP-1442](https://theeventscalendar.atlassian.net/browse/ECP-1442) 
[ECP-1455](https://theeventscalendar.atlassian.net/browse/ECP-1455)

* [screencast](https://share.cleanshot.com/gBrMVTt1)
* tests (updated)

[Related ECP PR](https://github.com/the-events-calendar/events-pro/pull/2216)

[ECP-1442]: https://theeventscalendar.atlassian.net/browse/ECP-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ECP-1455]: https://theeventscalendar.atlassian.net/browse/ECP-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ