### PR TITLE
Ensure we output valid html.

### DIFF
--- a/src/views/modules/meta/organizer.php
+++ b/src/views/modules/meta/organizer.php
@@ -75,6 +75,17 @@ $website_title = tribe_events_get_organizer_website_title();
 					<dt class="tribe-organizer-url-label">
 						<?php echo esc_html( $website_title ) ?>
 					</dt>
+				<?php else: ?>
+					<dt
+						class="tribe-common-a11y-visual-hide"
+						aria-label="<?php echo sprintf(
+							/* Translators: %1$s is the customizable organizer term, e.g. "Organizer website title" */
+							esc_html_x( '%1$s website title', "The label for the organizer's website title.", 'the-events-calendar' ),
+							tribe_get_organizer_label_singular()
+						) ; ?>"
+					>
+						<?php // This element is only present to ensure we have a valid HTML, it'll be hidden from browsers but visible to screenreaders for accessibility. ?>
+					</dt>
 				<?php endif; ?>
 				<dd class="tribe-organizer-url">
 					<?php echo $website; ?>

--- a/src/views/modules/meta/venue.php
+++ b/src/views/modules/meta/venue.php
@@ -65,6 +65,17 @@ $website_title = tribe_events_get_venue_website_title();
 		<?php if ( ! empty( $website ) ): ?>
 			<?php if ( ! empty( $website_title ) ): ?>
 				<dt class="tribe-venue-url-label"> <?php echo esc_html( $website_title ) ?> </dt>
+			<?php else: ?>
+				<dt
+					class="tribe-common-a11y-visual-hide"
+					aria-label="<?php echo sprintf(
+						/* Translators: %1$s is the customizable venue term, e.g. "Venue website title" */
+						esc_html_x( '%1$s website title', "The label for the venue's website title.", 'the-events-calendar' ),
+						tribe_get_venue_label_singular()
+					) ; ?>"
+				>
+					<?php // This element is only present to ensure we have a valid HTML, it'll be hidden from browsers but visible to screenreaders for accessibility. ?>
+				</dt>
 			<?php endif ?>
 			<dd class="tribe-venue-url"> <?php echo $website ?> </dd>
 		<?php endif ?>


### PR DESCRIPTION
Ticket : [TEC-4812](https://theeventscalendar.atlassian.net/browse/TEC-4812)

Display an empty `<dt>` tag before `<dd>` even when the website title isn't available to ensure we always output valid html.

**Screenshot 📸**

![image](https://github.com/the-events-calendar/the-events-calendar/assets/22029087/03eec004-534e-4464-a11a-6871980e9a57)

[TEC-4812]: https://theeventscalendar.atlassian.net/browse/TEC-4812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ