### PR TITLE
Fix excerpt serializer that would change current post.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 * Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 * Fix - Avoid SQL error when filtering by Series in Custom Tables v1 context. [ET-1486]
+* Fix - This fixes a situation where cache would cause the `post` reference to switch to the initial `post` mid-loop on the admin events list page. This likely could have been happening on other pages as well. [TEC-4690]
 
 = [6.0.13] 2023-05-08 =
 

--- a/src/Tribe/Models/Post_Types/Event.php
+++ b/src/Tribe/Models/Post_Types/Event.php
@@ -209,7 +209,7 @@ class Event extends Base {
 				'excerpt'                => (
 					new Lazy_String(
 						static function () use ( $post_id ) {
-							return tribe_events_get_the_excerpt( $post_id, wp_kses_allowed_html( 'post' ) );
+							return tribe_events_get_the_excerpt( $post_id, wp_kses_allowed_html( 'post' ), true );
 						},
 						false
 					)


### PR DESCRIPTION
[TEC-4690](https://theeventscalendar.atlassian.net/browse/TEC-4690)

This fixes a situation where cache would trigger a log call, that would serialize the `excerpt` property, and reset the global `post` mid-loop on the admin list.

Artifacts:
See tests and:
![Screenshot 2023-05-11 181727](https://github.com/the-events-calendar/the-events-calendar/assets/2826045/4dc73951-5c23-4f57-bbc7-ffbc41052ec9)


[TEC-4690]: https://theeventscalendar.atlassian.net/browse/TEC-4690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ