### PR TITLE
Updates to watch state and props for geocode call.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
+
 = [6.0.13] 2023-05-08 =
 
 * Fix - Correct issue with event subscriptions not passing events past the first 30. [TEC_4584]

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -71,6 +71,11 @@ class EventVenue extends Component {
 		onCreateNew: PropTypes.func,
 		removeVenue: PropTypes.func,
 		editVenue: PropTypes.func,
+		volatile: PropTypes.any,
+		name: PropTypes.any,
+		store: PropTypes.any,
+		fields: PropTypes.any,
+		setSubmit: PropTypes.any,
 	};
 
 	constructor( props ) {
@@ -90,9 +95,9 @@ class EventVenue extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps, prevState ) {
+	componentDidUpdate( prevProps ) {
 		const { isSelected, edit, create, setSubmit, details } = this.props;
-		const unSelected = prevProps.isSelected && !isSelected;
+		const unSelected = prevProps.isSelected && ! isSelected;
 		const address = addressToMapString( getAddress( details ) );
 		const { derivedAddressString } = this.state;
 
@@ -318,12 +323,12 @@ class EventVenue extends Component {
 	 *
 	 * @todo  We need to save the data into Meta Fields to avoid redoing the Geocode
 	 * @todo  Move the Maps into Pro
-	 * @param  {String} address Address string for geocode query.
+	 * @param  {string} address Address string for geocode query.
 	 * @return {void}
 	 */
 	setCoordinatesState = ( address ) => {
 		// Clear our state?
-		if ( !address ) {
+		if ( ! address ) {
 			this.setState( { coords: { lat: null, lng: null }, derivedAddressString: '' } );
 			return;
 		}
@@ -338,9 +343,9 @@ class EventVenue extends Component {
 			const { location } = results[ 0 ].geometry;
 			this.setState( {
 				coords: { lat: location.lat(), lng: location.lng() },
-				derivedAddressString: address
+				derivedAddressString: address,
 			} );
-		} )
+		} );
 	}
 }
 


### PR DESCRIPTION
[TEC-4741](https://theeventscalendar.atlassian.net/browse/TEC-4741)

In block editor while editing Event Venues, excessive geocode requests were being triggered. This adds a more definitive set of conditions and state changes are validated before fetching coords. No longer fetching during `render()`.

**Artifacts**:
Excessive requests to the Geocoding endpoint when a Google Maps API key is set, while in block editor. 

![geocoding-tribe (1)](https://user-images.githubusercontent.com/2826045/235805431-5b40a3a1-e096-4cc6-ae15-080833083bfb.png)


[TEC-4741]: https://theeventscalendar.atlassian.net/browse/TEC-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ