### PR TITLE
fix(Integrations/WPML) fix part of the URL translation for logged in admin users

### DIFF
--- a/src/Tribe/Integrations/WPML/Views/V2/Filters.php
+++ b/src/Tribe/Integrations/WPML/Views/V2/Filters.php
@@ -30,7 +30,9 @@ class Filters {
 	 * @return string The translated View URL.
 	 */
 	public static function translate_view_url( $url ) {
-		$lang = static::get_request_lang();
+		global $sitepress;
+		$lang = $sitepress->get_language_from_url( $url );
+
 		if ( false === $lang ) {
 			return $url;
 		}


### PR DESCRIPTION
A WiP PR to try and address [BTRIA-1758](https://theeventscalendar.atlassian.net/browse/BTRIA-1758) to avoid admin users from seein the Views in the wrong language.
