### PR TITLE
Remove typed return for Admin Footer

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -234,6 +234,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Ensure we output valid html around <dt> and <dd> elements in an accessible way. [TEC-4812]
 * Fix - Ensure the block editor includes support for user-defined custom CSS classes. [TEC-4724]
 * Fix - Correct some PHP 8.1 deprecations that impact loading of views.
+* Fix - Prevent TypeError warnings around `admin_footer_text_settings` filter due to type hinting conflicting with other plugins returning null.
 * Tweak - Deprecated misspelled `tribe_get_organiser_object_after` filter for one with correct spelling: `tribe_get_organizer_object_after`. Done as part of [TEC-4812]
 * Tweak - Remove end colons from some translated strings. Done as part of [TEC-4812]
 * Tweak - Fix typo in template displaying stray "w". [TEC-4870]

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -450,7 +450,7 @@ class Settings {
 	 * @param string $footer_text The admin footer text.
 	 * @return string $footer_text The admin footer text, maybe modified.
 	 */
-	public function admin_footer_text_settings( $footer_text ): string {
+	public function admin_footer_text_settings( $footer_text ) {
 		$admin_pages = tribe( 'admin.pages' );
 		$admin_page  = $admin_pages->get_current_page();
 


### PR DESCRIPTION
WP.org:
https://wordpress.org/support/topic/breaking-other-plugins-keep-getting-error-warnings-about-events-calendar/#post-16927655