### PR TITLE
Fix/wp query before is tag

### DIFF
--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -81,7 +81,8 @@ class Tribe__Events__Query {
 		// Refresh the query post types: they might have been modified.
 		$query_post_types = (array) $query->get( 'post_type' );
 		// Add our post type if we are on the tag archive - we need to check our global wp_query for this.
-		$on_tag_archive_page = is_tag();
+		global $wp_query;
+		$on_tag_archive_page = isset( $wp_query ) && is_tag();
 		// Add Events to tag archives when not looking at the admin screen for posts.
 		if (
 			! $any_post_type

--- a/tests/wpunit/Tribe/Events/QueryTest.php
+++ b/tests/wpunit/Tribe/Events/QueryTest.php
@@ -619,6 +619,15 @@ class QueryTest extends Events_TestCase {
 		$tax_query2 = new WP_Query( $args );
 		$this->assertContains( Main::POSTTYPE, (array) $tax_query2->get( 'post_type' ) );
 
+		// Someone calling early, should return gracefully.
+		$wp_query = null;
+		$did_fail = false;
+		add_action( 'doing_it_wrong_run', function ( $function, $message, $version ) use ( &$did_fail ) {
+			$did_fail = true;
+		}, 10, 3 );
+		$tax_query3 = new WP_Query( $args );
+		$this->assertFalse( $did_fail, 'Should not have hit doing it wrong action.' );
+
 		// Cleanup
 		$wp_query = $old_query;
 	}


### PR DESCRIPTION
From https://github.com/the-events-calendar/the-events-calendar/pull/4232

This fixes an edge case where the query is run before `$wp_query` global is set.

Test updated to validate given scenario.