### PR TITLE
Prevent pagination in `month` and `week` views.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
+
 = [6.0.13] 2023-05-08 =
 
 * Fix - Correct issue with event subscriptions not passing events past the first 30. [TEC_4584]

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -479,8 +479,9 @@ tribe.events.views.manager = {};
 		var urlObj = new URL( data.url );
 
 		// Check if the 'eventDisplay' query parameter is set to 'month' or 'week'.
-		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
-			// If the 'eventDisplay' parameter is set to 'month' or 'week', delete the 'paged' parameter since per-day events never paginate.
+		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) ||
+			 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
+			// Delete the 'paged' parameter since per-day events never paginate.
 			urlObj.searchParams.delete( 'paged' );
 
 			// Update the data.url string with the modified URL.

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -479,8 +479,7 @@ tribe.events.views.manager = {};
 		var urlObj = new URL( data.url );
 
 		// Check if the 'eventDisplay' query parameter is set to 'month' or 'week'.
-		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) ||
-			 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
+		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) { // eslint-disable-next-line max-len
 			// Delete the 'paged' parameter since per-day events never paginate.
 			urlObj.searchParams.delete( 'paged' );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -465,7 +465,7 @@ tribe.events.views.manager = {};
 	 * we are going to pass the answer to.
 	 *
 	 * @since 4.9.2
-	 * @since TBD Added a check to remove the `paged` parameter in the URL for `month` and `week` views.
+	 * @since TBD Added a check to remove the `paged` parameter from the URL on `month` and `week` views.
 	 *
 	 * @param  {object}         data       DOM Event related to the Click action
 	 * @param  {Element|jQuery} $container Which container we are dealing with

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -465,6 +465,7 @@ tribe.events.views.manager = {};
 	 * we are going to pass the answer to.
 	 *
 	 * @since 4.9.2
+	 * @since TBD Added a check to remove the `paged` parameter in the URL for `month` and `week` views.
 	 *
 	 * @param  {object}         data       DOM Event related to the Click action
 	 * @param  {Element|jQuery} $container Which container we are dealing with
@@ -473,6 +474,18 @@ tribe.events.views.manager = {};
 	 */
 	obj.request = function( data, $container ) {
 		$container.trigger( 'beforeRequest.tribeEvents', [ data, $container ] );
+
+		// Create a new URL object from the data.url string.
+		var urlObj = new URL( data.url );
+
+		// Check if the 'eventDisplay' query parameter is set to 'month' or 'week'.
+		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
+			// If the 'eventDisplay' parameter is set to 'month' or 'week', delete the 'paged' parameter since per-day events never paginate.
+			urlObj.searchParams.delete( 'paged' );
+
+			// Update the data.url string with the modified URL.
+			data.url = urlObj.toString();
+		}	
 
 		var settings = obj.getAjaxSettings( $container );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -479,7 +479,8 @@ tribe.events.views.manager = {};
 		var urlObj = new URL( data.url );
 
 		// Check if the 'eventDisplay' query parameter is set to 'month' or 'week'.
-		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) { // eslint-disable-next-line max-len
+		// eslint-disable-next-line max-len
+		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
 			// Delete the 'paged' parameter since per-day events never paginate.
 			urlObj.searchParams.delete( 'paged' );
 


### PR DESCRIPTION
Ticket : [TEC-4615](https://theeventscalendar.atlassian.net/browse/TEC-4615)

This update prevents pagination on the `month` and `week` views to address issue of missing events when a user switches views from a paginated list-style view. 

**Screencast 🎥**

https://drive.google.com/file/d/1AZQvmdVxH2kTUuJofuRskHI0UXQ9OMrG/view?usp=share_link

[TEC-4615]: https://theeventscalendar.atlassian.net/browse/TEC-4615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ