### PR TITLE
Fix and test for the WPML permalink filter.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - For CT1 in markers the occurrence would sometimes not be the same one found as the date field, only one was filtering by post_status. We were only using `provisional_id` for CT1, now we fallback to `post_id`. Now removing options when no occurrences are found, instead of retaining a stale value. [TEC-4768]
+* Fix - Fix a `Fatal error: Uncaught TypeError: Illegal offset type in isset or empty in …/wp-content/plugins/sitepress-multilingual-cms/classes/url-handling/converter/class-wpml-url-cached-converter.php:46` fatal with our WPML integration when filtering Event permalinks for Event views. [TEC-4770]
 
 = [6.0.12] 2023-04-10 =
 

--- a/src/Tribe/Integrations/WPML/Views/V2/Filters.php
+++ b/src/Tribe/Integrations/WPML/Views/V2/Filters.php
@@ -185,7 +185,7 @@ class Filters {
 				continue;
 			}
 
-			$event->permalink = apply_filters( 'wpml_permalink', $event->permalink );
+			$event->permalink = (string) apply_filters( 'wpml_permalink', (string) $event->permalink );
 		}
 
 		return $template_vars;


### PR DESCRIPTION
[TEC-4770](https://theeventscalendar.atlassian.net/browse/TEC-4770)

A fatal was happening because we use a Lazy_String object for the permalink property. Adding stringifying for the wpml filter.

Artifacts:
Fatal and tests.
```
Warning: Illegal offset type in isset or empty in /var/www/html/wp-content/plugins/sitepress-multilingual-cms/classes/url-handling/converter/class-wpml-url-cached-converter.php on line 46 Call Stack: 0.2026 381104 
1. {main}() /var/www/html/index.php:0 0.2026 381384 
2. require('/var/www/html/wp-blog-header.php') /var/www/html/index.php:17 0.3813 12812312 
3. require_once('/var/www/html/wp-includes/template-loader.php') /var/www/html/wp-blog-header.php:19 0.3946 13798528
4. include('/var/www/html/wp-content/plugins/the-events-calendar/src/views/v2/default-template.php') /var/www/html/wp-includes/template-loader.php:106 0.5935 17635304

[TEC-4770]: https://theeventscalendar.atlassian.net/browse/TEC-4770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ