### PR TITLE
Fix for Full_Activation_Provider.php:update_blog_tables not throttling as expected

### DIFF
--- a/src/Events/Custom_Tables/V1/Activation.php
+++ b/src/Events/Custom_Tables/V1/Activation.php
@@ -87,6 +87,17 @@ class Activation {
 			return;
 		}
 
+
+		if ( wp_using_ext_object_cache() ) {
+			wp_cache_set( static::ACTIVATION_TRANSIENT, $now, '', DAY_IN_SECONDS );
+			// Clean up.
+			delete_transient( static::ACTIVATION_TRANSIENT );
+		} else {
+			set_transient( static::ACTIVATION_TRANSIENT, $now, DAY_IN_SECONDS );
+			// Clean up.
+			wp_cache_delete( static::ACTIVATION_TRANSIENT );
+		}
+		
 		$schema_builder = $services->make( Schema_Builder::class );
 		$state          = $services->make( State::class );
 		$phase          = $state->get_phase();
@@ -113,16 +124,6 @@ class Activation {
 				 */
 				$services->register( Full_Activation_Provider::class );
 			}
-		}
-
-		if ( wp_using_ext_object_cache() ) {
-			wp_cache_set( static::ACTIVATION_TRANSIENT, $now, '', DAY_IN_SECONDS );
-			// Clean up.
-			delete_transient( static::ACTIVATION_TRANSIENT );
-		} else {
-			set_transient( static::ACTIVATION_TRANSIENT, $now, DAY_IN_SECONDS );
-			// Clean up.
-			wp_cache_delete( static::ACTIVATION_TRANSIENT );
 		}
 	}
 

--- a/src/Events/Custom_Tables/V1/Full_Activation_Provider.php
+++ b/src/Events/Custom_Tables/V1/Full_Activation_Provider.php
@@ -146,7 +146,7 @@ class Full_Activation_Provider extends Service_Provider {
 		}
 
 		// Do not run again on this site for a day.
-		set_transient( Activation::ACTIVATION_TRANSIENT, true, DAY_IN_SECONDS );
+		set_transient( Activation::ACTIVATION_TRANSIENT, time(), DAY_IN_SECONDS );
 
 		$schema_builder = $this->container->make( Schema_Builder::class );
 		$schema_builder->update_blog_tables( $blog_id );

--- a/src/Events/Custom_Tables/V1/Full_Activation_Provider.php
+++ b/src/Events/Custom_Tables/V1/Full_Activation_Provider.php
@@ -145,10 +145,10 @@ class Full_Activation_Provider extends Service_Provider {
 			return;
 		}
 
-		$schema_builder = $this->container->make( Schema_Builder::class );
-		$schema_builder->update_blog_tables( $blog_id );
-
 		// Do not run again on this site for a day.
 		set_transient( Activation::ACTIVATION_TRANSIENT, true, DAY_IN_SECONDS );
+
+		$schema_builder = $this->container->make( Schema_Builder::class );
+		$schema_builder->update_blog_tables( $blog_id );
 	}
 }


### PR DESCRIPTION
# Reference to the ticket
- :ticket: [TICKET-447565]

We believe we have found a bug with TEC and also the solution (simple code change). This bug took down our website a couple of days ago.

# Bug description
Our website experienced downtime due to **overwhelming ALTER queries from TEC** that caused our database server to crash.

When dealing with a busy table, executing table ALTERs can be a challenging task, as the ALTER query waits for the table metadata lock. As more ALTERs **queue up** behind the first one, the database runs out of connections, leading to the site’s eventual crash.

To prevent this issue from recurring, we recommend implementing the following **three** fixes:

## Fix 1
To address this issue, TEC actually introduced the function below in version 6.0.2:
`the-events-calendar/src/Events/Custom_Tables/V1/Full_Activation_Provider.php:update_blog_tables`
https://github.com/the-events-calendar/the-events-calendar/blob/cce5a10dbcc9843b491f28620e3eba7f689880b3/src/Events/Custom_Tables/V1/Full_Activation_Provider.php#L135-L153
This function aims to limit the attempts to **once every 24 hours**. 

However, there is a problem since the transient is not updated until **after** the ALTER. This means that if the ALTER is stalled, **the transient is never updated**, and more ALTERs continue to add to the queue. This overwhelms the database before the first ALTER has a chance to execute, which is the exact issue that the method was designed to prevent.

To resolve this, we need to call the `set_transient` function right **before** the line of code that reads `$schema_builder = $this->container->make( Schema_Builder::class );`. 
This approach ensures that the alter is attempted only **once per day**.

## Fix 2
Another location in which the TEC plugin tries to update tables is in `wp-content/plugins/the-events-calendar/src/Events/Custom_Tables/V1/Activation.php` through the `TEC\Events\Custom_Tables\V1\Activation::init() function`.
 
This function also attempts to limit updates to **once per 24 hours** and updates the transient only **after** schema updates are attempted, similar to the function I just mentioned.

In fact, TEC used to throttle successfully **before** schema updates, but this was changed in a commit found at https://github.com/the-events-calendar/the-events-calendar/commit/930684d3a1d0148714b69bc4172977893ea39697.
It is possible that this change was **accidental**. The commit note states that the change aimed to "_refactor(CT1/Activation) simplify code, add tests_" which suggests that the behavioural change in the throttling may have been **unintended**.

To resolve this, we need to move the throttle to engage **before** the attempt begins. 
This ensures that the throttle is in place and working properly before any updates are made to the schema.

## Fix 3
In addition to the two issues mentioned earlier, there appears to be another problem with the TEC plugin. Specifically, in this file: https://github.com/the-events-calendar/the-events-calendar/blob/cd158ba92f719b666c5c05ec22dafc7bdb855462/src/Events/Custom_Tables/V1/Full_Activation_Provider.php#L152

The code in that file is not in sync with `TEC\Events\Custom_Tables\V1\Activation::init()`. 

To resolve this, in our opinion, it should use `time()` instead of `true`:
`set_transient( Activation::ACTIVATION_TRANSIENT, time(), DAY_IN_SECONDS );`

This is similar to what happens in `TEC\Events\Custom_Tables\V1\Activation::init()`. 

Furthermore, the code in `Full_Activation_Provider.php` does not handle cases where the throttling uses an external `cache (wp_using_ext_object_cache())`.




Thanks!