### PR TITLE
More friendly default alignment

### DIFF
--- a/src/resources/postcss/base/full/_view.pcss
+++ b/src/resources/postcss/base/full/_view.pcss
@@ -11,6 +11,6 @@
  * Elementor Overrides
  * ------------------------ */
 .tribe-events-view.alignwide {
-	margin-left: 0;
-	margin-right: 0;
+	margin-left: auto;
+	margin-right: auto;
 }


### PR DESCRIPTION
[TEC-4677](https://theeventscalendar.atlassian.net/browse/TEC-4677)

QA fix for a more friendly base alignment (centered as intended?).

[TEC-4677]: https://theeventscalendar.atlassian.net/browse/TEC-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ