### PR TITLE
Prevent adding venues from breaking the event

### DIFF
--- a/src/modules/blocks/event-venue/data/meta-sync.js
+++ b/src/modules/blocks/event-venue/data/meta-sync.js
@@ -3,6 +3,7 @@
  */
 import { selectors } from '@moderntribe/events/data/blocks/venue';
 import { wpData } from '@moderntribe/common/utils/globals';
+import { editor } from '@moderntribe/common/data';
 import { store } from '@moderntribe/common/store';
 const { getState } = store;
 
@@ -12,14 +13,13 @@ const { getState } = store;
  * @since TBD
  */
 export const syncVenuesWithPost = () => {
-	let currentPost = wpData.select( 'core/editor' ).getCurrentPost();
-	let modifiedPost = {
-		...currentPost,
+	const currentPost = wpData.select( 'core/editor' ).getCurrentPost();
+	const postId = wpData.select( 'core/editor' ).getCurrentPostId();
+	const modifiedPost = {
 		meta: {
-			...currentPost.meta,
 			_EventVenueID: selectors.getVenuesInBlock( getState() ),
 		}
 	};
 
-	wpData.dispatch( 'core/editor' ).editPost( modifiedPost );
+	wpData.dispatch( 'core' ).editEntityRecord( 'postType', editor.EVENT, postId, modifiedPost );
 };


### PR DESCRIPTION
This is a simple swap to using the proper editor function: `editEntityRecord()` rather than `editPost()`

:ticket: [ECP-1540]
:movie_camera: https://www.loom.com/share/d2a9e6b6e9e1444cb92b80e27dc3ad96

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ