### PR TITLE
Move modal logic to plugin. Ensure it show show up on all TEC admin pages.

### DIFF
--- a/src/Events/Telemetry/Provider.php
+++ b/src/Events/Telemetry/Provider.php
@@ -25,6 +25,7 @@ class Provider extends Service_Provider {
 	 */
 	public function register() {
 		$this->add_filters();
+		$this->add_actions();
 	}
 
 	/**
@@ -40,13 +41,22 @@ class Provider extends Service_Provider {
 	}
 
 	/**
-	 * Filter the telemetry optin arguments.
+	 * Handles the action hooks for this module.
+	 *
+	 * @since TBD
+	 */
+	public function add_actions() {
+		add_action( 'in_admin_footer', tribe_callback( Telemetry::class, 'inject_modal_link' ) );
+	}
+
+	/**
+	 * Filter the telemetry opt-in arguments.
 	 *
 	 * @since TBD
 	 *
 	 * @param array $optin_args Previous set of args we are changing.
 	 *
-	 * @return array 
+	 * @return array
 	 */
 	public function filter_tec_common_telemetry_optin_args( $optin_args ) {
 		return $this->container->get( Telemetry::class )->filter_tec_common_telemetry_optin_args( $optin_args );

--- a/src/Events/Telemetry/Provider.php
+++ b/src/Events/Telemetry/Provider.php
@@ -46,7 +46,7 @@ class Provider extends Service_Provider {
 	 * @since TBD
 	 */
 	public function add_actions() {
-		add_action( 'in_admin_footer', tribe_callback( Telemetry::class, 'inject_modal_link' ) );
+		add_action( 'in_admin_footer', [ $this, 'inject_modal_link' ] );
 	}
 
 	/**
@@ -103,5 +103,14 @@ class Provider extends Service_Provider {
 	 */
 	public function filter_tec_telemetry_slugs( $slugs ) {
 		return $this->container->get( Telemetry::class )->filter_tec_telemetry_slugs( $slugs );
+	}
+
+	/**
+	 * Conditionally injects the hook to trigger the Telemetry modal.
+	 *
+	 * @since TBD
+	 */
+	public function inject_modal_link() {
+		return $this->container->get( Telemetry::class )->inject_modal_link();
 	}
 }

--- a/src/Events/Telemetry/Telemetry.php
+++ b/src/Events/Telemetry/Telemetry.php
@@ -209,8 +209,11 @@ class Telemetry {
 		}
 
 		$telemetry_slug = \TEC\Common\Telemetry\Telemetry::get_plugin_slug();
+
 		/**
-		 * Fires when the user is viewing the tab content.
+		 * Fires to trigger the modal content on admin pages.
+		 *
+		 * @since TBD
 		 */
 		do_action( "stellarwp/telemetry/{$telemetry_slug}/optin" );
 	}

--- a/src/Events/Telemetry/Telemetry.php
+++ b/src/Events/Telemetry/Telemetry.php
@@ -12,8 +12,7 @@ namespace TEC\Events\Telemetry;
 use TEC\Common\StellarWP\Telemetry\Config;
 use TEC\Common\StellarWP\Telemetry\Opt_In\Status;
 use TEC\Common\Telemetry\Telemetry as Common_Telemetry;
-use Tribe\Events\Admin\Settings as Plugin_Settings;
-use Tribe__Events__Main;
+use Tribe__Events__Main as TEC;
 
 /**
  * Class Telemetry
@@ -52,8 +51,7 @@ class Telemetry {
 	 * @return array<string|mixed> The filtered args.
 	 */
 	public function filter_tec_common_telemetry_optin_args( $original_optin_args ): array {
-		// wp-admin/admin.php?page=tec-events-settings
-		if ( ! tribe( Plugin_Settings::class )->is_tec_events_settings() ) {
+		if ( ! static::is_tec_admin_page() ) {
 			return $original_optin_args;
 		}
 
@@ -163,8 +161,57 @@ class Telemetry {
 	 * @return array<string,string> $slugs The same array with The Events Calendar added to it.
 	 */
 	public function filter_tec_telemetry_slugs( $slugs ) {
-		$dir = Tribe__Events__Main::instance()->plugin_dir;
+		$dir = TEC::instance()->plugin_dir;
 		$slugs[ static::$plugin_slug ] =  $dir . static::$plugin_path;
 		return array_unique( $slugs, SORT_STRING );
+	}
+
+	/**
+	 * Determines if we are on a TEC admin page except the post edit page.
+	 *
+	 * @since TBD
+	 *
+	 * @return boolean
+	 */
+	public static function is_tec_admin_page(): bool {
+		$helper = \Tribe__Admin__Helpers::instance();
+
+		// Are we on a tec post-type admin screen?
+		if (
+			! $helper->is_post_type_screen( TEC::POSTTYPE )
+			&& ! $helper->is_post_type_screen( TEC::ORGANIZER_POST_TYPE )
+			&& ! $helper->is_post_type_screen( TEC::VENUE_POST_TYPE )
+		) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		// Don't show on the event edit screen.
+		if (
+			TEC::POSTTYPE === $screen->id
+			|| TEC::ORGANIZER_POST_TYPE === $screen->id
+			|| TEC::VENUE_POST_TYPE === $screen->id
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Outputs the hook that renders the Telemetry action on all TEC admin pages.
+	 *
+	 * @since TBD
+	 */
+	public function inject_modal_link() {
+		if ( ! static::is_tec_admin_page() ) {
+			return;
+		}
+
+		$telemetry_slug = \TEC\Common\Telemetry\Telemetry::get_plugin_slug();
+		/**
+		 * Fires when the user is viewing the tab content.
+		 */
+		do_action( "stellarwp/telemetry/{$telemetry_slug}/optin" );
 	}
 }


### PR DESCRIPTION
Except for post editors and the Help page - as it does not trigger `in_admin_footer`.

[TEC-4704]

Related: https://github.com/the-events-calendar/tribe-common/pull/1928

[TEC-4704]: https://theeventscalendar.atlassian.net/browse/TEC-4704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ