### PR TITLE
Publish venues and organizers on save of an event when it is published

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2969,16 +2969,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 						continue;
 					}
 
-					do_action( 'log', "publishing an event with a {$type}", 'tribe-events', $post );
-
 					$id_index = "{$linked_post_prefix}ID";
 
 					$linked_post_ids = is_array( $pm[ $id_index ] ) ? $pm[ $id_index ] : [ $pm[ $id_index ] ];
 					if ( empty( $linked_post_ids ) ) {
 						continue;
 					}
-
-					do_action( 'log', "event has at least one {$type}", 'tribe-events', print_r( $linked_post_ids, true ) );
 
 					foreach ( $linked_post_ids as $linked_post_id ) {
 						if ( ! $linked_post_id ) {
@@ -2990,7 +2986,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 							continue;
 						}
 
-						do_action( 'log', "{$type} post found", 'tribe-events', $linked_post );
 						wp_publish_post( $linked_post_id );
 					}
 				}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2965,11 +2965,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				];
 
 				foreach ( $linked_post_prefixes as $type => $linked_post_prefix ) {
-					if ( empty( $pm[ "{$linked_post_prefix}ID" ] ) ) {
+					$id_index = "{$linked_post_prefix}ID";
+
+					if ( empty( $pm[ $id_index ] ) ) {
 						continue;
 					}
-
-					$id_index = "{$linked_post_prefix}ID";
 
 					$linked_post_ids = is_array( $pm[ $id_index ] ) ? $pm[ $id_index ] : [ $pm[ $id_index ] ];
 					if ( empty( $linked_post_ids ) ) {

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2978,10 +2978,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 							continue;
 						}
 
-						$linked_post = get_post( $linked_post_id );
-						if ( empty( $linked_post ) || $linked_post->post_status === 'publish' || $linked_post->post_status === 'private' ) {
-							continue;
-						}
+						if ( in_array( get_post_status( $linked_post_id ), [ 'publish', 'private' ], true ) ) {
 
 						wp_publish_post( $linked_post_id );
 					}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2972,9 +2972,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 					}
 
 					$linked_post_ids = is_array( $pm[ $id_index ] ) ? $pm[ $id_index ] : [ $pm[ $id_index ] ];
-					if ( empty( $linked_post_ids ) ) {
-						continue;
-					}
 
 					foreach ( $linked_post_ids as $linked_post_id ) {
 						if ( ! $linked_post_id ) {

--- a/tests/wpunit/Tribe/Events/Linked_Posts/Publish_AssociatedTest.php
+++ b/tests/wpunit/Tribe/Events/Linked_Posts/Publish_AssociatedTest.php
@@ -1,0 +1,113 @@
+<?php
+namespace Tribe\Events\Linked_Posts;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Events\Test\Factories\Event;
+use Tribe\Events\Test\Factories\Organizer;
+use Tribe\Events\Test\Factories\Venue;
+use Tribe__Events__Main;
+
+class Publish_AssociatedTest extends WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		$this->factory()->event = new Event();
+		$this->factory()->organizer = new Organizer();
+		$this->factory()->venue = new Venue();
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_publish_non_private_linked_posts() {
+		$venue_1_id = $this->factory()->venue->create( [
+			'post_status' => 'draft',
+		] );
+		$venue_2_id = $this->factory()->venue->create( [
+			'post_status' => 'private',
+		] );
+		$venue_3_id = $this->factory()->venue->create( [
+			'post_status' => 'pending',
+		] );
+		$organizer_1_id = $this->factory()->organizer->create( [
+			'post_status' => 'draft',
+		] );
+		$organizer_2_id = $this->factory()->organizer->create( [
+			'post_status' => 'future',
+			'post_date'   => date( 'Y-m-d 00:00:00', strtotime( '+1 month' ) ),
+		] );
+		$organizer_3_id = $this->factory()->organizer->create( [
+			'post_status' => 'trash',
+		] );
+
+		$event_args = [
+			'post_status' => 'publish',
+		];
+
+		$event_id = $this->factory()->event->create( $event_args );
+
+		$meta_ids = [
+			'venue'     => [
+				$venue_1_id,
+				$venue_2_id,
+				$venue_3_id,
+			],
+			'organizer' => [
+				$organizer_1_id,
+				$organizer_2_id,
+				$organizer_3_id,
+			],
+		];
+
+		foreach ( $meta_ids['venue'] as $id ) {
+			add_post_meta( $event_id, '_EventVenueID', $id );
+		}
+
+		foreach ( $meta_ids['organizer'] as $id ) {
+			add_post_meta( $event_id, '_EventOrganizerID', $id );
+		}
+
+		/** @var Tribe__Events__Main $main */
+		$main = tribe( 'tec.main' );
+
+		$event       = tribe_events()->where( 'ID', $event_id )->first();
+		$venue_1     = get_post( $venue_1_id );
+		$venue_2     = get_post( $venue_2_id );
+		$venue_3     = get_post( $venue_3_id );
+		$organizer_1 = get_post( $organizer_1_id );
+		$organizer_2 = get_post( $organizer_2_id );
+		$organizer_3 = get_post( $organizer_3_id );
+
+		$this->assertEquals( 'draft', $venue_1->post_status );
+		$this->assertEquals( 'private', $venue_2->post_status );
+		$this->assertEquals( 'pending', $venue_3->post_status );
+		$this->assertEquals( 'draft', $organizer_1->post_status );
+		$this->assertEquals( 'future', $organizer_2->post_status );
+		$this->assertEquals( 'trash', $organizer_3->post_status );
+
+		$main->publishAssociatedTypes( $event_id, $event );
+
+		$venue_1     = get_post( $venue_1_id );
+		$venue_2     = get_post( $venue_2_id );
+		$venue_3     = get_post( $venue_3_id );
+		$organizer_1 = get_post( $organizer_1_id );
+		$organizer_2 = get_post( $organizer_2_id );
+		$organizer_3 = get_post( $organizer_3_id );
+
+		$this->assertEquals( 'publish', $venue_1->post_status );
+		$this->assertEquals( 'private', $venue_2->post_status );
+		$this->assertEquals( 'publish', $venue_3->post_status );
+		$this->assertEquals( 'publish', $organizer_1->post_status );
+		$this->assertEquals( 'publish', $organizer_2->post_status );
+		$this->assertEquals( 'publish', $organizer_3->post_status );
+	}
+}


### PR DESCRIPTION
This reworks the `publishAssociatedTypes()` method to support arrays of organizers and venues and also updates the logic to accommodate changing any post status except `private` to publish.

:ticket: [ECP-1540]
🎥 https://www.loom.com/share/16e9aa58d0514d29b4ae4e4866cb560a

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ