### PR TITLE
[ET-1741] Hide TEC filtered RSVP email settings when RSVP is using Ticket settings.

### DIFF
--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/RSVP.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/RSVP.php
@@ -57,6 +57,10 @@ class RSVP {
 	 * @return array<array<string,mixed>> $settings The modified email settings.
 	 */
 	public function include_settings( $settings ): array {
+		// If the ticket email settings are being used, don't add these settings.
+		if ( tribe( RSVP_Email::class )->is_using_ticket_email_settings() ) {
+			return $settings;
+		}
 
 		$settings[ static::$option_add_event_links ] = [
 			'type'            => 'checkbox_bool',


### PR DESCRIPTION
[ET-1741]

[ET-1741]: https://theeventscalendar.atlassian.net/browse/ET-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Depends on: https://github.com/the-events-calendar/event-tickets/pull/2638

**Using Ticket Emails settings:**
<img width="993" alt="Screenshot 2023-05-16 at 9 22 16 PM" src="https://github.com/the-events-calendar/the-events-calendar/assets/7523321/55b8c164-3684-46b7-84ee-00360bab2a42">

**Without using Ticket Emails settings:**
<img width="746" alt="Screenshot 2023-05-16 at 9 22 55 PM" src="https://github.com/the-events-calendar/the-events-calendar/assets/7523321/82886e07-d949-4927-b10b-4c5e9d9a88e5">
