### PR TITLE
fix(Integrations/WPML) correctly build accented URLs

### DIFF
--- a/src/Tribe/I18n.php
+++ b/src/Tribe/I18n.php
@@ -57,6 +57,13 @@ class I18n {
 	public const RETURN_BY_LANGUAGE = 8;
 
 	/**
+	 * A flag to require the translations to include the slug version of the translation.
+	 *
+	 * @since TBD
+	 */
+	public const COMPILE_SLUG =  9;
+
+	/**
 	 * An instance of the The Events Calendar main class.
 	 *
 	 * @since 5.1.1
@@ -118,6 +125,7 @@ class I18n {
 	 *
 	 * @since 5.1.1
 	 * @since 5.1.5   Add support for the $flags argument.
+	 * @since TBD     Add support for the `RETURN_BY_LANGUAGE` and `COMPILE_SLUG` flags.
 	 *
 	 * @param array $strings    An array of strings (required).
 	 * @param array $languages Which l10n to fetch the string (required).
@@ -132,8 +140,6 @@ class I18n {
 	 *                         `static::RETURN_BY_LANGUAGE` will return the translations indexed by language.
 	 *
 	 * @return array<string,array|string> A multi level array with the possible translations for the given strings.
-	 *
-	 * @todo Include support for the `load_theme_textdomain` + `load_muplugin_textdomain`
 	 */
 	public function get_i18n_strings_for_domains( $strings, $languages, $domains = [ 'default' ], $flags = 7 ) {
 		sort( $languages );
@@ -157,6 +163,12 @@ class I18n {
 		}
 
 		if ( $flags & static::RETURN_BY_LANGUAGE ) {
+			foreach ( $strings_buffer as &$entries ) {
+				foreach ( $entries as &$entry ) {
+					$entry = array_values( $entry );
+				}
+			}
+
 			return $strings_buffer;
 		}
 
@@ -184,6 +196,7 @@ class I18n {
 	 * it uses 'sanitize_title()'.
 	 *
 	 * @since 6.0.2
+	 * @since TBD  Add support for `static::COMPILE_SLUG` flag.
 	 *
 	 * @param array<string> $strings   An array of strings (required).
 	 * @param array<string> $languages Which l10n to fetch the string (required).
@@ -194,6 +207,8 @@ class I18n {
 	 *                                 `static::COMPILE_STRTOLOWER` will compile the translation for the string in its
 	 *                                 lowercase version.
 	 *                                 `static::COMPILE_UCFIRST` will compile the translation for the string in its title
+	 *                                 version.
+	 *                                 `static::COMPILE_SLUG` will compile the translation for the string in its slug
 	 *                                 version.
 	 *
 	 * @return array<string,array|string> A multi level array with the possible translations for the given strings.
@@ -291,6 +306,7 @@ class I18n {
 	 *
 	 * @since 5.1.1
 	 * @since 5.1.5   Add support for the $flags argument.
+	 * @since TBD     Add support for the `static::COMPILE_SLUG` flag.
 	 *
 	 * @param array<string,array|string> $strings The set of strings to compile the translations for.
 	 * @param string|array<string>       $domains The domain(s) that should be used to compile the string translations.
@@ -303,6 +319,8 @@ class I18n {
 	 *                                            string in its lowercase version.
 	 *                                            `static::COMPILE_UCFIRST` will compile the translation for the string
 	 *                                            in its title version.
+	 *                                            `static::COMPILE_SLUG` will compile the translation for the string in
+	 *                                            its slug version.
 	 *
 	 * @return array<string|array> A map of the compiled string translations.
 	 */
@@ -339,6 +357,9 @@ class I18n {
 
 				// Grab the possible strings for default and any other domain.
 				if ( 'default' === $domain ) {
+					if ( $flags & static::COMPILE_SLUG ) {
+						$strings[ $key ][] = sanitize_key( __( $value ) );
+					}
 					if ( $flags & static::COMPILE_INPUT ) {
 						$strings[ $key ][] = __( $value );
 					}
@@ -349,6 +370,9 @@ class I18n {
 						$strings[ $key ][] = __( ucfirst( $value ) );
 					}
 				} else {
+					if ( $flags & static::COMPILE_SLUG ) {
+						$strings[ $key ][] = sanitize_key( __( $value, $domain ) );
+					}
 					if ( $flags & static::COMPILE_INPUT ) {
 						$strings[ $key ][] = __( $value, $domain );
 					}

--- a/src/Tribe/Integrations/WPML/Rewrites.php
+++ b/src/Tribe/Integrations/WPML/Rewrites.php
@@ -321,9 +321,9 @@ class Tribe__Events__Integrations__WPML__Rewrites {
 	/**
 	 * Filters the bases used to generate TEC rewrite rules to use WPML managed translations.
 	 *
-	 * @param array<string,string>  $bases  An array of bases to translate.
-	 * @param string $method The method used to generate the rewrite rules, unused by this method.
-	 * @param array<string>  $domains
+	 * @param array<string,string> $bases  An array of bases to translate.
+	 * @param string               $method The method used to generate the rewrite rules, unused by this method.
+	 * @param array<string>        $domains
 	 *
 	 * @return array An array of bases each with its (optional) WPML managed translations set.
 	 */
@@ -365,7 +365,7 @@ class Tribe__Events__Integrations__WPML__Rewrites {
 		$untranslated_bases = array_combine( array_keys( $bases ), array_column( $bases, 0 ) );
 
 		$i18n        = tribe( 'tec.i18n' );
-		$flags       = I18n::COMPILE_STRTOLOWER | I18n::RETURN_BY_LANGUAGE;
+		$flags       = I18n::COMPILE_STRTOLOWER | I18n::RETURN_BY_LANGUAGE | I18n::COMPILE_SLUG;
 		$by_language = $i18n->get_i18n_strings( $untranslated_bases, $languages, $domains, $current_locale, $flags );
 		// Store this value to use it in the `filter_localized_matchers` method.
 		$this->bases_by_language = $by_language;
@@ -416,5 +416,31 @@ class Tribe__Events__Integrations__WPML__Rewrites {
 		}
 
 		return $localized_slug;
+	}
+
+	/**
+	 * Decodes the bases that have been encoded by default from TEC.
+	 *
+	 * Bases are encoded by default to avoid issues with special characters
+	 * and back-compatibility.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string<array<string>> $bases The bases to decode.
+	 *
+	 * @return array<string<array<string>> The decoded bases.
+	 */
+	public function urldecode_base_slugs( $bases ) {
+		if ( ! is_array( $bases ) ) {
+			return $bases;
+		}
+
+		foreach ( $bases as &$base ) {
+			foreach ( $base as &$slug ) {
+				$slug = urldecode( $slug );
+			}
+		}
+
+		return $bases;
 	}
 }

--- a/src/Tribe/Integrations/WPML/WPML.php
+++ b/src/Tribe/Integrations/WPML/WPML.php
@@ -1,6 +1,7 @@
 <?php
 
 use Tribe\Events\Integrations\WPML\Views\V2\Filters as Views_V2_Filters;
+use Tribe\Events\Views\V2\Hooks;
 
 /**
  * Class Tribe__Events__Integrations__WPML__WPML
@@ -77,6 +78,8 @@ class Tribe__Events__Integrations__WPML__WPML {
 			3
 		);
 		add_filter( 'tec_common_rewrite_localize_matcher', [ $rewrites, 'localize_matcher' ], 10, 2 );
+		// Ensure the base slugs are urldecoded before they are used to build the rewrite rules, go after all the plugins.
+		add_filter( 'tribe_events_rewrite_base_slugs', [ $rewrites, 'urldecode_base_slugs' ], 100 );
 
 		$permalinks = Tribe__Events__Integrations__WPML__Permalinks::instance();
 		add_filter( 'post_type_link', [ $permalinks, 'filter_post_type_link' ], 20, 2 );
@@ -112,6 +115,11 @@ class Tribe__Events__Integrations__WPML__WPML {
 		add_filter( 'tribe_events_views_v2_request_uri', [ Views_V2_Filters::class, 'translate_view_request_uri' ] );
 
 		if ( tribe()->getVar( 'ct1_fully_activated' ) ) {
+			// Rewrite bases should not be encoded when using WPML.
+			remove_filter( 'tribe_events_rewrite_i18n_slugs_raw', [
+				tribe( Hooks::class ),
+				'filter_rewrite_i18n_slugs_raw'
+			], 50 );
 			// Handle the translation of the Events permalinks in Views v2 and Custom Tables V1 context.
 			add_filter( 'tribe_events_views_v2_view_template_vars', [ Views_V2_Filters::class, 'translate_events_permalinks' ] );
 			// Filter the tracked meta keys to trigger the update of the custom tables when duplicating events.

--- a/tests/wpunit/Tribe/Events/I18nTest.php
+++ b/tests/wpunit/Tribe/Events/I18nTest.php
@@ -118,27 +118,113 @@ class I18nTest extends \Codeception\TestCase\WPTestCase {
 		$expected = [
 			0       =>
 				[
-					[ 0 => 'list', ],
-					[ 0 => 'page', ],
-					[ 0 => 'month', ],
+					[ 'list', ],
+					[ 'page', ],
+					[ 'month', ],
 				],
 			'en_US' =>
 				[
-					[ 0 => 'list', ],
-					[ 0 => 'page', ],
-					[ 0 => 'month', ],
+					[ 'list', ],
+					[ 'page', ],
+					[ 'month', ],
 				],
 			'fr_FR' =>
 				[
-					[ 0 => 'list', 2 => 'liste', ],
-					[ 0 => 'page', ],
-					[ 0 => 'month', 2 => 'mois', ],
+					[ 'list', 'liste', ],
+					[ 'page', ],
+					[ 'month', 'mois', ],
 				],
 			'it_IT' =>
 				[
-					[ 0 => 'list', 2 => 'lista', ],
-					[ 0 => 'page', 1 => 'pagina', ],
-					[ 0 => 'month', 2 => 'mese', ],
+					[ 'list', 'lista', ],
+					[ 'page', 'pagina', ],
+					[ 'month', 'mese', ],
+				],
+		];
+		$this->assertEquals( $expected, $strings_by_language );
+	}
+
+	/**
+	 * It should allow compiling strings including slug
+	 *
+	 * @test
+	 */
+	public function should_allow_compiling_strings_including_slug(): void {
+		// Translation files will not be loaded, fake them.
+		$translations_map = [
+			'en_US' => [
+				'default'             => [
+					'page' => 'page',
+				],
+				'the-events-calendar' => [
+					'list'  => 'list',
+					'page'  => 'page',
+					'today' => 'today'
+				],
+			],
+			'it_IT' => [
+				'default'             => [
+					'page' => 'pagina',
+				],
+				'the-events-calendar' => [
+					'list'  => 'lista',
+					'page'  => 'pagina',
+					'today' => 'giorno'
+				],
+			],
+			'fr_FR' => [
+				'default'             => [
+					'page' => 'page',
+				],
+				'the-events-calendar' => [
+					'list'  => 'liste',
+					'page'  => 'page',
+					'today' => "auhjourd'hui"
+				],
+			],
+		];
+		add_filter( 'gettext', function ( string $translation, string $text, string $domain ) use ( $translations_map ) {
+			$locale = get_locale();
+
+			return $translations_map[ $locale ][ $domain ][ $text ] ?? $translation;
+		}, 10, 3 );
+		$tec  = TEC::instance();
+		$i18n = new I18n( $tec );
+
+		$strings_by_language = $i18n->get_i18n_strings_for_domains( [
+			'list',
+			'page',
+			'today',
+		],
+			[ 'en_US', 'it_IT', 'fr_FR' ],
+			[ 'default' => __DIR__, 'the-events-calendar' => __DIR__ ], // Not loading translation files.
+			I18n::RETURN_BY_LANGUAGE | I18n::COMPILE_INPUT | I18n::COMPILE_SLUG
+		);
+
+		$expected = [
+			0       =>
+				[
+					[ 'list', ],
+					[ 'page', ],
+					[ 'today', ],
+				],
+			'en_US' =>
+				[
+					[ 'list', ],
+					[ 'page', ],
+					[ 'today', ],
+				],
+			'fr_FR' =>
+				[
+					[ 'list', 'liste', ],
+					[ 'page', ],
+					[ 'today', 'auhjourdhui', "auhjourd'hui" ], // Order matters to match the apostrophe version.
+				],
+			'it_IT' =>
+				[
+					[ 'list', 'lista', ],
+					[ 'page', 'pagina', ],
+					[ 'today', 'giorno', ],
 				],
 		];
 		$this->assertEquals( $expected, $strings_by_language );


### PR DESCRIPTION
[TEC-4689](https://theeventscalendar.atlassian.net/browse/TEC-4689) 

Artifacts:
* tests (where possible)
* [screencast](https://share.cleanshot.com/vyMDDCHq) 

When using languages, like the French one, using accented words or
apostrophes, the URL building would break in WPML context.

This fixes that by adding an additional slug flag to the `I18n`
component to closely match the rewrite rules generated when using
permalinks.
