### PR TITLE
Set venue defaults from block editor and pass state/stateProvince

### DIFF
--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -92,12 +92,15 @@ class Tribe__Events__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta( 'post', '_VenueCity', $this->text() );
 		register_meta( 'post', '_VenueCountry', $this->text() );
 		register_meta( 'post', '_VenueProvince', $this->text() );
+		register_meta( 'post', '_VenueState', $this->text() );
 		register_meta( 'post', '_VenueZip', $this->text() );
 		register_meta( 'post', '_VenuePhone', $this->text() );
 		register_meta( 'post', '_VenueURL', $this->text() );
 		register_meta( 'post', '_VenueStateProvince', $this->text() );
 		register_meta( 'post', '_VenueLat', $this->text() );
 		register_meta( 'post', '_VenueLng', $this->text() );
+		register_meta( 'post', '_VenueShowMap', $this->boolean() );
+		register_meta( 'post', '_VenueShowMapLink', $this->boolean() );
 	}
 
 	/**

--- a/src/modules/blocks/event-venue/container.js
+++ b/src/modules/blocks/event-venue/container.js
@@ -17,6 +17,7 @@ import { actions, selectors } from '@moderntribe/events/data/blocks/venue';
 import { actions as detailsActions } from '@moderntribe/events/data/details';
 import { editor } from '@moderntribe/common/data';
 import { syncVenuesWithPost } from "./data/meta-sync";
+import { globals } from '@moderntribe/common/utils';
 const { getState } = store;
 
 /**

--- a/src/modules/blocks/event-venue/data/meta-sync.js
+++ b/src/modules/blocks/event-venue/data/meta-sync.js
@@ -3,6 +3,8 @@
  */
 import { selectors } from '@moderntribe/events/data/blocks/venue';
 import { wpData } from '@moderntribe/common/utils/globals';
+import { store } from '@moderntribe/common/store';
+const { getState } = store;
 
 /**
  * Synchronizes venues in the state with the meta of the post.

--- a/src/modules/data/blocks/venue/subscribers.js
+++ b/src/modules/data/blocks/venue/subscribers.js
@@ -14,6 +14,7 @@ import {
 	actions as venueActions,
 	selectors as venueSelectors,
 } from '@moderntribe/events/data/blocks/venue';
+import { syncVenuesWithPost } from '@moderntribe/events/blocks/event-venue/data/meta-sync';
 import { actions as requestActions } from '@moderntribe/common/store/middlewares/request';
 
 const { getState, dispatch } = store;
@@ -101,24 +102,7 @@ export const handleBlockRemoved = ( currBlocks ) => ( block ) => {
 		globals.wpHooks.doAction( 'tec.events.blocks.venue.maybeRemoveVenue', venue );
 	}
 
-	syncVenuesWithPostMeta();
-};
-
-/**
- * Synchronizes venues in blocks with post meta.
- *
- * @since TBD
- */
-export const syncVenuesWithPostMeta = () => {
-	const blockVenues = venueSelectors.getVenuesInBlock( getState() );
-	const postId = globals.wpData.select( 'core/editor' ).getCurrentPostId();
-	const record = {
-		meta: {
-			_EventVenueID: blockVenues,
-		},
-	};
-
-	globals.wpData.dispatch( 'core' ).editEntityRecord( 'postType', editor.EVENT, postId, record );
+	syncVenuesWithPost();
 };
 
 /**

--- a/src/modules/elements/search-or-create/template.js
+++ b/src/modules/elements/search-or-create/template.js
@@ -125,6 +125,11 @@ class SearchOrCreate extends Component {
 			{ 'tribe-editor__soc__input__container--active': isSelected },
 		);
 
+		let currentTerm = '';
+		if ( isSelected ) {
+			currentTerm = term;
+		}
+
 		return (
 			<section className="tribe-soc__container">
 				<div className={ containerClass }>
@@ -132,7 +137,7 @@ class SearchOrCreate extends Component {
 					<input
 						className="tribe-editor__soc__input"
 						ref={ this.inputRef }
-						value={ term }
+						value={ currentTerm }
 						placeholder={ placeholder }
 						onChange={ onInputChange }
 					/>

--- a/src/modules/elements/search-or-create/template.js
+++ b/src/modules/elements/search-or-create/template.js
@@ -125,10 +125,7 @@ class SearchOrCreate extends Component {
 			{ 'tribe-editor__soc__input__container--active': isSelected },
 		);
 
-		let currentTerm = '';
-		if ( isSelected ) {
-			currentTerm = term;
-		}
+		const currentTerm = isSelected ? term : '';
 
 		return (
 			<section className="tribe-soc__container">

--- a/src/modules/elements/venue-form/element.js
+++ b/src/modules/elements/venue-form/element.js
@@ -62,12 +62,15 @@ export function toVenue( fields ) {
 		meta: {
 			_VenueAddress: address,
 			_VenueCity: city,
-			_VenueCountry: get( list.countries, country, '' ) || country,
-			_VenueProvince: get( list.us_states, stateProvince, '' ) || stateProvince,
+			_VenueCountry: country,
+			_VenueProvince: stateProvince,
 			_VenueZip: zip,
 			_VenuePhone: phone,
 			_VenueURL: url,
+			_VenueState: stateProvince,
 			_VenueStateProvince: stateProvince,
+			_VenueShowMap: true,
+			_VenueShowMapLink: true,
 		},
 	};
 }


### PR DESCRIPTION
This set of fixes resolves a couple of things:

1. Venues created in the block editor will now default to having ShowMap and ShowMapLink set to true
2. Venues created in the block editor will now properly pass State, Province, and stateProvince to the backend
3. When you have multiple empty Organizer or Venue blocks and you start typing in one, text does not appear in all of them, just in the block you are typing in

:ticket: [ECP-1540]
🎥 https://www.loom.com/share/c98ddc6e6a5141e191029a398bde62d6?sid=fd545b83-099e-43a3-b7dd-bb79d2cddc59

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ