### PR TITLE
Prevent regression caused by registration of `core/legacy-widget` block.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,7 +233,6 @@ Remember to always make a backup of your database and files before updating!
 
 * Fix - Performance improvements on Month and Day view when a lot of future and past events were found. [TEC-3089]
 * Fix - Ensure we're using the correct download link for the `Export Outlook .ics` file in the single event page. [TEC-4776]
-* Fix - Prevent re-registration of the `core/legacy-widget` block. [TEC-4764]
 * Fix - Ensure TEC styles can be easily overridden by themes and page builders. [ECP-1503]
 * Fix - Avoid the issue where TEC blocks would break when either the `WP Go Maps`, `MapPress Google Maps` and `Leaflet Maps` plugins were active on a site. [TEC-4810]
 * Fix - Added some event parsing to ensure only valid events are handled in the iCal file generation. [TEC-4837]

--- a/src/modules/widgets/index.js
+++ b/src/modules/widgets/index.js
@@ -6,7 +6,8 @@ import './style.pcss';
 
 const { registerBlockType } = wp.blocks;
 
-// We need to register core/legacy-widget block to support earlier versions of WP which don't have it registered by default.
+// We need to register core/legacy-widget block to support
+// earlier versions of WP which don't have it registered by default.
 wp.widgets.registerLegacyWidgetBlock();
 
 const blocks = [

--- a/src/modules/widgets/index.js
+++ b/src/modules/widgets/index.js
@@ -6,6 +6,7 @@ import './style.pcss';
 
 const { registerBlockType } = wp.blocks;
 
+// We need to register core/legacy-widget block to support earlier versions of WP which don't have it registered by default.
 wp.widgets.registerLegacyWidgetBlock();
 
 const blocks = [

--- a/src/modules/widgets/index.js
+++ b/src/modules/widgets/index.js
@@ -6,6 +6,7 @@ import './style.pcss';
 
 const { registerBlockType } = wp.blocks;
 
+wp.widgets.registerLegacyWidgetBlock();
 
 const blocks = [
 	EventsList,


### PR DESCRIPTION
Reverts the updates made on this [pr](https://github.com/the-events-calendar/the-events-calendar/pull/4281).

The `core/legacy-widget` block needs to be registered for the block widgets to work.

- In earlier versions of WP i.e. between 5.8 and 6.0, the block is not registered by default in core. This was when widget blocks was in the _experimental_ phase.
- The error on this [ticket](https://theeventscalendar.atlassian.net/browse/TEC-4764) i.e. `Block "core/legacy-widget" is already registered` is showing up in later versions where the block is registered by default.