### PR TITLE
Elementor Posts widget [TEC-4685]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Fix - Ensure Events are displayed correctly on Elementor's `Posts` widget. [TEC-4685]
 * Fix - Pass a NOOP callback function to Google Maps scripts to prevent JS warnings. [TEC-4762]
 * Fix - Fixed an edge case to not inadvertently trash entire Events Pro recurrences. [ECP-1475]
 * Tweak - Updates to `tribe_events_delete_old_events_sql_args` and `tribe_events_delete_old_events_sql` filters to support Events Pro recurrence cleanup. [ECP-1475]

--- a/src/Events/Integrations/Plugins/Elementor/Provider.php
+++ b/src/Events/Integrations/Plugins/Elementor/Provider.php
@@ -5,7 +5,6 @@ namespace TEC\Events\Integrations\Plugins\Elementor;
 use TEC\Events\Integrations\Integration_Abstract;
 use TEC\Events\Integrations\Plugins\Plugin_Integration;
 use Tribe__Events__Main;
-use Elementor\Widget_Base;
 
 /**
  * Class Provider
@@ -47,7 +46,7 @@ class Provider extends Integration_Abstract {
 	 *
 	 * @return array The modified Elementor posts widget query arguments.
 	 */
-	public function suppress_query_filters( $query_args ): array {	
+	public function suppress_query_filters( $query_args ): array {
 		// Bail if the selcted post type is not the Events post type.
 		if ( (array) $query_args['post_type'] !== [ Tribe__Events__Main::POSTTYPE ] ) {
 			return $query_args;

--- a/src/Events/Integrations/Plugins/Elementor/Provider.php
+++ b/src/Events/Integrations/Plugins/Elementor/Provider.php
@@ -5,6 +5,7 @@ namespace TEC\Events\Integrations\Plugins\Elementor;
 use TEC\Events\Integrations\Integration_Abstract;
 use TEC\Events\Integrations\Plugins\Plugin_Integration;
 use Tribe__Events__Main;
+use Elementor\Widget_Base;
 
 /**
  * Class Provider
@@ -36,7 +37,7 @@ class Provider extends Integration_Abstract {
 	 * @inheritDoc
 	 */
 	protected function load(): void {
-		add_filter( 'elementor/query/query_args', [ $this, 'tec_suppress_query_filters' ], 10, 1 );
+		add_filter( 'elementor/query/query_args', [ $this, 'suppress_query_filters' ], 10, 1 );
 	}
 
 	/**
@@ -46,8 +47,8 @@ class Provider extends Integration_Abstract {
 	 *
 	 * @return array The modified Elementor posts widget query arguments.
 	 */
-	public function tec_suppress_query_filters( $query_args ): array {
-		// Check if the query is for the events post type.
+	public function suppress_query_filters( $query_args ): array {	
+		// Bail if the selcted post type is not the Events post type.
 		if ( (array) $query_args['post_type'] !== [ Tribe__Events__Main::POSTTYPE ] ) {
 			return $query_args;
 		}

--- a/src/Events/Integrations/Plugins/Elementor/Provider.php
+++ b/src/Events/Integrations/Plugins/Elementor/Provider.php
@@ -46,7 +46,7 @@ class Provider extends Integration_Abstract {
 	 *
 	 * @return array The modified Elementor posts widget query arguments.
 	 */
-	public function tec_suppress_query_filters( $query_args ) {
+	public function tec_suppress_query_filters( $query_args ): array {
 		// Check if the query is for the events post type.
 		if ( (array) $query_args['post_type'] !== [ Tribe__Events__Main::POSTTYPE ] ) {
 			return $query_args;

--- a/src/Events/Integrations/Plugins/Elementor/Provider.php
+++ b/src/Events/Integrations/Plugins/Elementor/Provider.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace TEC\Events\Integrations\Plugins\Elementor;
+
+use TEC\Events\Integrations\Integration_Abstract;
+use TEC\Events\Integrations\Plugins\Plugin_Integration;
+use Tribe__Events__Main;
+
+/**
+ * Class Provider
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Elementor
+ */
+class Provider extends Integration_Abstract {
+	use Plugin_Integration;
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_slug(): string {
+		return 'elementor';
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return bool Whether or not integrations should load.
+	 */
+	public function load_conditionals(): bool {
+		return defined( 'ELEMENTOR_PATH' ) && ! empty( ELEMENTOR_PATH );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function load(): void {
+		add_filter( 'elementor/query/query_args', [ $this, 'tec_suppress_query_filters' ], 10, 1 );
+	}
+
+	/**
+	 * Modifies the Elementor posts widget query arguments to set 'tribe_suppress_query_filters' to true for the Event post type.
+	 *
+	 * @param array $query_args The Elementor posts widget query arguments.
+	 *
+	 * @return array The modified Elementor posts widget query arguments.
+	 */
+	public function tec_suppress_query_filters( $query_args ) {
+		// Check if the query is for the events post type.
+		if ( (array) $query_args['post_type'] !== [ Tribe__Events__Main::POSTTYPE ] ) {
+			return $query_args;
+		}
+
+		// Set the 'tribe_suppress_query_filters' to true.
+		$query_args['tribe_suppress_query_filters'] = true;
+
+		return $query_args;
+	}
+}

--- a/src/Events/Integrations/Provider.php
+++ b/src/Events/Integrations/Provider.php
@@ -27,5 +27,6 @@ class Provider extends \tad_DI52_ServiceProvider {
 		$this->container->register( Plugins\WordPress_SEO\Provider::class );
 		$this->container->register( Plugins\Rank_Math\Provider::class );
 		$this->container->register( Plugins\Colbri_Page_Builder\Provider::class );
+		$this->container->register( Plugins\Elementor\Provider::class );
 	}
 }


### PR DESCRIPTION
Ticket : [TEC-4685](https://theeventscalendar.atlassian.net/browse/TEC-4685)

This update ensures Events are displayed correctly on Elementor's `Posts` widget.

I'm setting `tribe_suppress_query_filters` to true in order to prevent custom filters from modifying the query. In the context of the widget, we want the standard WordPress query behaviour to be applied.

**Screencast 🎥**

https://drive.google.com/file/d/1kN6AxJ9BMPwaRGTLrEnuusvep8zoI2ul/view?usp=share_link

[TEC-4685]: https://theeventscalendar.atlassian.net/browse/TEC-4685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ