### PR TITLE
Reverse order for past events.

### DIFF
--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -216,8 +216,13 @@ class Title {
 	public static function build_post_range_title( Context $context, $event_date, array $posts ) {
 		$event_date = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
 
-		$first = reset( $posts );
-		$last  = end( $posts );
+		if ( $context->get( 'event_display_mode' ) === 'past' ) {
+			$first = end( $posts );
+			$last  = reset( $posts );
+		} else {
+			$first = reset( $posts );
+			$last  = end( $posts );
+		}
 
 		$first_returned_date = tribe_get_start_date( $first, false, Dates::DBDATEFORMAT );
 		$first_event_date    = tribe_get_start_date( $first, false );

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
@@ -167,6 +167,15 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	public function test_title_with_views( $events, $context ) {
 		$context     = tribe_context()->alter( $context );
 		$mock_events = [];
+		$is_past     = $context->get( 'event_display_mode' ) === 'past';
+		usort( $events, function ( $a, $b ) use ( $is_past ) {
+
+			if ( $is_past ) {
+				return strtotime( $a['start_date'] ) > strtotime( $b['start_date'] ) ? - 1 : 1;
+			}
+
+			return strtotime( $a['start_date'] ) > strtotime( $b['start_date'] ) ? 1 : - 1;
+		} );
 		foreach ( $events as $event ) {
 			$mock_events[] = $this->get_mock_event( 'events/single/1.template.json', $event );
 		}


### PR DESCRIPTION
Fix for QA fail.

Past events need to flip order.