### PR TITLE
Fix/tec 4677 button style bleed

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - For CT1 in markers the occurrence would sometimes not be the same one found as the date field, only one was filtering by post_status. We were only using `provisional_id` for CT1, now we fallback to `post_id`. Now removing options when no occurrences are found, instead of retaining a stale value. [TEC-4768]
+* Fix - Some button style hardening to prevent some common theme global style bleed, namely from Elementor global styles. [TEC-4677]
 
 = [6.0.12] 2023-04-10 =
 

--- a/src/resources/postcss/components/full/_ical-link.pcss
+++ b/src/resources/postcss/components/full/_ical-link.pcss
@@ -57,8 +57,17 @@
 			}
 		}
 
-		.tribe-events-c-subscribe-dropdown__button-text {
+		.tribe-events-c-subscribe-dropdown__button-text,
+		button.tribe-events-c-subscribe-dropdown__button-text {
+			background-image: none;
+			border-radius: 0;
+			border: none;
+			box-shadow: none;
+			color: currentColor;
 			cursor: pointer;
+			font-size: inherit;
+			padding: 0;
+			text-shadow: none;
 		}
 
 		.tribe-events-c-subscribe-dropdown__button-icon {

--- a/src/resources/postcss/components/full/_ical-link.pcss
+++ b/src/resources/postcss/components/full/_ical-link.pcss
@@ -60,8 +60,8 @@
 		.tribe-events-c-subscribe-dropdown__button-text,
 		button.tribe-events-c-subscribe-dropdown__button-text {
 			background-image: none;
-			border-radius: 0;
 			border: none;
+			border-radius: 0;
 			box-shadow: none;
 			color: currentColor;
 			cursor: pointer;

--- a/src/resources/postcss/components/full/_navigation.pcss
+++ b/src/resources/postcss/components/full/_navigation.pcss
@@ -65,8 +65,8 @@
 		&:disabled {
 			background-color: transparent;
 			background-image: none;
-			border-radius: 0;
 			border: none;
+			border-radius: 0;
 			box-shadow: none;
 			color: var(--tec-color-text-disabled);
 			cursor: default;

--- a/src/resources/postcss/components/full/_navigation.pcss
+++ b/src/resources/postcss/components/full/_navigation.pcss
@@ -65,9 +65,18 @@
 		&:disabled {
 			background-color: transparent;
 			background-image: none;
+			border-radius: 0;
+			border: none;
+			box-shadow: none;
 			color: var(--tec-color-text-disabled);
 			cursor: default;
+			font-size: 1rem;
+			font-style: normal;
+			outline: none;
+			padding: 0;
 			pointer-events: none;
+			text-decoration: none;
+			text-shadow: none;
 		}
 	}
 

--- a/src/resources/postcss/components/full/_search.pcss
+++ b/src/resources/postcss/components/full/_search.pcss
@@ -94,7 +94,8 @@
 		}
 	}
 
-	.tribe-events-c-search__button, button.tribe-events-c-search__button {
+	.tribe-events-c-search__button,
+	button.tribe-events-c-search__button {
 		background-color: var(--tec-color-background-events-bar-submit-button);
 		background-image: none;
 		box-shadow: none;
@@ -107,8 +108,8 @@
 		&:focus,
 		&:hover {
 			background-color: var(--tec-color-background-events-bar-submit-button-hover);
-			border-radius: var(--tec-border-radius-default);
 			border: none;
+			border-radius: var(--tec-border-radius-default);
 			box-shadow: none;
 			color: var(--tec-color-text-events-bar-submit-button-hover);
 			font-size: var(--tec-font-size-2);

--- a/src/resources/postcss/components/full/_search.pcss
+++ b/src/resources/postcss/components/full/_search.pcss
@@ -94,14 +94,28 @@
 		}
 	}
 
-	.tribe-events-c-search__button {
+	.tribe-events-c-search__button, button.tribe-events-c-search__button {
 		background-color: var(--tec-color-background-events-bar-submit-button);
+		background-image: none;
+		box-shadow: none;
 		color: var(--tec-color-text-events-bar-submit-button);
+		font-style: normal;
+		outline: none;
+		text-decoration: none;
+		text-shadow: none;
 
 		&:focus,
 		&:hover {
 			background-color: var(--tec-color-background-events-bar-submit-button-hover);
+			border-radius: var(--tec-border-radius-default);
+			border: none;
+			box-shadow: none;
 			color: var(--tec-color-text-events-bar-submit-button-hover);
+			font-size: var(--tec-font-size-2);
+			font-style: normal;
+			outline: none;
+			text-decoration: none;
+			text-shadow: none;
 		}
 
 		&:active {

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -4,30 +4,52 @@
  *
  * ----------------------------------------------------------------------------- */
 
+.tribe-common.tribe-common--breakpoint-medium button.tribe-events-c-top-bar__datepicker-button {
+	font-size: var(--tec-font-size-8);
+}
+
 .tribe-events {
 
 	button.tribe-events-c-top-bar__nav-link--prev:disabled,
 	button.tribe-events-c-top-bar__nav-link--next:disabled {
 		background-color: transparent;
 		background-image: none;
+		border-radius: 0;
 		border: none;
+		box-shadow: none;
 		color: var(--tec-color-text-disabled);
+		font-size: 1rem;
+		font-style: normal;
 		outline: none;
+		padding: 0;
+		text-decoration: none;
+		text-shadow: none;
 	}
 
 	button.tribe-events-c-top-bar__datepicker-button {
 		background-color: transparent;
 		background-image: none;
+		border-radius: 0;
 		border: none;
+		box-shadow: none;
 		color: var(--tec-color-text-primary);
+		font-size: var(--tec-font-size-6);
+		font-style: normal;
 		outline: none;
+		padding: 0;
+		text-decoration: none;
+		text-shadow: none;
 		transition: var(--tec-transition-opacity);
 
 		&:hover,
 		&:focus {
+			border-radius: 0;
 			border: none;
+			box-shadow: none;
+			color: var(--tec-color-text-primary);
 			opacity: var(--tec-opacity-icon-hover);
 			outline: none;
+			text-shadow: none;
 		}
 
 		&:active {

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -14,8 +14,8 @@
 	button.tribe-events-c-top-bar__nav-link--next:disabled {
 		background-color: transparent;
 		background-image: none;
-		border-radius: 0;
 		border: none;
+		border-radius: 0;
 		box-shadow: none;
 		color: var(--tec-color-text-disabled);
 		font-size: 1rem;
@@ -29,8 +29,8 @@
 	button.tribe-events-c-top-bar__datepicker-button {
 		background-color: transparent;
 		background-image: none;
-		border-radius: 0;
 		border: none;
+		border-radius: 0;
 		box-shadow: none;
 		color: var(--tec-color-text-primary);
 		font-size: var(--tec-font-size-6);
@@ -43,8 +43,8 @@
 
 		&:hover,
 		&:focus {
-			border-radius: 0;
 			border: none;
+			border-radius: 0;
 			box-shadow: none;
 			color: var(--tec-color-text-primary);
 			opacity: var(--tec-opacity-icon-hover);


### PR DESCRIPTION
[TEC-4677](https://theeventscalendar.atlassian.net/browse/TEC-4677)

This hardens some of our button styles that would inherit global `button` styles, especially in themes like Elementor, but these style updates should benefit all themes.

Artifacts:

![image](https://user-images.githubusercontent.com/2826045/232912687-dfd42ded-82d3-4048-815d-f1991db313bf.png)


[TEC-4677]: https://theeventscalendar.atlassian.net/browse/TEC-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ