### PR TITLE
WPML Integration - fix events link from Permalinks page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -249,6 +249,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Added filter: `tec_events_custom_tables_v1_events_only_modifier_before_get_posts` in our 6.0 query modifier, useful to make changes to the query prior to fetching posts for the selected events.
 * Fix - Build secondary Views navigation links correctly when WPML is active. [TEC-4689]
 * Fix - Avoid JS error when using the first compact date display format together with WPML. [TEC-4360]
+* Fix - Build the link to the Events page from the Permalinks settings page correctly. [TEC-4689]
 
 = [6.0.11] 2023-03-20 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2484,6 +2484,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				$event_url = home_url( '/' );
 			}
 
+			// Ensure the URL ends with a trailing slash.
+			$event_url = trailingslashit( $event_url );
+
 			// URL Arguments on home_url() pre-check
 			$url_query = @parse_url( $event_url, PHP_URL_QUERY );
 			if ( null === $url_query ) {

--- a/tests/wpunit/Tribe__Events__MainTest.php
+++ b/tests/wpunit/Tribe__Events__MainTest.php
@@ -50,4 +50,47 @@ class Tribe__Events__MainTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( [ 'cat_test-category' ], $post_class );
 	}
+
+	public function getLink_dataProvider(): \Generator {
+		yield 'home_url return empty string' => [
+			function () {
+				$this->set_fn_return( 'home_url', '' );
+
+				return [ 'home', '/events/' ];
+			},
+		];
+
+		yield 'home_url returns relative path' => [
+			function () {
+				$this->set_fn_return( 'home_url', '/' );
+
+				return [ 'home', '/events/' ];
+			},
+		];
+
+		yield 'home_url returns URL w/o trailing slash' => [
+			function () {
+				$this->set_fn_return( 'home_url', 'http://example.com' );
+
+				return [ 'home', 'http://example.com/events/' ];
+			},
+		];
+
+		yield 'home_url returns URL w/ trailing slash' => [
+			function () {
+				$this->set_fn_return( 'home_url', 'http://example.com/' );
+
+				return [ 'home', 'http://example.com/events/' ];
+			},
+		];
+	}
+
+	/**
+	 * @dataProvider getLink_dataProvider
+	 */
+	public function test_getLink( Closure $fixture ): void {
+		[ $type, $expected ] = $fixture();
+		$actual = TEC::instance()->getLink( $type );
+		$this->assertEquals( $expected, $actual );
+	}
 }


### PR DESCRIPTION
[TEC-4689](https://theeventscalendar.atlassian.net/browse/TEC-4689)

Fix a smaller, pre-existing, issue found during QA pass to make sure the link to the Events page from the Permalinks page is built correctly.
The issue is highlighted by the WPML integration, but is based upon making the code that builds that link more robust.

Artifacts:
[Screencast](https://share.cleanshot.com/3vNpSN5j) 


[TEC-4689]: https://theeventscalendar.atlassian.net/browse/TEC-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ