### PR TITLE
Resolve venue duplication, state saving, and button handling issues

### DIFF
--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -957,7 +957,7 @@ class Tribe__Events__Linked_Posts {
 			}
 
 			// Remove all pre-existing (and non-removed) linked posts to start fresh by re-adding below (for `meta_id` ordering purposes)
-			if ( ! empty( $temp_prior_linked_posts ) ) {
+			if ( ! empty( $temp_old_order ) ) {
 				delete_post_meta( $event_id, $linked_post_type_meta_key );
 			}
 
@@ -1264,7 +1264,9 @@ class Tribe__Events__Linked_Posts {
 				data-force-search
 				<?php endif; ?>
 			>
-				<option></option>
+				<option value="-1" <?php selected( empty( $current ) ); ?>>
+					<?php echo esc_html( $label ); ?>
+				</option>
 				<?php if ( ! empty( $data[0]['children'] ) ) : ?>
 					<?php foreach ( $data as $group ) : ?>
 						<optgroup label="<?php echo esc_attr( $group['text'] ); ?>">

--- a/src/admin-views/create-venue-fields.php
+++ b/src/admin-views/create-venue-fields.php
@@ -149,7 +149,7 @@ if ( ! $_POST ) {
 			class="tribe-dropdown"
 			tabindex="<?php tribe_events_tab_index(); ?>"
 			id="StateProvinceSelect"
-			name="venue[State]"
+			name="venue[State][]"
 			aria-label="<?php esc_html_e( 'Venue State', 'the-events-calendar' ); ?>"
 			data-prevent-clear
 		>

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -364,7 +364,7 @@ jQuery( function( $ ) {
 			group.append( fields );
 		} );
 
-		section.on( 'click', '.tribe-delete-this', function(e) {
+		$( document ).on( 'click', `#event_${post_type} .tribe-delete-this`, function(e) {
 			e.preventDefault();
 			var $group = $( this ).closest( 'tbody' );
 
@@ -383,6 +383,8 @@ jQuery( function( $ ) {
 					section.find( '.tribe-delete-this' ).hide();
 					section.find( '.move-linked-post-group' ).hide();
 				}
+
+				showOrHideAddPostButton( section );
 			} );
 		});
 
@@ -436,11 +438,11 @@ jQuery( function( $ ) {
 		$edit.hide();
 		$wrapper.find( 'tfoot .tribe-add-post' ).show();
 
-		if ( ! existingPost && value ) {
+		if ( ! existingPost && value !== '-1' && value ) {
 			// Apply the New Given Title to the Correct Field
 			$group.find( '.linked-post-name' ).val( value ).parents( '.linked-post' ).eq( 0 ).attr( 'data-hidden', true );
 
-			$select.val( '' );
+			$select.val( '-1' );
 
 			// Display the Fields
 			$group
@@ -460,14 +462,42 @@ jQuery( function( $ ) {
 			}
 		}
 
+		showOrHideAddPostButton( $wrapper );
+	};
+
+	/**
+	 * Shows or hides the Add <Post> button.
+	 *
+	 * @since TBD
+	 * @param {Object} $wrapper The jQuery object for the wrapper of the linked post fields.
+	 */
+	function showOrHideAddPostButton( $wrapper ) {
+		const $groups = $wrapper.find( 'tbody' );
+		const linkedPostCount = $groups.length;
+
+		const $select = $wrapper.find( 'tbody' ).last().find( 'select' );
+		const value = $select.val();
+		const $selected = $select.find( ':selected' );
+		const selectedVal = $selected.val();
+		const $group = $select.closest( 'tbody' );
+
+		const currentGroupPosition = $groups.index( $group ) + 1;
+		let existingPost = false;
+
+		if ( selectedVal === value ) {
+			existingPost = !! $selected.data( 'existingPost' );
+		}
+
 		if (
 			! existingPost &&
-			! value &&
+			( ! value || value === '-1' ) &&
 			currentGroupPosition === linkedPostCount
 		) {
 			$wrapper.find( 'tfoot .tribe-add-post' ).hide();
+		} else {
+			$wrapper.find( 'tfoot .tribe-add-post' ).show();
 		}
-	};
+	}
 
 	$( '.hide-if-js' ).hide();
 


### PR DESCRIPTION
This resolves 3 primary things:

1. **Fixed:** When a new venue was added to the event and save/publish/update was hit, the pre-existing venues were being duplicated on the event post.
1. **Fixed:** When a new venue was created from the event post editor, the state was not saving appropriately.
1. **Fixed:** When a new venue select box was added to the page and then the trash icon was clicked, the add venue button would not re-appear

:ticket: [ECP-1540]
:movie_camera: https://www.loom.com/share/2cd8a6079f6d4a3a922206d724fe9bd2?sid=92951c45-124f-403d-9b2e-ba3ef613f94d

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ