### PR TITLE
Tickets Emails: Add Event Title to Order Emails

### DIFF
--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Completed_Order.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Completed_Order.php
@@ -2,7 +2,7 @@
 /**
  * Class Completed_Order.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Integrations\Plugins\Event_Tickets\Emails
  */
@@ -15,7 +15,7 @@ use TEC\Tickets\Emails\Email\Completed_Order as Completed_Order_Email;
 /**
  * Class Completed_Order.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Integrations\Plugins\Event_Tickets
  */

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Completed_Order.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Completed_Order.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class Completed_Order.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Event_Tickets\Emails
+ */
+
+namespace TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email;
+
+use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Template;
+use TEC\Tickets\Emails\Email\Completed_Order as Completed_Order_Email;
+
+/**
+ * Class Completed_Order.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Event_Tickets
+ */
+class Completed_Order {
+
+	/**
+	 * Includes event styles in email body for Completed Order emails.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__Template $parent_template Event Tickets template object.
+	 *
+	 * @return void
+	 */
+	public function include_event_styles( $parent_template ): void {
+		$args = $parent_template->get_local_values();
+
+		if ( ! $args['email'] instanceof Completed_Order_Email ) {
+			return;
+		}
+
+		tribe( Template::class )->template( 'template-parts/header/head/tec-styles', $args, true );
+	}
+	
+    /**
+	 * Includes event title in email body for Completed Order emails.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__Template $parent_template Event Tickets template object.
+	 *
+	 * @return void
+	 */
+	public function include_event_title( $parent_template ) {
+		$args = $parent_template->get_local_values();
+
+		if ( ! $args['email'] instanceof Completed_Order_Email ) {
+			return;
+		}
+
+		tribe( Template::class )->template( 'template-parts/body/order/event-title', $args, true );
+	}
+}

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Purchase_Receipt.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Class Purchase_Receipt.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Event_Tickets\Emails
+ */
+
+namespace TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email;
+
+use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Template;
+use TEC\Tickets\Emails\Email\Purchase_Receipt as Purchase_Receipt_Email;
+
+/**
+ * Class Purchase_Receipt.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Event_Tickets
+ */
+class Purchase_Receipt {
+
+	/**
+	 * Includes event styles in email body for Purchase Receipt emails.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__Template $parent_template Event Tickets template object.
+	 *
+	 * @return void
+	 */
+	public function include_event_styles( $parent_template ): void {
+		$args = $parent_template->get_local_values();
+
+		if ( ! $args['email'] instanceof Purchase_Receipt_Email ) {
+			return;
+		}
+
+		tribe( Template::class )->template( 'template-parts/header/head/tec-styles', $args, true );
+	}
+	
+    /**
+	 * Includes event title in email body for Purchase Receipt emails.
+	 *
+	 * @since TBD
+	 *
+	 * @param \Tribe__Template $parent_template Event Tickets template object.
+	 *
+	 * @return void
+	 */
+	public function include_event_title( $parent_template ) {
+		$args = $parent_template->get_local_values();
+
+		if ( ! $args['email'] instanceof Purchase_Receipt_Email ) {
+			return;
+		}
+
+		tribe( Template::class )->template( 'template-parts/body/order/event-title', $args, true );
+	}
+}

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Purchase_Receipt.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Purchase_Receipt.php
@@ -2,7 +2,7 @@
 /**
  * Class Purchase_Receipt.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Integrations\Plugins\Event_Tickets\Emails
  */
@@ -15,7 +15,7 @@ use TEC\Tickets\Emails\Email\Purchase_Receipt as Purchase_Receipt_Email;
 /**
  * Class Purchase_Receipt.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Integrations\Plugins\Event_Tickets
  */

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Hooks.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Hooks.php
@@ -15,6 +15,8 @@
 
 namespace TEC\Events\Integrations\Plugins\Event_Tickets\Emails;
 
+use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email\Completed_Order;
+use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email\Purchase_Receipt;
 use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email\RSVP;
 use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Email\Ticket;
 use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\JSON_LD\Event_Data;
@@ -53,6 +55,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'tribe_template_before_include:tickets/emails/template-parts/header/head/styles', [ $this, 'include_event_ticket_rsvp_styles' ], 10, 3 );
 		add_action( 'tribe_template_after_include:tickets/emails/template-parts/body/tickets', [ $this, 'include_event_venue_ticket_rsvp_emails' ], 10, 3 );
 		add_action( 'tribe_template_after_include:tickets/emails/template-parts/body/tickets', [ $this, 'include_event_calendar_links' ], 10, 3 );
+		add_action( 'tribe_template_before_include:tickets/emails/template-parts/body/order/ticket-totals', [ $this, 'include_event_title' ], 10, 3 );
 	}
 
 	/**
@@ -309,5 +312,25 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	public function filter_include_json_ld_event_data( $data, $schema ): array {
 		return $this->container->make( Event_Data::class )->filter_event_data( $data, $schema );
+	}
+
+	/**
+	 * Include Event title above the ticket totals in order emails.
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string          $file     Template file.
+	 * @param string          $name     Template name.
+	 * @param Common_Template $template Event Tickets template object.
+	 * 
+	 * @return void
+	 */
+	public function include_event_title( $file, $name, $template ) {
+		if ( ! $template instanceof Common_Template ) {
+			return;
+		}
+		
+		$this->container->make( Completed_Order::class )->include_event_title( $template );
+		$this->container->make( Purchase_Receipt::class )->include_event_title( $template );
 	}
 }

--- a/src/views/integrations/event-tickets/emails/template-parts/body/order/event-title.php
+++ b/src/views/integrations/event-tickets/emails/template-parts/body/order/event-title.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Event Tickets Emails: Main template > Body > Order > Event Title
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/events/integrations/event-tickets/emails/template-parts/body/order/event-title.php
+ *
+ * See more documentation about our views templating system.
+ *
+ * @link https://evnt.is/tickets-emails-tpl Help article for Tickets Emails template files.
+ *
+ * @version TBD
+ *
+ * @since TBD
+ *
+ * @var Tribe__Template                    $this               Current template object.
+ * @var \TEC\Tickets\Emails\Email_Abstract $email              The email object.
+ * @var string                             $heading            The email heading.
+ * @var string                             $title              The email title.
+ * @var bool                               $preview            Whether the email is in preview mode or not.
+ * @var string                             $additional_content The email additional content.
+ * @var bool                               $is_tec_active      Whether `The Events Calendar` is active or not.
+ * @var \WP_Post                           $order              The order object.
+ * @var \WP_Post                           $event              The event object.
+ */
+
+if ( empty( $event ) ) {
+	return;
+}
+if ( empty( $event->title ) ) {
+	return;
+}
+
+?>
+<tr>
+	<td class="tec-tickets__email-table-content-order-event-title">
+			<a href="<?php echo esc_url( $event->permalink ); ?>" target="_blank">
+				<?php
+					echo esc_html( $event->title );
+				?>
+			</a>
+	</td>
+</tr>

--- a/src/views/integrations/event-tickets/emails/template-parts/header/head/tec-styles.php
+++ b/src/views/integrations/event-tickets/emails/template-parts/header/head/tec-styles.php
@@ -174,4 +174,11 @@
 	h3.tec-tickets__email-table-content-event-title a {
 		text-decoration: none;
 	}
+	
+	.tec-tickets__email-table-content-order-event-title,
+	td.tec-tickets__email-table-content-order-event-title {
+		font-size: 16px;
+		font-weight: 700;
+		padding-top:43px;
+	}
 </style>

--- a/src/views/integrations/event-tickets/emails/template-parts/header/head/tec-styles.php
+++ b/src/views/integrations/event-tickets/emails/template-parts/header/head/tec-styles.php
@@ -181,4 +181,9 @@
 		font-weight: 700;
 		padding-top:43px;
 	}
+	
+	.tec-tickets__email-table-content-order-event-title a,
+	td.tec-tickets__email-table-content-order-event-title a {
+		text-decoration: none;
+	}
 </style>


### PR DESCRIPTION
### Issues

- TE-8ADA
- TE-DC94

### Description

The event titles were initially added into ET, but were set to be moved to TEC eventually. That never happened, so this PR handles all of that.

### Abstract

https://www.loom.com/share/8dc76ea87ad2419490a714ba6a2514d7
