### PR TITLE
Adjust styling for venue blocks and set better map defaults

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: 'npm lint'
 on:
-  pull_request:
+  workflow_dispatch:
     paths:
       - 'src/modules/**.js'
       - 'src/resources/js/**.js'

--- a/readme.txt
+++ b/readme.txt
@@ -233,7 +233,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Tweak - Change styling for Venue Blocks to constrain to a card-like style. [ECP-1540]
 * Tweak - Adjust REST endpoints to support multiple venues during event creation and updates. [ECP-1540]
-* Tweak - If multiple venues exist on an event, display them in the event editor. [ECP-1540]
+* Tweak - If multiple venues exist on an event, display them in the classic event editor. [ECP-1540]
 * Fix - Ensure the block editor includes support for user-defined custom CSS classes. [TEC-4724]
 * Fix - Ensure the "Add Organizer" button is visible in the classic editor if organizers have been set. [TEC-4729]
 * Fix - Simplify data handling of venues within the block editor. [ECP-1540]

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -693,11 +693,6 @@ class Assets extends Service_Provider {
 			return true;
 		}
 
-		// Bail if not Single Event V2.
-		if ( ! tribe_events_single_view_v2_is_enabled() ) {
-			$should_enqueue = false;
-		}
-
 		// Bail if not Single Event.
 		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
 			$should_enqueue = false;

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -674,6 +674,8 @@ class Assets extends Service_Provider {
 	 * @return boolean
 	 */
 	public function should_enqueue_single_event_block_editor_styles() {
+		$should_enqueue = true;
+
 		/**
 		 * Checks whether the page is being viewed in Elementor preview mode.
 		 *
@@ -693,20 +695,27 @@ class Assets extends Service_Provider {
 
 		// Bail if not Single Event V2.
 		if ( ! tribe_events_single_view_v2_is_enabled() ) {
-			return false;
+			$should_enqueue = false;
 		}
 
 		// Bail if not Single Event.
 		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
-			return false;
+			$should_enqueue = false;
 		}
 
 		// Bail if not Block Editor.
 		if ( ! tribe( 'editor' )->should_load_blocks() && ! has_blocks( get_queried_object_id() ) ) {
-			return false;
+			$should_enqueue = false;
 		}
 
-		return true;
+		/**
+		 * Allow filtering of where the base Frontend Assets will be loaded.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_enqueue Should the assets be enqueued.
+		 */
+		return apply_filters( 'tec_events_views_v2_assets_should_enqueue_single_event_block_editor_styles', $should_enqueue );
 	}
 
 	/**

--- a/src/modules/blocks/event-venue/style.pcss
+++ b/src/modules/blocks/event-venue/style.pcss
@@ -2,7 +2,6 @@
 	display: flex;
 	justify-content: space-between;
 	width: 100%;
-	position: relative;
 
 	&--current {
 		width: 100%;

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -232,7 +232,7 @@ class EventVenue extends Component {
 		const { coords } = this.state;
 		return (
 			<GoogleMap
-				size={ { width: 450, height: 353 } }
+				size={ { width: 450, height: 220 } }
 				coordinates={ coords }
 				address={ addressToMapString( getAddress( details ) ) }
 				interactive={ true }

--- a/src/modules/elements/google-map/element.js
+++ b/src/modules/elements/google-map/element.js
@@ -364,12 +364,17 @@ export default class GoogleMap extends Component {
 	}
 
 	renderIframe() {
+		const { size } = this.props;
+		let { width = 450, height = 350 } = size;
+		width = width ? `${ width }px` : width;
+		height = height ? `${ height }px` : height;
+
 		return (
 			<iframe
 				title="Venue Map"
 				src="https://www.google.com/maps/embed?pb=!1m10!1m8!1m3!1d65369183.36050215!2d0!3d0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sus!4v1633005420084!5m2!1sen!2sus" // eslint-disable-line max-len
-				width="450px"
-				height="300px"
+				width={ width }
+				height={ height }
 			/>
 		);
 	}

--- a/src/modules/elements/google-map/style.pcss
+++ b/src/modules/elements/google-map/style.pcss
@@ -29,6 +29,6 @@
 	.tribe-editor__venue--has-map & {
 		width: 49%;
 		flex-basis: 49%;
-		min-height: 270px;
+		min-height: 220px;
 	}
 }

--- a/src/resources/postcss/events-admin.pcss
+++ b/src/resources/postcss/events-admin.pcss
@@ -293,7 +293,7 @@
 
 .linked-post-wrapper {
 	tbody + tbody tr:first-child td {
-		padding-top: calc(var(--tec-spacer-4) + 2px);
+		padding-top: var(--tec-spacer-4);
 	}
 
 	tbody + tbody tr.saved_linked-post td,

--- a/src/resources/postcss/tribe-admin-single-blocks.pcss
+++ b/src/resources/postcss/tribe-admin-single-blocks.pcss
@@ -66,15 +66,20 @@
 		.tribe-block__venue__map {
 
 			@media screen and (min-width: 768px) {
-				width: 310px;
+				width: 53%;
+			}
+
+			iframe {
+				width: 100%;
 			}
 		}
 
 		.tribe-block__venue__meta {
+			margin-bottom: var(--tec-spacer-1);
 
 			@media screen and (min-width: 768px) {
 				margin-right: var(--tec-spacer-1);
-				width: 214px;
+				width: 47%;
 			}
 		}
 	}

--- a/src/resources/postcss/tribe-admin-single-blocks.pcss
+++ b/src/resources/postcss/tribe-admin-single-blocks.pcss
@@ -41,33 +41,40 @@
 /* = Venue block view styles
 ============================================= */
 .tribe-editor__venue {
-	border-top: 1px solid var(--tec-color-border-default);
-	flex-direction: column-reverse;
+	border: 1px solid var(--tec-color-border-secondary);
+	border-radius: var(--tec-border-radius-default);
+	flex-direction: column;
 	font-family: var(--tec-font-family-sans-serif);
 	justify-content: flex-start;
-	padding: 22.5px 0;
+	margin-top: var(--tec-spacer-6);
+	max-width: 580px;
+	padding: var(--tec-spacer-2);
 
 	@media screen and (min-width: 768px) {
 		flex-direction: row;
-		padding: 32px 0;
+		padding: var(--tec-spacer-5);
 	}
 
 	&.tribe-editor__venue--has-map {
 
-		.tribe-editor__venue--current,
-		.tribe-editor__map {
+		.tribe-block__venue__meta,
+		.tribe-block__venue__map {
 			flex: none;
 			width: 100%;
+		}
+
+		.tribe-block__venue__map {
 
 			@media screen and (min-width: 768px) {
-				width: 50%;
+				width: 310px;
 			}
 		}
 
-		.tribe-editor__venue--current {
-			@media screen and (min-width: 1200px) {
-				margin-right: 100px;
-				width: 35%;
+		.tribe-block__venue__meta {
+
+			@media screen and (min-width: 768px) {
+				margin-right: var(--tec-spacer-1);
+				width: 214px;
 			}
 		}
 	}

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -38,15 +38,18 @@
 /* = Venue block view styles
 ============================================= */
 .tribe-block__venue {
-	border-top: 1px solid var(--tec-color-border-default);
-	flex-direction: column-reverse;
+	border: 1px solid var(--tec-color-border-secondary);
+	border-radius: var(--tec-border-radius-default);
+	flex-direction: column;
 	font-family: var(--tec-font-family-sans-serif);
 	justify-content: flex-start;
-	padding: 22.5px 0;
+	margin-top: var(--tec-spacer-6);
+	max-width: 580px;
+	padding: var(--tec-spacer-2);
 
 	@media screen and (min-width: 768px) {
 		flex-direction: row;
-		padding: 32px 0;
+		padding: var(--tec-spacer-5);
 	}
 
 	&.tribe-block__venue--has-map {
@@ -55,31 +58,30 @@
 		.tribe-block__venue__map {
 			flex: none;
 			width: 100%;
+		}
+
+		.tribe-block__venue__map {
 
 			@media screen and (min-width: 768px) {
-				width: 50%;
+				width: 310px;
 			}
 		}
 
 		.tribe-block__venue__meta {
-			@media screen and (min-width: 1200px) {
-				margin-right: 20px;
-				width: 35%;
+
+			@media screen and (min-width: 768px) {
+				margin-right: var(--tec-spacer-1);
+				width: 214px;
 			}
 		}
 	}
 
 	.tribe-block__venue__meta {
-		margin-top: 24px;
-
-		@media screen and (min-width: 768px) {
-			margin-top: 0;
-		}
 
 		.tribe-block__venue__name {
 
 			h3 {
-				font-size: var(--tec-font-size-3);
+				font-size: var(--tec-font-size-2);
 				font-weight: normal;
 				letter-spacing: normal;
 				line-height: 1.64;
@@ -91,11 +93,15 @@
 
 			a {
 				color: var(--tec-color-link-accent);
-				margin-top: 17px;
+				margin-top: var(--tec-spacer-2);
 			}
 
 			.tribe-region.tribe-events-abbr {
 				text-decoration: none;
+			}
+
+			.tribe-country-name {
+				display: block;
 			}
 		}
 
@@ -107,6 +113,7 @@
 		.tribe-block__venue__phone,
 		.tribe-block__venue__website {
 			color: var(--tec-color-text-primary);
+			font-size: var(--tec-font-size-2);
 			font-weight: normal;
 			letter-spacing: normal;
 			line-height: 1.64;

--- a/src/resources/postcss/tribe-events-single-blocks.pcss
+++ b/src/resources/postcss/tribe-events-single-blocks.pcss
@@ -63,15 +63,20 @@
 		.tribe-block__venue__map {
 
 			@media screen and (min-width: 768px) {
-				width: 310px;
+				width: 53%;
+			}
+
+			iframe {
+				width: 100%;
 			}
 		}
 
 		.tribe-block__venue__meta {
+			margin-bottom: var(--tec-spacer-1);
 
 			@media screen and (min-width: 768px) {
 				margin-right: var(--tec-spacer-1);
-				width: 214px;
+				width: 47%;
 			}
 		}
 	}

--- a/src/styles/event-venue/frontend.pcss
+++ b/src/styles/event-venue/frontend.pcss
@@ -39,7 +39,6 @@
 			margin-bottom: 20px;
 
 			a {
-				color: #009FD4;
 				display: block;
 
 				&:hover {
@@ -73,6 +72,6 @@
 		justify-content: center;
 		text-align: center;
 		position: relative;
-		min-height: 270px;
+		min-height: 220px;
 	}
 }

--- a/src/views/blocks/event-venue.php
+++ b/src/views/blocks/event-venue.php
@@ -14,11 +14,13 @@
  * @var bool $show_map Whether to show the map or not.
  */
 
-$event_id = $this->get( 'post_id' );
-
-$map = $show_map ? 'tribe-block__venue--has-map' : '';
-
-$default_classes = [ 'tribe-block', 'tribe-block__venue', 'tribe-clearfix', $map ];
+$event_id        = $this->get( 'post_id' );
+$default_classes = [
+	'tribe-block',
+	'tribe-block__venue',
+	'tribe-clearfix',
+	'tribe-block__venue--has-map' => $show_map,
+];
 
 // Add the custom classes from the block attributes.
 $classes = isset( $attributes['className'] ) ? array_merge( $default_classes, [ $attributes['className'] ] ) : $default_classes;

--- a/src/views/blocks/parts/map.php
+++ b/src/views/blocks/parts/map.php
@@ -22,7 +22,7 @@ if ( ! $show_map ) {
 	return;
 }
 
-$map = tribe_get_embedded_map( $venue_id );
+$map = tribe_get_embedded_map( $venue_id, 310, 256 );
 
 if ( empty( $map ) ) {
 	return;

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -10,6 +10,7 @@
  * @link http://evnt.is/1aiy
  *
  * @version TBD
+ * @since TBD Added the `tec_events_view_venue_after_address` action.
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
  * @var string  $slug  The slug of the view.

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -12,6 +12,7 @@
  * @version 4.9.11
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
+ * @var string  $slug  The slug of the view.
  *
  * @see tribe_get_event() For the format of the event object.
  */
@@ -35,4 +36,5 @@ $address              = $venue->address . ( $venue->address && $append_after_add
 			<?php echo esc_html( reset( $append_after_address ) ); ?>
 		<?php endif; ?>
 	</span>
+	<?php do_action( 'tec_events_view_venue_after_address', $event->ID, $slug ); ?>
 </address>

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -9,7 +9,7 @@
  *
  * @link http://evnt.is/1aiy
  *
- * @version 4.9.11
+ * @version TBD
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
  * @var string  $slug  The slug of the view.

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -36,5 +36,5 @@ $address              = $venue->address . ( $venue->address && $append_after_add
 			<?php echo esc_html( reset( $append_after_address ) ); ?>
 		<?php endif; ?>
 	</span>
-	<?php do_action( 'tec_events_view_venue_after_address', $event->ID, $slug ); ?>
+	<?php do_action( 'tec_events_view_venue_after_address', $event, $slug ); ?>
 </address>

--- a/src/views/v2/day/event/venue.php
+++ b/src/views/v2/day/event/venue.php
@@ -36,5 +36,15 @@ $address              = $venue->address . ( $venue->address && $append_after_add
 			<?php echo esc_html( reset( $append_after_address ) ); ?>
 		<?php endif; ?>
 	</span>
-	<?php do_action( 'tec_events_view_venue_after_address', $event, $slug ); ?>
+	<?php
+	/**
+	 * Fires after the full venue has been displayed.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $event Event post object.
+	 * @param string  $slug  Slug of the view.
+	 */
+	do_action( 'tec_events_view_venue_after_address', $event, $slug );
+	?>
 </address>

--- a/src/views/v2/list/event/venue.php
+++ b/src/views/v2/list/event/venue.php
@@ -12,6 +12,7 @@
  * @version 4.9.11
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
+ * @var string  $slug  The slug of the view.
  *
  * @see tribe_get_event() For the format of the event object.
  */
@@ -30,18 +31,18 @@ $address              = $venue->address . ( $venue->address && ( $append_after_a
 		<?php echo wp_kses_post( $venue->post_title ); ?>
 	</span>
 	<span class="tribe-events-calendar-list__event-venue-address">
-		<?php 
-		echo esc_html( $address ); 
+		<?php
+		echo esc_html( $address );
 
-		if ( ! empty( $venue->city ) ) : 
+		if ( ! empty( $venue->city ) ) :
 			echo esc_html( $venue->city );
 			if ( $append_after_address ) :
 				echo $separator;
 			endif;
 		endif;
 
-		if ( $append_after_address ) : 
-			echo esc_html( reset( $append_after_address ) ); 
+		if ( $append_after_address ) :
+			echo esc_html( reset( $append_after_address ) );
 		endif;
 
 		if ( ! empty( $venue->country ) ):
@@ -49,4 +50,5 @@ $address              = $venue->address . ( $venue->address && ( $append_after_a
 		endif;
 		?>
 	</span>
+	<?php do_action( 'tec_events_view_venue_after_address', $event, $slug ); ?>
 </address>

--- a/src/views/v2/list/event/venue.php
+++ b/src/views/v2/list/event/venue.php
@@ -9,7 +9,8 @@
  *
  * @link http://evnt.is/1aiy
  *
- * @version 4.9.11
+ * @version TBD
+ * @since TBD Added the `tec_events_view_venue_after_address` action.
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
  * @var string  $slug  The slug of the view.

--- a/src/views/v2/list/event/venue.php
+++ b/src/views/v2/list/event/venue.php
@@ -50,5 +50,15 @@ $address              = $venue->address . ( $venue->address && ( $append_after_a
 		endif;
 		?>
 	</span>
-	<?php do_action( 'tec_events_view_venue_after_address', $event, $slug ); ?>
+	<?php
+	/**
+	 * Fires after the full venue has been displayed.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $event Event post object.
+	 * @param string  $slug  Slug of the view.
+	 */
+	do_action( 'tec_events_view_venue_after_address', $event, $slug );
+	?>
 </address>

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/Event/__snapshots__/VenueTest__test_render_with_event_with_venue__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Day_View/Event/__snapshots__/VenueTest__test_render_with_event_with_venue__1.php
@@ -3,5 +3,5 @@
 		Venue 2233 title	</span>
 	<span class="tribe-events-calendar-day__event-venue-address">
 		100 Rue de Le Chat, 					Paris			</span>
-</address>
+	</address>
 ';

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/Event/__snapshots__/VenueTest__test_render_with_event_with_venue__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/List_View/Event/__snapshots__/VenueTest__test_render_with_event_with_venue__1.php
@@ -3,5 +3,5 @@
 		Venue 2233 title	</span>
 	<span class="tribe-events-calendar-list__event-venue-address">
 		100 Rue de Le Chat, Paris, Ile de France, France	</span>
-</address>
+	</address>
 ';


### PR DESCRIPTION
This updates block styling for venues so that they have a card-like appearance and cease to be full width, which looks odd on wide spaces.

🎥 
* [single event](https://www.loom.com/share/612f072c754b4f5ebe5657d6f931469b?sid=e2b72d15-d3c0-442a-9c70-26248ee62d98)
* [multi-venue +x](https://www.loom.com/share/9d9776a710ed49f2baedf60266d300f9?sid=4c7ea5d4-68e8-46d1-b2e2-ae36956ae161)

🎫 [ECP-1540]

Related:
* https://github.com/the-events-calendar/tribe-common/pull/1963
* https://github.com/the-events-calendar/events-pro/pull/2290

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ