### PR TITLE
Bug fix – prevent duplicate JOIN statement in query

### DIFF
--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -220,8 +220,11 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			 * table as that is the only way to represent Occurrences.
 			 */
 			global $wpdb;
-			$occurrences                = Occurrences::table_name( true );
-			$this->query_vars['join'][] = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
+			$occurrences = Occurrences::table_name( true );
+			$local_join  = "JOIN {$occurrences} ON {$wpdb->posts}.ID = {$occurrences}.post_id";
+			if ( ! in_array( $local_join, $this->query_vars['join'], true ) ) {
+				$this->query_vars['join'][] = $local_join;
+			}
 		} else if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );
 		}


### PR DESCRIPTION
Back in December 2022, I had noticed that sometimes the related JOIN statement appeared multiple times in the query, creating a WP database error. I created this workaround, not knowing what the proper fix was. I do not know if this problem has since been fixed some other way.