### PR TITLE
Prevent pagination in month and week views.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,7 +232,6 @@ Remember to always make a backup of your database and files before updating!
 = [6.0.15] TBD =
 
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
-* Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 
 = [6.0.13] 2023-05-08 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 

--- a/readme.txt
+++ b/readme.txt
@@ -231,9 +231,9 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
-* Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
+* Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 
 = [6.0.13] 2023-05-08 =
 

--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -795,4 +795,14 @@ abstract class By_Day_View extends View {
 		$this->repository->where( 'ends_after', $start_date );
 		$this->repository->where( 'starts_before', $end_date );
 	}
+
+	public function url_for_query_args( $date = null, $query_args = [] ) {
+		if ( ! is_array( $query_args ) ) {
+			parse_str( $query_args, $query_args );
+		}
+
+		unset( $query_args[ 'page' ], $query_args[ 'paged' ] );
+
+		return parent::url_for_query_args( $date, $query_args );
+	}
 }

--- a/src/Tribe/Views/V2/Views/By_Day_View.php
+++ b/src/Tribe/Views/V2/Views/By_Day_View.php
@@ -796,13 +796,21 @@ abstract class By_Day_View extends View {
 		$this->repository->where( 'starts_before', $end_date );
 	}
 
+	/**
+	 * Overrides the base View implementation to remove pagination from the URL.
+	 * 
+	 * {@inheritdoc}
+	 */
 	public function url_for_query_args( $date = null, $query_args = [] ) {
+		// If the query arguments are passed as a string, convert them to an array.
 		if ( ! is_array( $query_args ) ) {
 			parse_str( $query_args, $query_args );
 		}
 
+		// Remove the 'page' and 'paged' query parameters from the array of query arguments.
 		unset( $query_args[ 'page' ], $query_args[ 'paged' ] );
 
+		// Call the parent class's 'url_for_query_args' method with the updated query arguments.
 		return parent::url_for_query_args( $date, $query_args );
 	}
 }

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -465,7 +465,6 @@ tribe.events.views.manager = {};
 	 * we are going to pass the answer to.
 	 *
 	 * @since 4.9.2
-	 * @since TBD Added a check to remove the `paged` parameter from the URL on `month` and `week` views.
 	 *
 	 * @param  {object}         data       DOM Event related to the Click action
 	 * @param  {Element|jQuery} $container Which container we are dealing with
@@ -474,19 +473,6 @@ tribe.events.views.manager = {};
 	 */
 	obj.request = function( data, $container ) {
 		$container.trigger( 'beforeRequest.tribeEvents', [ data, $container ] );
-
-		// Create a new URL object from the data.url string.
-		var urlObj = new URL( data.url );
-
-		// Check if the 'eventDisplay' query parameter is set to 'month' or 'week'.
-		// eslint-disable-next-line max-len
-		if ( 'month' === urlObj.searchParams.get( 'eventDisplay' ) || 'week' === urlObj.searchParams.get( 'eventDisplay' ) ) {
-			// Delete the 'paged' parameter since per-day events never paginate.
-			urlObj.searchParams.delete( 'paged' );
-
-			// Update the data.url string with the modified URL.
-			data.url = urlObj.toString();
-		}	
 
 		var settings = obj.getAjaxSettings( $container );
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/By_Day_ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/By_Day_ViewTest.php
@@ -178,4 +178,64 @@ class By_Day_ViewTest extends ViewTestCase {
 		};
 	}
 
+	/**
+	 * Tests that the `url_for_query_args` method removes pagination parameters from the query arguments.
+	 *
+	 * @test
+	 */
+	public function should_remove_pagination_params_from_query_args() {
+		$view                = $this->make_view();
+		$query_args          = [
+			'foo'   => 'bar',
+			'page'  => 2,
+			'paged' => 3,
+			'baz'   => 'qux',
+		];
+		$expected_query_args = [
+			'foo' => 'bar',
+			'baz' => 'qux',
+		];
+
+		$url = $view->url_for_query_args( '2019-10-28', $query_args );
+		$this->assertStringContainsString( '?foo=bar&baz=qux', $url, 'Expected query args are not present in URL' );
+		$this->assertStringNotContainsString( 'page', $url, 'The "page" query parameter was not removed' );
+		$this->assertStringNotContainsString( 'paged', $url, 'The "paged" query parameter was not removed' );
+	}
+
+	/**
+	 * Tests that the `url_for_query_args` method converts a query string argument to an array of query arguments.
+	 *
+	 * @test
+	 */
+	public function should_convert_string_args_to_array() {
+		$view                = $this->make_view();
+		$query_args          = 'foo=bar&page=2&baz=qux';
+		$expected_query_args = [
+			'foo' => 'bar',
+			'baz' => 'qux',
+		];
+
+		$url = $view->url_for_query_args( '2019-10-28', $query_args );
+		$this->assertStringContainsString( '?foo=bar&baz=qux', $url, 'Expected query args are not present in URL' );
+		$this->assertStringNotContainsString( 'page', $url, 'The "page" query parameter was not removed' );
+		$this->assertStringNotContainsString( 'paged', $url, 'The "paged" query parameter was not removed' );
+	}
+
+	/**
+	 * Tests that the `url_for_query_args` method does not remove non-pagination parameters from the query arguments.
+	 *
+	 * @test
+	 */
+	public function should_not_remove_other_params_from_query_args() {
+		$view       = $this->make_view();
+		$query_args = [
+			'foo' => 'bar',
+			'baz' => 'qux',
+		];
+
+		$url = $view->url_for_query_args( '2019-10-28', $query_args );
+		$this->assertStringContainsString( '?foo=bar&baz=qux', $url, 'Expected query args are not present in URL' );
+		$this->assertStringNotContainsString( 'page', $url, 'The "page" query parameter was removed' );
+		$this->assertStringNotContainsString( 'paged', $url, 'The "paged" query parameter was removed' );
+	}
 }


### PR DESCRIPTION
Ticket : [TEC-4615](https://theeventscalendar.atlassian.net/browse/TEC-4615)

Reverts the changes made on [this pr](https://github.com/the-events-calendar/the-events-calendar/pull/4240) because they've introduced some negative side-effects to the date picker.

Handling the issue from the PHP side of things.

[TEC-4615]: https://theeventscalendar.atlassian.net/browse/TEC-4615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ