### PR TITLE
FF Link in Month View.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.0.15] TBD =
 
+* Fix - Ensure the fast forward link in month view is only displayed when there are upcoming events in the context of the current view. [FBAR-292]
 * Tweak - Ensure the page titles on the single venue and organizer pages include the respective post titles for improved SEO. [ECP-1173]
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -700,7 +700,8 @@ class Month_View extends By_Day_View {
 
 		$fast_forward_link = $this->get_fast_forward_link( true );
 
-		if ( ! empty( $fast_forward_link ) ) {
+		// We need to check for the existence of events again to avoid showing the fast forward link when filtering using FBAR.
+		if ( ! empty( $events ) && ! empty( $fast_forward_link ) ) {
 			$this->messages->insert(
 				Messages::TYPE_NOTICE,
 				Messages::for_key( 'month_no_results_found_w_ff_link', $fast_forward_link ),

--- a/src/Tribe/Views/V2/Views/Month_View.php
+++ b/src/Tribe/Views/V2/Views/Month_View.php
@@ -700,8 +700,7 @@ class Month_View extends By_Day_View {
 
 		$fast_forward_link = $this->get_fast_forward_link( true );
 
-		// We need to check for the existence of events again to avoid showing the fast forward link when filtering using FBAR.
-		if ( ! empty( $events ) && ! empty( $fast_forward_link ) ) {
+		if ( ! empty( $fast_forward_link ) ) {
 			$this->messages->insert(
 				Messages::TYPE_NOTICE,
 				Messages::for_key( 'month_no_results_found_w_ff_link', $fast_forward_link ),


### PR DESCRIPTION
WIP 🚧 not ready for review.

Ensure the fast forward link in month view is only displayed when there are upcoming events in the context of the current view.