### PR TITLE
Updates to watch state and props for geocode call.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
+
 = [6.0.13] 2023-05-08 =
 
 * Fix - Correct issue with event subscriptions not passing events past the first 30. [TEC_4584]

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -35,7 +35,11 @@ import { Venue as VenueIcon } from '@moderntribe/events/icons';
 import { utils } from '@moderntribe/events/data/blocks/venue';
 import { google, wpEditor } from '@moderntribe/common/utils/globals';
 import './style.pcss';
+
 const { InspectorControls } = wpEditor;
+const { getAddress } = utils;
+const { maps } = google();
+const geocoder = new maps.Geocoder();
 
 /**
  * Module Code
@@ -67,6 +71,11 @@ class EventVenue extends Component {
 		onCreateNew: PropTypes.func,
 		removeVenue: PropTypes.func,
 		editVenue: PropTypes.func,
+		volatile: PropTypes.any,
+		name: PropTypes.any,
+		store: PropTypes.any,
+		fields: PropTypes.any,
+		setSubmit: PropTypes.any,
 	};
 
 	constructor( props ) {
@@ -75,14 +84,30 @@ class EventVenue extends Component {
 		/**
 		 * @todo move this into the Store
 		 */
-		this.state = { coords: { lat: null, lng: null } };
+		this.state = { coords: { lat: null, lng: null }, derivedAddressString: '' };
+	}
+
+	componentDidMount() {
+		const { details } = this.props;
+		const address = addressToMapString( getAddress( details ) );
+		if ( address ) {
+			this.setCoordinatesState( address );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSelected, edit, create, setSubmit } = this.props;
+		const { isSelected, edit, create, setSubmit, details } = this.props;
 		const unSelected = prevProps.isSelected && ! isSelected;
+		const address = addressToMapString( getAddress( details ) );
+		const { derivedAddressString } = this.state;
+
 		if ( unSelected && ( edit || create ) ) {
 			setSubmit();
+		}
+		// Did we change?
+		if ( derivedAddressString !== address ) {
+			// Get coords if we did.
+			this.setCoordinatesState( address );
 		}
 	}
 
@@ -121,7 +146,6 @@ class EventVenue extends Component {
 
 	renderDetails = () => {
 		const { showMapLink, details } = this.props;
-		const { getAddress } = utils;
 
 		return (
 			<VenueDetails
@@ -155,7 +179,6 @@ class EventVenue extends Component {
 
 	renderContainer() {
 		const { isLoading, edit, create, submit } = this.props;
-
 		if ( isLoading || submit ) {
 			return (
 				<Placeholder key="loading">
@@ -173,14 +196,9 @@ class EventVenue extends Component {
 
 	renderMap() {
 		const { details, edit, create, isLoading, submit, showMap } = this.props;
-
 		if ( ! showMap || isEmpty( details ) || edit || create || isLoading || submit ) {
 			return null;
 		}
-
-		const { getAddress } = utils;
-
-		this.getCoordinates( details );
 		const { coords } = this.state;
 		return (
 			<GoogleMap
@@ -305,28 +323,28 @@ class EventVenue extends Component {
 	 *
 	 * @todo  We need to save the data into Meta Fields to avoid redoing the Geocode
 	 * @todo  Move the Maps into Pro
-	 * @param  {Object} details Information to pass along to the geocoder
+	 * @param  {string} address Address string for geocode query.
 	 * @return {void}
 	 */
-	getCoordinates = ( details ) => {
-		const { maps } = google();
-		const geocoder = new maps.Geocoder();
-		const { getAddress } = utils;
+	setCoordinatesState = ( address ) => {
+		// Clear our state?
+		if ( ! address ) {
+			this.setState( { coords: { lat: null, lng: null }, derivedAddressString: '' } );
+			return;
+		}
 
-		const address = addressToMapString( getAddress( details ) );
-
-		/**
-		 * @todo Need to move this out of the template
-		 */
+		// Fetch coords.
 		geocoder.geocode( { address: address }, ( results, status ) => {
 			if ( 'OK' !== status ) {
+				this.setState( ( state ) => ( { ...state, derivedAddressString: address } ) );
 				return;
 			}
 
 			const { location } = results[ 0 ].geometry;
-
-			this.setState( { coords: { lat: location.lat(), lng: location.lng() } } );
-			return;
+			this.setState( {
+				coords: { lat: location.lat(), lng: location.lng() },
+				derivedAddressString: address,
+			} );
 		} );
 	}
 }


### PR DESCRIPTION
More definitive set of conditions and state changes are validated before fetching coords. No longer fetching during render().

[TEC-4741]

In block editor while editing Event Venues, excessive geocode requests were being triggered. This adds a more definitive set of conditions and state changes are validated before fetching coords. No longer fetching during `render()`.

**Artifacts**:
Excessive requests to the Geocoding endpoint when a Google Maps API key is set, while in block editor.

![geocoding-tribe (1)](https://user-images.githubusercontent.com/2826045/235805431-5b40a3a1-e096-4cc6-ae15-080833083bfb.png)

Original PR: https://github.com/the-events-calendar/the-events-calendar/pull/4239

[TEC-4741]: https://theeventscalendar.atlassian.net/browse/TEC-4741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ