### PR TITLE
Add Google Maps callback function.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Pass a NOOP callback function to Google Maps scripts to prevent JS warnings. [TEC-4762]
+
 = [6.0.12] 2023-04-10 =
 
 * Fix - Avoid JS error when using the first compact date display format together with WPML. [TEC-4360]

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -175,12 +175,12 @@ class Tribe__Events__Assets {
 		if ( ! tribe_is_using_basic_gmaps_api() ) {
 
 			// FrontEnd
-			$api_url  = 'https://maps.google.com/maps/api/js';
-			$api_key  = tribe_get_option( 'google_maps_js_api_key', Tribe__Events__Google__Maps_API_Key::$default_api_key );
-			$callback = 'Function.prototype';
+			$api_url      = 'https://maps.google.com/maps/api/js';
+			$api_key      = tribe_get_option( 'google_maps_js_api_key', Tribe__Events__Google__Maps_API_Key::$default_api_key );
+			$api_callback = 'Function.prototype';
 
 			if ( ! empty( $api_key ) && is_string( $api_key ) ) {
-				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s&callback=%s', trim( $api_key ), urlencode( $callback ) );
+				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s&callback=%s', trim( $api_key ), urlencode( $api_callback ) );
 			}
 
 			/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -175,11 +175,12 @@ class Tribe__Events__Assets {
 		if ( ! tribe_is_using_basic_gmaps_api() ) {
 
 			// FrontEnd
-			$api_url = 'https://maps.google.com/maps/api/js';
-			$api_key = tribe_get_option( 'google_maps_js_api_key', Tribe__Events__Google__Maps_API_Key::$default_api_key );
+			$api_url  = 'https://maps.google.com/maps/api/js';
+			$api_key  = tribe_get_option( 'google_maps_js_api_key', Tribe__Events__Google__Maps_API_Key::$default_api_key );
+			$callback = 'Function.prototype';
 
 			if ( ! empty( $api_key ) && is_string( $api_key ) ) {
-				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s&callback=Function.prototype', trim( $api_key ) );
+				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s&callback=%s', trim( $api_key ), urlencode( $callback ) );
 			}
 
 			/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -179,7 +179,7 @@ class Tribe__Events__Assets {
 			$api_key = tribe_get_option( 'google_maps_js_api_key', Tribe__Events__Google__Maps_API_Key::$default_api_key );
 
 			if ( ! empty( $api_key ) && is_string( $api_key ) ) {
-				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s', trim( $api_key ) );
+				$api_url = sprintf( 'https://maps.googleapis.com/maps/api/js?key=%s&callback=Function.prototype', trim( $api_key ) );
 			}
 
 			/**

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -410,11 +410,15 @@ class Tribe__Events__Editor extends Tribe__Editor {
 		 *
 		 * @param string $api_url The Google Maps API URL.
 		 */
-		$gmaps_api_key = tribe_get_option( 'google_maps_js_api_key' );
-		$gmaps_api_url = 'https://maps.googleapis.com/maps/api/js';
+		$gmaps_api_key      = tribe_get_option( 'google_maps_js_api_key' );
+		$gmaps_api_url      = 'https://maps.googleapis.com/maps/api/js';
+		$gmaps_api_callback = 'Function.prototype';
 
 		if ( ! empty( $gmaps_api_key ) && is_string( $gmaps_api_key ) ) {
-			$gmaps_api_url = add_query_arg( [ 'key' => $gmaps_api_key ], $gmaps_api_url );
+			$gmaps_api_url = add_query_arg( [
+				'key'      => $gmaps_api_key,
+				'callback' => $gmaps_api_callback,
+			], $gmaps_api_url );
 		}
 
 		/**

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -407,8 +407,10 @@ class Tribe__Events__Editor extends Tribe__Editor {
 		 * Allows for filtering the embedded Google Maps API URL.
 		 *
 		 * @since 4.7
+		 * @since TBD Added the `$gmaps_api_callback` parameter.
 		 *
 		 * @param string $api_url The Google Maps API URL.
+		 * @param string $gmaps_api_callback The Google Maps API callback.
 		 */
 		$gmaps_api_key      = tribe_get_option( 'google_maps_js_api_key' );
 		$gmaps_api_url      = 'https://maps.googleapis.com/maps/api/js';


### PR DESCRIPTION
Ticket : [TEC-4762](https://theeventscalendar.atlassian.net/browse/TEC-4762)

Pass a NOOP callback function to Google Maps scripts to prevent JS warnings. These updates get rid of the warning in the following pages.

- Single events page ( Classic Editor )
- Create/edit events page ( Block Editor )

See related [pr](https://github.com/the-events-calendar/events-pro/pull/2242) in ECP.

**Screenshot 📸**

![image](https://user-images.githubusercontent.com/22029087/230888637-a41bce2d-949b-4a9d-9ee9-fb71231ec160.png)

[TEC-4762]: https://theeventscalendar.atlassian.net/browse/TEC-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ