### PR TITLE
TE-27C1 Tickets Emails: Place Event Date Before Post Title

### DIFF
--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Hooks.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Hooks.php
@@ -47,7 +47,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @since TBD
 	 */
 	protected function add_actions(): void {
-		add_action( 'tribe_template_before_include:tickets/emails/template-parts/body/tickets', [ $this, 'include_event_date_ticket_rsvp_emails' ], 10, 3 );
+		add_action( 'tribe_template_before_include:tickets/emails/template-parts/body/post-title', [ $this, 'include_event_date_ticket_rsvp_emails' ], 10, 3 );
 		add_action( 'tribe_template_before_include:tickets/emails/template-parts/body/tickets', [ $this, 'include_event_image_ticket_rsvp_emails' ], 15, 3 );
 		add_action( 'tribe_template_before_include:tickets/emails/template-parts/header/head/styles', [ $this, 'include_event_ticket_rsvp_styles' ], 10, 3 );
 		add_action( 'tribe_template_after_include:tickets/emails/template-parts/body/post-description', [ $this, 'include_event_venue_ticket_rsvp_emails' ], 15, 3 );


### PR DESCRIPTION
### Issues

- TE-27C1
- TE-9699

### Description

The event date should appear above the post title. By putting it in the right place, this also fixes the spacing issue (TE-9699) around the title.

### Abstract

Before:
![image](https://github.com/the-events-calendar/the-events-calendar/assets/7432506/b808c1ec-e751-4055-adc5-3bd1e7433594)

After:
![image](https://github.com/the-events-calendar/the-events-calendar/assets/7432506/e1bd5361-5141-421e-af5e-512c90c93a0a)
