### PR TITLE
Fix for eager alter statements w/ tests.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,13 +229,15 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [6.0.15] TBD =
+= [TBD] TBD =
 
 * Tweak - Ensure the page titles on the single venue and organizer pages include the respective post titles for improved SEO. [ECP-1173]
 * Fix - Prevent administration navigation fatal error with `TypeError: array_search()`. [TEC-4780]
 * Fix - In block editor there were unnecessary geocode API calls being triggered for Event Venue blocks. Moved logic within stateful conditions, now it no longer runs fetch if the address has not actually changed. [TEC-4741]
 * Fix - Added option to disable pagination on the Month and Week views to address issue of missing events. [TEC-4615]
 * Fix - Avoid SQL error when filtering by Series in Custom Tables v1 context. [ET-1486]
+* Fix - This fixes a situation where cache would cause the `post` reference to switch to the initial `post` mid-loop on the admin events list page. This likely could have been happening on other pages as well. [TEC-4690]
+* Fix - Removing our eager schema updates. This was causing a number of `ALTER` statements being run redundantly. No longer utilizes cache/transient for the last run check as it is not dependable. [TEC-4797]
 
 = [6.0.13] 2023-05-08 =
 

--- a/src/Events/Custom_Tables/V1/Activation.php
+++ b/src/Events/Custom_Tables/V1/Activation.php
@@ -44,31 +44,7 @@ class Activation {
 		$schema_builder->up();
 	}
 
-	/**
-	 * This is reliant on the Activation::init run to refresh this value. If you are inspecting this
-	 * last run value, ensure you are checking after it has a chance to check and refresh cache/transient
-	 * do to their schema sync checks.
-	 *
-	 * @since 6.0.9
-	 *
-	 * @return int|null Last time we attempted activating our tables, null if last run cache
-	 *                  expired or never ran.
-	 */
-	public static function last_run_time(): ?int {
-		/*
-		 * Transients will use the cache when using real object cache, why check both then?
-		 * Transients might be disabled. In that case we'll use the cache and work around that limitation.
-		 * A user seeking to force the Activation to run again can flush the cache when using one, or clear
-		 * the transient when not using one.
-		 */
-		if ( wp_using_ext_object_cache() ) {
-			$last_run = wp_cache_get( static::ACTIVATION_TRANSIENT );
-		} else {
-			$last_run = get_transient( static::ACTIVATION_TRANSIENT );
-		}
 
-		return is_numeric( $last_run ) ? (int) $last_run : null;
-	}
 
 	/**
 	 * Checks the state to determine if whether we should create or update custom tables.
@@ -76,28 +52,17 @@ class Activation {
 	 * This method will run once a day (using transients).
 	 *
 	 * @since 6.0.0
+	 * @since TBD Reworked transient logic to use tec_timed_option instead. More concise. No longer forces schema updates.
 	 */
 	public static function init() {
-		$services = tribe();
-		$last_run = static::last_run_time();
-		$now      = time();
-
 		// If the activation last ran less than 24 hours ago, bail.
-		if ( $last_run && $last_run > ( $now - DAY_IN_SECONDS ) ) {
+		if ( tec_timed_option()->get( static::ACTIVATION_TRANSIENT ) ) {
 			return;
 		}
 
+		tec_timed_option()->set( static::ACTIVATION_TRANSIENT, 1, DAY_IN_SECONDS );
 
-		if ( wp_using_ext_object_cache() ) {
-			wp_cache_set( static::ACTIVATION_TRANSIENT, $now, '', DAY_IN_SECONDS );
-			// Clean up.
-			delete_transient( static::ACTIVATION_TRANSIENT );
-		} else {
-			set_transient( static::ACTIVATION_TRANSIENT, $now, DAY_IN_SECONDS );
-			// Clean up.
-			wp_cache_delete( static::ACTIVATION_TRANSIENT );
-		}
-		
+		$services       = tribe();
 		$schema_builder = $services->make( Schema_Builder::class );
 		$state          = $services->make( State::class );
 		$phase          = $state->get_phase();
@@ -114,7 +79,7 @@ class Activation {
 
 		// Update the tables if required by the migration phase.
 		if ( $update ) {
-			$schema_builder->up( true );
+			$schema_builder->up();
 
 			// Ensure late activation only after we have the tables.
 			if ( ! $services->getVar( 'ct1_fully_activated' ) ) {

--- a/src/Events/Custom_Tables/V1/Health_Check.php
+++ b/src/Events/Custom_Tables/V1/Health_Check.php
@@ -96,7 +96,7 @@ class Health_Check {
 		global $wpdb;
 
 		// No activation / schema attempt ran? We wouldn't have the table yet.
-		if ( Activation::last_run_time() === null ) {
+		if ( tec_timed_option()->get( Activation::ACTIVATION_TRANSIENT ) === null ) {
 			return false;
 		}
 
@@ -120,7 +120,7 @@ class Health_Check {
 		global $wpdb;
 
 		// No activation / schema attempt ran? We wouldn't have the table yet.
-		if ( Activation::last_run_time() === null ) {
+		if ( tec_timed_option()->get( Activation::ACTIVATION_TRANSIENT ) === null ) {
 			return false;
 		}
 

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
@@ -27,7 +27,7 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$query =  $this->get_update_sql();
-		$this->validate_for_dbDelta($query);
+		$this->validate_for_db_delta($query);
 		$results = (array) dbDelta($query );
 		$this->sync_stored_version();
 		$results = $this->after_update( $results );
@@ -40,9 +40,11 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 	 *
 	 * @since TBD
 	 *
+	 * @see https://developer.wordpress.org/reference/functions/dbdelta/
+	 *
 	 * @param string $query Query string to inspect for case sensitivity before using in dbDelta
 	 */
-	public function validate_for_dbDelta( string $query ) {
+	public function validate_for_db_delta( string $query ) {
 		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
 			do_action( 'tribe_log', 'error', __METHOD__, [ 'schema_builder_error' => "Failed dbDelta field validation: $query" ] );
 		}

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
@@ -26,11 +26,19 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 	public function update() {
 		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		$results = (array) dbDelta( $this->get_update_sql() );
+		$query =  $this->get_update_sql();
+		$this->validate_for_dbDelta($query);
+		$results = (array) dbDelta($query );
 		$this->sync_stored_version();
 		$results = $this->after_update( $results );
 
 		return $results;
+	}
+
+	public function validate_for_dbDelta( string $query ) {
+		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
+			do_action( 'tribe_log', 'error', __METHOD__, ['schema_builder_error' => "Failed dbDelta field validation: $query"] );
+		}
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Field.php
@@ -35,9 +35,16 @@ abstract class Abstract_Custom_Field implements Field_Schema_Interface {
 		return $results;
 	}
 
+	/**
+	 * Inspects query strings being passed to dbDelta, and logs an error if not ideal.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $query Query string to inspect for case sensitivity before using in dbDelta
+	 */
 	public function validate_for_dbDelta( string $query ) {
 		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
-			do_action( 'tribe_log', 'error', __METHOD__, ['schema_builder_error' => "Failed dbDelta field validation: $query"] );
+			do_action( 'tribe_log', 'error', __METHOD__, [ 'schema_builder_error' => "Failed dbDelta field validation: $query" ] );
 		}
 	}
 

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -64,9 +64,16 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 		return $results;
 	}
 
+	/**
+	 * Inspects query strings being passed to dbDelta, and logs an error if not ideal.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $query Query string to inspect for case sensitivity before using in dbDelta
+	 */
 	public function validate_for_dbDelta( string $query ) {
 		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
-			do_action( 'tribe_log', 'error', __METHOD__, ['schema_builder_error' => "Failed dbDelta field validation: $query"] );
+			do_action( 'tribe_log', 'error', __METHOD__, [ 'schema_builder_error' => "Failed dbDelta field validation: $query" ] );
 		}
 	}
 

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -56,7 +56,7 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$query = $this->get_update_sql();
-		$this->validate_for_dbDelta($query);
+		$this->validate_for_db_delta($query);
 		$results = (array) dbDelta( $query );
 		$this->sync_stored_version();
 		$results = $this->after_update( $results );
@@ -69,9 +69,11 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	 *
 	 * @since TBD
 	 *
+	 * @see https://developer.wordpress.org/reference/functions/dbdelta/
+	 *
 	 * @param string $query Query string to inspect for case sensitivity before using in dbDelta
 	 */
-	public function validate_for_dbDelta( string $query ) {
+	public function validate_for_db_delta( string $query ) {
 		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
 			do_action( 'tribe_log', 'error', __METHOD__, [ 'schema_builder_error' => "Failed dbDelta field validation: $query" ] );
 		}

--- a/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
+++ b/src/Events/Custom_Tables/V1/Schema_Builder/Abstract_Custom_Table.php
@@ -55,11 +55,19 @@ abstract class Abstract_Custom_Table implements Table_Schema_Interface {
 	public function update() {
 		$this->before_update();
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		$results = (array) dbDelta( $this->get_update_sql() );
+		$query = $this->get_update_sql();
+		$this->validate_for_dbDelta($query);
+		$results = (array) dbDelta( $query );
 		$this->sync_stored_version();
 		$results = $this->after_update( $results );
 
 		return $results;
+	}
+
+	public function validate_for_dbDelta( string $query ) {
+		if ( preg_match( '/`.*?` [A-Z]/', $query ) ) {
+			do_action( 'tribe_log', 'error', __METHOD__, ['schema_builder_error' => "Failed dbDelta field validation: $query"] );
+		}
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Tables/Events.php
+++ b/src/Events/Custom_Tables/V1/Tables/Events.php
@@ -60,15 +60,15 @@ class Events extends Abstract_Custom_Table {
 
 		// VARCHAR(19) to store YYYY-MM-DD HH:MM:SS values as strings and allow partial compare.
 		return "CREATE TABLE `{$table_name}` (
-			`event_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-			`post_id` BIGINT(20) UNSIGNED NOT NULL,
-			`start_date` VARCHAR(19) NOT NULL,
-			`end_date` VARCHAR(19) DEFAULT NULL,
-			`timezone` VARCHAR(30) NOT NULL DEFAULT 'UTC',
-			`start_date_utc` VARCHAR(19) NOT NULL,
-			`end_date_utc` VARCHAR(19) DEFAULT NULL,
-			`duration` MEDIUMINT(30) DEFAULT 7200,
-			`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			`event_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			`post_id` bigint(20) unsigned NOT NULL,
+			`start_date` varchar(19) NOT NULL,
+			`end_date` varchar(19) DEFAULT NULL,
+			`timezone` varchar(30) NOT NULL DEFAULT 'UTC',
+			`start_date_utc` varchar(19) NOT NULL,
+			`end_date_utc` varchar(19) DEFAULT NULL,
+			`duration` mediumint(30) DEFAULT 7200,
+			`updated_at` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			`hash` varchar(40) NOT NULL,
 			PRIMARY KEY  (`event_id`)
 			) {$charset_collate};";

--- a/src/Events/Custom_Tables/V1/Tables/Occurrences.php
+++ b/src/Events/Custom_Tables/V1/Tables/Occurrences.php
@@ -62,16 +62,16 @@ class Occurrences extends Abstract_Custom_Table {
 
 		// VARCHAR(19) to store YYYY-MM-DD HH:MM:SS values as strings and allow partial compare.
 		return "CREATE TABLE `{$table_name}` (
-			`occurrence_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-			`event_id` BIGINT(20) UNSIGNED NOT NULL,
-			`post_id` BIGINT(20) UNSIGNED NOT NULL,
-			`start_date` VARCHAR(19) NOT NULL,
-			`start_date_utc` VARCHAR(19) NOT NULL,
-			`end_date` VARCHAR(19) NOT NULL,
-			`end_date_utc` VARCHAR(19) NOT NULL,
-			`duration` MEDIUMINT(30) DEFAULT 7200,
-			`hash` VARCHAR(40) NOT NULL,
-			`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			`occurrence_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			`event_id` bigint(20) unsigned NOT NULL,
+			`post_id` bigint(20) unsigned NOT NULL,
+			`start_date` varchar(19) NOT NULL,
+			`start_date_utc` varchar(19) NOT NULL,
+			`end_date` varchar(19) NOT NULL,
+			`end_date_utc` varchar(19) NOT NULL,
+			`duration` mediumint(30) DEFAULT 7200,
+			`hash` varchar(40) NOT NULL,
+			`updated_at` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY  (`occurrence_id`)
 			) {$charset_collate};";
 	}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
 
-		const VERSION             = '6.1.1';
+		const VERSION             = '6.1.0';
 
 		/**
 		 * Min Pro Addon

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
 
-		const VERSION             = '6.0.13';
+		const VERSION             = '6.1.2';
 
 		/**
 		 * Min Pro Addon

--- a/tests/_support/Traits/CT1/CT1_Fixtures.php
+++ b/tests/_support/Traits/CT1/CT1_Fixtures.php
@@ -85,8 +85,7 @@ trait CT1_Fixtures {
 		$tables = $wpdb->get_col( $q );
 		$this->assertNotContains( OccurrencesSchema::table_name( true ), $tables );
 		$this->assertNotContains( EventsSchema::table_name( true ), $tables );
-		wp_cache_delete( Activation::ACTIVATION_TRANSIENT );
-		delete_transient( Activation::ACTIVATION_TRANSIENT );
+		tec_timed_option()->delete( Activation::ACTIVATION_TRANSIENT );
 	}
 
 	/**


### PR DESCRIPTION
[TEC-4797](https://theeventscalendar.atlassian.net/browse/TEC-4797)

Removing our eager schema updates. This was causing a number of `ALTER` statements being run redundantly. No longer utilizes cache/transient for the last run check as it is not dependable.

Artifacts:
```
ALTER TABLE wp_tec_occurrences CHANGE COLUMNstart_date start_date VARCHAR(19) NOT NULL
```

See tests.

[TEC-4797]: https://theeventscalendar.atlassian.net/browse/TEC-4797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ