### PR TITLE
Show the checkboxes for ShowMap and ShowMapLink

### DIFF
--- a/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
+++ b/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
@@ -145,7 +145,6 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 		$i           = 0;
 		$num_records = count( $current_linked_posts );
 
-
 		do {
 			echo '<tbody>';
 			$this->single_post_dropdown( isset( $current_linked_posts[ $i ] ) ? $current_linked_posts[ $i ] : 0 );
@@ -245,10 +244,6 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 	 * Renders the "Add Another Organizer" button
 	 */
 	protected function render_add_post_button() {
-		if ( ! $this->linked_posts->allow_multiple( $this->post_type ) ) {
-			return;
-		}
-
 		$classes = [ 'tribe-add-post' ];
 
 		if ( is_admin() ) {

--- a/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
+++ b/src/Tribe/Linked_Posts/Chooser_Meta_Box.php
@@ -73,7 +73,7 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 	public function render() {
 
 		$this->render_dropdowns();
-		$this->render_add_post_button();
+		$this->render_footer();
 
 		/**
 		 * Make this Template filterable, used for Community Facing templates.
@@ -241,9 +241,29 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 	}
 
 	/**
+	 * Renders the footer for the linked post area.
+	 *
+	 * @since TBD
+	 */
+	protected function render_footer() {
+		?>
+		<tfoot>
+		<?php
+		$this->render_add_post_button();
+		$this->render_map_fields();
+		?>
+		</tfoot>
+		<?php
+	}
+
+	/**
 	 * Renders the "Add Another Organizer" button
 	 */
 	protected function render_add_post_button() {
+		if ( ! $this->linked_posts->allow_multiple( $this->post_type ) ) {
+			return;
+		}
+
 		$classes = [ 'tribe-add-post' ];
 
 		if ( is_admin() ) {
@@ -254,18 +274,24 @@ class Tribe__Events__Linked_Posts__Chooser_Meta_Box {
 		}
 
 		?>
-		<tfoot>
-			<tr>
-				<td></td>
-				<td><a class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" href="#"><?php echo esc_html( sprintf( __( 'Add another %s', 'the-events-calendar' ), $this->singular_name_lowercase ) ); ?></a></td>
-			</tr>
-			<?php
-			if ( $this->post_type === Tribe__Events__Venue::POSTTYPE ) {
-				require_once $this->tribe->pluginPath . 'src/admin-views/venue-map-fields.php';
-			}
-			?>
-		</tfoot>
+		<tr>
+			<td></td>
+			<td><a class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" href="#"><?php echo esc_html( sprintf( __( 'Add another %s', 'the-events-calendar' ), $this->singular_name_lowercase ) ); ?></a></td>
+		</tr>
 		<?php
+	}
+
+	/**
+	 * Renders the map fields if necessary.
+	 *
+	 * @since TBD
+	 */
+	protected function render_map_fields() {
+		if ( $this->post_type !== Tribe__Events__Venue::POSTTYPE ) {
+			return;
+		}
+
+		require_once $this->tribe->pluginPath . 'src/admin-views/venue-map-fields.php';
 	}
 
 	/**


### PR DESCRIPTION
I accidentally hid the checkboxes behind a check for multiple venues (which is only enabled with Pro active), which was a silly thing to do. Rolling that back.

:ticket: [ECP-1540]

Here they are in all of their glory with Pro deactivated:
![Screenshot 2023-08-03 144726](https://github.com/the-events-calendar/the-events-calendar/assets/430385/61c14c83-a89f-4695-9fbd-59c1d6478037)


[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ