### PR TITLE
fix(CT1) avoid JOINing on Occurrences twice

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -159,6 +159,7 @@ jobs:
       - name: Install the plugins on this particular Test Suite
         if: steps.skip.outputs.value != 1 && steps.test_suite_plugins_required.outputs.content
         run: |
+          ${SLIC_BIN} wp core update --version=6.1
           ${SLIC_BIN} wp plugin install ${{ steps.test_suite_plugins_required.outputs.content }}
 
       # ------------------------------------------------------------------------------

--- a/readme.txt
+++ b/readme.txt
@@ -235,7 +235,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 * Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
-* Fix - Avoid SQL error when filtering by Series in Custom Tables v1 context. [TBD]
+* Fix - Avoid SQL error when filtering by Series in Custom Tables v1 context. [ET-1486]
 
 = [6.0.13] 2023-05-08 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 * Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
+* Fix - Avoid SQL error when filtering by Series in Custom Tables v1 context. [TBD]
 
 = [6.0.13] 2023-05-08 =
 

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -518,11 +518,11 @@ class Custom_Tables_Query extends WP_Query {
 		}
 
 		global $wpdb;
-		$str = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
+		$join_clause = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
 
-		if ( strpos( $join, $str ) === false ) {
+		if ( strpos( $join, $join_clause ) === false ) {
 			// Let's add the JOIN clause only if we did not already.
-			$join .= ' ' . $str;
+			$join .= ' ' . $join_clause;
 		}
 
 		return $join;

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -220,8 +220,12 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			 * table as that is the only way to represent Occurrences.
 			 */
 			global $wpdb;
-			$occurrences                = Occurrences::table_name( true );
-			$this->query_vars['join'][] = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
+			$occurrences = Occurrences::table_name( true );
+			$join_clause = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
+
+			if ( ! in_array( $join_clause, $this->query_vars['join'], true ) ) {
+				$this->query_vars['join'][] = $join_clause;
+			}
 		} else if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );
 		}

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_FiltersTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_FiltersTest.php
@@ -2,7 +2,9 @@
 
 namespace TEC\Events\Custom_Tables\V1\WP_Query\Repository;
 
+use TEC\Events\Custom_Tables\V1\Tables\Occurrences;
 use Tribe__Repository__Decorator as Repository_Decorator;
+use Tribe__Events__Main as TEC;
 
 class Test_Repository_ecc8dffa78cbdc94a161c83a1faa3134 extends Repository_Decorator {
 	public function __construct() {
@@ -80,34 +82,77 @@ class Custom_Tables_Query_FiltersTest extends \Codeception\TestCase\WPTestCase {
 
 		// No date filter, has connections.
 		$repository = new  Test_Repository_ecc8dffa78cbdc94a161c83a1faa3134();
-		$matches = $repository->where( 'has_connections', true )->fields( 'ids' )->all();
+		$matches    = $repository->where( 'has_connections', true )->fields( 'ids' )->all();
 
 		$this->assertEmpty( $wpdb->last_error );
 		$this->assertEqualSets( [ $event_with_connection_1->ID, $event_with_connection_2->ID ], $matches );
 
 		// With date filter, has connections.
 		$repository = new  Test_Repository_ecc8dffa78cbdc94a161c83a1faa3134();
-		$matches = $repository->where( 'has_connections', true )
-			->where( 'starts_after', '2022-01-02 00:00:00' )
-			->fields( 'ids' )->all();
+		$matches    = $repository->where( 'has_connections', true )
+		                         ->where( 'starts_after', '2022-01-02 00:00:00' )
+		                         ->fields( 'ids' )->all();
 
 		$this->assertEmpty( $wpdb->last_error );
 		$this->assertEquals( [ $event_with_connection_2->ID ], $matches );
 
 		// No date filter, has no connections.
 		$repository = new  Test_Repository_ecc8dffa78cbdc94a161c83a1faa3134();
-		$matches = $repository->where( 'has_connections', false )->fields( 'ids' )->all();
+		$matches    = $repository->where( 'has_connections', false )->fields( 'ids' )->all();
 
 		$this->assertEmpty( $wpdb->last_error );
 		$this->assertEqualSets( [ $event_wo_connection_1->ID, $event_wo_connection_2->ID ], $matches );
 
 		// With date filter, has no connections.
 		$repository = new  Test_Repository_ecc8dffa78cbdc94a161c83a1faa3134();
-		$matches = $repository->where( 'has_connections', false )
-			->where( 'starts_after', '2022-01-04 00:00:00' )
-			->fields( 'ids' )->all();
+		$matches    = $repository->where( 'has_connections', false )
+		                         ->where( 'starts_after', '2022-01-04 00:00:00' )
+		                         ->fields( 'ids' )->all();
 
 		$this->assertEmpty( $wpdb->last_error );
 		$this->assertEquals( [ $event_wo_connection_2->ID ], $matches );
+	}
+
+	/**
+	 * It should not add same JOIN clause twice when there are no redirections to custom tables
+	 *
+	 * The issue would manifest in the context of some queries triggered from ECP, but should be addressed
+	 * in TEC: this is the reason why this test is here. The query filters hold internal state that will
+	 * store the JOIN clauses to be added, and this state should not contain the same JOIN clause twice.
+	 *
+	 * @test
+	 */
+	public function should_not_add_same_join_clause_twice_when_there_are_no_redirections_to_custom_tables(): void {
+		$wp_query = new \WP_Query( [
+			'post_type' => TEC::POSTTYPE,
+		] );
+
+		$query_filters = new Custom_Tables_Query_Filters( new Query_Replace() );
+		$query_filters->set_query( $wp_query );
+
+		$filtered_join = trim( $query_filters->filter_posts_join( '', $wp_query ) );
+		$occurrences   = Occurrences::table_name();
+
+		$this->assertEquals(
+			"JOIN $occurrences ON test_posts.ID = $occurrences.post_id",
+			$filtered_join,
+			'On first filtering, the JOIN clause on Occurrences should be added.'
+		);
+
+		$filtered_join_2 = trim( $query_filters->filter_posts_join( '', $wp_query ) );
+
+		$this->assertEquals(
+			"JOIN $occurrences ON test_posts.ID = $occurrences.post_id",
+			$filtered_join_2,
+			'On second filtering, the JOIN clause on Occurrences should not be added a 2nd time.'
+		);
+
+		$filtered_join_3 = trim( $query_filters->filter_posts_join( '', $wp_query ) );
+
+		$this->assertEquals(
+			"JOIN $occurrences ON test_posts.ID = $occurrences.post_id",
+			$filtered_join_3,
+			'On third filtering, the JOIN clause on Occurrences should not be added a 2nd time.'
+		);
 	}
 }


### PR DESCRIPTION
Ticket: n/a

Emerged in the context of the work for Flexible Tickets.

Artifacts: tests

This PR fixes an issue where, in ECP + CT1 context, using the Repository (`tribe_events`) to filter Events by series could raise a SQL error due to the `JOIN` clause on the Occurrences table being added twice to the filtered query `JOIN` clauses.
