### PR TITLE
Check for `$wp_query` before `is_tag()`

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -81,7 +81,8 @@ class Tribe__Events__Query {
 		// Refresh the query post types: they might have been modified.
 		$query_post_types = (array) $query->get( 'post_type' );
 		// Add our post type if we are on the tag archive - we need to check our global wp_query for this.
-		$on_tag_archive_page = is_tag();
+		global $wp_query;
+		$on_tag_archive_page = isset( $wp_query ) && is_tag();
 		// Add Events to tag archives when not looking at the admin screen for posts.
 		if (
 			! $any_post_type


### PR DESCRIPTION
Another plugin is running a bland `get_posts()` and The Events Calendar is filtering `parse_query` and calling `is_tag()` resulting in:

```
PHP Notice:  Function is_tag was called <strong>incorrectly</strong>. Conditional query tags do not work before the query is run. Before then, they always return false. Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.1.0.) in /path/to/wp-includes/functions.php on line 5865
```

This PR checks is the `global $wp_query` set before calling `is_tag()`.