### PR TITLE
orderby regex match if contains ending space

### DIFF
--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -694,7 +694,7 @@ class Custom_Tables_Query extends WP_Query {
 			}
 
 			// Each `ORDER BY` entry could specify an order (DESC|ASC) or not.
-			if ( preg_match( '~(?<orderby>.*?)\s?(?<order>ASC|DESC)$~i', $orderby_frag, $m ) ) {
+			if ( preg_match( '~(?<orderby>.*?)\s?(?<order>ASC|DESC)\s?$~i', $orderby_frag, $m ) ) {
 				$orderby = trim( $m['orderby'] );
 				$order = trim( $m['order'] );
 			} else {


### PR DESCRIPTION
Fix resulting MYSQL error when the orderby string failed to match the regex sent because it conatins an ending space after the ASC|DESC declaration.

Example: If orderby_frag string ends with a space `wp_posts.ID DESC ` this would fail the REGEX test and the result would become `wp_posts.ID DESC DESC` which results in a MYSQL error.