### PR TITLE
Fix for meta_value orderby in CT1 context.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - Fixes database error, caused by the CT1 query parser when attempting rewrite the order by statement. Added logic to reflect on meta query arrays, and not just key/value pairs. [ECP-1495]
+
 = [6.0.13] 2023-05-08 =
 
 * Fix - Correct issue with event subscriptions not passing events past the first 30. [TEC_4584]

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -385,6 +385,10 @@ class Custom_Tables_Query extends WP_Query {
 		if ( $orderby === 'meta_value' ) {
 			// Handle the case where the order is by a meta key and value couple.
 			$meta_query_orderby = $this->get( 'meta_key' );
+			// If we have a list of meta query args.
+			if ( ! $meta_query_orderby && isset( reset( $meta_query_clauses )['original_meta_key'] ) ) {
+				$meta_query_orderby = reset( $meta_query_clauses )['original_meta_key'];
+			}
 		} else if ( isset( $meta_query_clauses[ $orderby ]['original_meta_key'] ) ) {
 			// Handle the case where the order is by the meta query key.
 			$meta_query_orderby = $meta_query_clauses[ $orderby ]['original_meta_key'];


### PR DESCRIPTION
[ECP-1495](https://theeventscalendar.atlassian.net/browse/ECP-1495)

Fixes database error, caused by the CT1 query parser when attempting rewrite the order by statement. Added logic to reflect on meta query arrays, and not just key/value pairs.

Artifact:

```WordPress database error Unknown column 'wp_tec_occurrences.meta_value' in 'order clause' for query 
			SELECT   (wp_tec_occurrences.occurrence_id + 10000000) as occurrence_id
			FROM wp_posts  LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id) INNER JOIN wp_tec_occurrences ON wp_posts.ID = wp_tec_occurrences.post_id
			WHERE 1=1  AND ( 
  wp_term_relationships.term_taxonomy_id IN (4)
) AND ( 
  wp_tec_occurrences.end_date >= '2023-03-23 00:00:00'
) AND wp_posts.post_type = 'tribe_events' AND ((wp_posts.post_status = 'publish'))
			GROUP BY wp_tec_occurrences.occurrence_id
			ORDER BY wp_tec_occurrences.meta_value DESC
			LIMIT 0, 3

[ECP-1495]: https://theeventscalendar.atlassian.net/browse/ECP-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ