### PR TITLE
Gracefully handle invalid values for nav handler.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
-* Fix - Fix Fatal error: `Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, string given in /nas/content/live/website/wp-content/plugins/the-events-calendar/src/Tribe/Main.php:3535`. [TEC-4780]
+* Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 * Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 

--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - Fix Fatal error: `Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, string given in /nas/content/live/website/wp-content/plugins/the-events-calendar/src/Tribe/Main.php:3535`. [TEC-4780]
+
 = [6.0.13] 2023-05-08 =
 
 * Fix - Correct issue with event subscriptions not passing events past the first 30. [TEC_4584]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -3532,6 +3532,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			$current_hidden_boxes = get_user_option( 'metaboxhidden_nav-menus', $user_id );
 
+			if ( ! is_array( $current_hidden_boxes ) ) {
+				return;
+			}
+
 			if ( $array_key = array_search( 'add-' . self::POSTTYPE, $current_hidden_boxes ) ) {
 				unset( $current_hidden_boxes[ $array_key ] );
 			}


### PR DESCRIPTION
[TEC-4780](https://theeventscalendar.atlassian.net/browse/TEC-4780)

Fix fatal error caused by our assumption the `metaboxhidden_nav-menus` is always an array when on the Nav page.

Artifact:
```PHP Fatal error: Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, string given in /nas/content/live/website/wp-content/plugins/the-events-calendar/src/Tribe/Main.php:3535```

[TEC-4780]: https://theeventscalendar.atlassian.net/browse/TEC-4780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ