### PR TITLE
Block Editor - Support for custom CSS classes.

### DIFF
--- a/src/views/blocks/featured-image.php
+++ b/src/views/blocks/featured-image.php
@@ -7,7 +7,7 @@
  *
  * See more documentation about our Blocks Editor templating system.
  *
- * @link http://evnt.is/1aiy
+ * @link    http://evnt.is/1aiy
  *
  * @version 4.7
  *
@@ -15,4 +15,17 @@
 
 $event_id = $this->get( 'post_id' );
 
-echo tribe_event_featured_image( $event_id, 'full', false );
+// Get the custom class from the block attributes.
+$class = isset( $attributes['className'] ) ? $attributes['className'] : '';
+
+// Generate the featured image HTML.
+$featured_image = tribe_event_featured_image( $event_id, 'full', false );
+
+// If a featured image and custom class are present, append the custom class to the parent container.
+if ( $featured_image && $class ) {
+	$search_pattern  = 'class="tribe-events-event-image"';
+	$replace_pattern = 'class="tribe-events-event-image ' . esc_attr( $class ) . '"';
+	$featured_image  = str_replace( $search_pattern, $replace_pattern, $featured_image );
+}
+
+echo $featured_image;

--- a/src/views/blocks/parts/subscribe-list.php
+++ b/src/views/blocks/parts/subscribe-list.php
@@ -19,8 +19,13 @@ if ( empty( $items ) ) {
 }
 
 remove_filter( 'the_content', 'do_blocks', 9 );
+
+$default_classes = [ 'tribe-block', 'tribe-block__events-link' ];
+
+// Add the custom classes from the block attributes.
+$classes = isset( $attributes['className'] ) ? array_merge( $default_classes, [ $attributes['className'] ] ) : $default_classes;
 ?>
-	<div class="tribe-block tribe-block__events-link">
+	<div <?php tribe_classes( $classes ); ?>>
 		<div class="tribe-events tribe-common">
 			<div class="tribe-events-c-subscribe-dropdown__container">
 				<div class="tribe-events-c-subscribe-dropdown">

--- a/src/views/blocks/parts/subscribe-single.php
+++ b/src/views/blocks/parts/subscribe-single.php
@@ -22,8 +22,13 @@ if ( ! $item instanceof Link_Abstract ) {
 }
 
 remove_filter( 'the_content', 'do_blocks', 9 );
+
+$default_classes = [ 'tribe-block', 'tribe-block__events-link' ];
+
+// Add the custom classes from the block attributes.
+$classes = isset( $attributes['className'] ) ? array_merge( $default_classes, [ $attributes['className'] ] ) : $default_classes;
 ?>
-	<div class="tribe-block tribe-block__events-link">
+	<div <?php tribe_classes( $classes ); ?>>
 		<div class="tribe-events tribe-common">
 			<div class="tribe-events-c-ical tribe-common-b2 tribe-common-b3--min-medium">
 				<a

--- a/tests/views_integration/Tribe/Events/Views/Blocks/Event_LinksTest.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/Event_LinksTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tribe\Events\Views\Blocks;
+
+use Spatie\Snapshots\MatchesSnapshots;
+use Tribe\Test\Products\WPBrowser\Views\V2\HtmlTestCase;
+use Tribe__Events__Editor__Blocks__Event_Links;
+
+class Event_LinksTest extends HtmlTestCase {
+	use MatchesSnapshots;
+
+	protected $block_content;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$block = new Tribe__Events__Editor__Blocks__Event_Links();
+
+		ob_start();
+		echo $block->render();
+
+		$this->block_content = ob_get_clean();
+	}
+
+	/**
+	 * Test that the block is rendered.
+	 */
+	public function test_block_is_rendered() {
+		$this->assertStringContainsString( 'tribe-block', $this->block_content );
+		$this->assertStringContainsString( 'tribe-block__events-link', $this->block_content );
+	}
+
+	/**
+	 * Test that the block is rendered with no custom classes.
+	 */
+	public function test_render_no_custom_classes() {
+		$this->assertMatchesSnapshot( $this->block_content );
+	}
+
+	/**
+	 * Test that the block is rendered with single custom class.
+	 */
+	public function test_render_with_single_custom_class() {
+		$block_with_custom_class = new Tribe__Events__Editor__Blocks__Event_Links();
+		$custom_class_content    = $block_with_custom_class->render( [ 'className' => 'custom-class' ] );
+
+		$this->assertMatchesSnapshot( $custom_class_content );
+	}
+
+	/**
+	 * Test that the block is rendered with single custom class.
+	 */
+	public function test_render_with_multiple_custom_classes() {
+		$block_with_custom_class = new Tribe__Events__Editor__Blocks__Event_Links();
+		$custom_class_content    = $block_with_custom_class->render( [ 'className' => 'custom-class custom-class-2' ] );
+
+		$this->assertMatchesSnapshot( $custom_class_content );
+	}
+}

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_no_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_no_custom_classes__1.php
@@ -1,0 +1,63 @@
+<?php return '	<div  class="tribe-block tribe-block__events-link" >
+		<div class="tribe-events tribe-common">
+			<div class="tribe-events-c-subscribe-dropdown__container">
+				<div class="tribe-events-c-subscribe-dropdown">
+					<div class="tribe-common-c-btn-border tribe-events-c-subscribe-dropdown__button" tabindex="0">
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--cal-export tribe-events-c-subscribe-dropdown__export-icon"  viewBox="0 0 23 17" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M.128.896V16.13c0 .211.145.383.323.383h15.354c.179 0 .323-.172.323-.383V.896c0-.212-.144-.383-.323-.383H.451C.273.513.128.684.128.896Zm16 6.742h-.901V4.679H1.009v10.729h14.218v-3.336h.901V7.638ZM1.01 1.614h14.218v2.058H1.009V1.614Z" />
+  <path d="M20.5 9.846H8.312M18.524 6.953l2.89 2.909-2.855 2.855" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+						<button class="tribe-events-c-subscribe-dropdown__button-text">
+							Add to calendar						</button>
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tribe-events-c-subscribe-dropdown__button-icon"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+					</div>
+					<div class="tribe-events-c-subscribe-dropdown__content">
+						<ul class="tribe-events-c-subscribe-dropdown__list" tabindex="0">
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Google Calendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										iCalendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook 365									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook Live									</a>
+								</li>
+													</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+';

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_multiple_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_multiple_custom_classes__1.php
@@ -1,0 +1,63 @@
+<?php return '	<div  class="tribe-block tribe-block__events-link custom-class custom-class-2" >
+		<div class="tribe-events tribe-common">
+			<div class="tribe-events-c-subscribe-dropdown__container">
+				<div class="tribe-events-c-subscribe-dropdown">
+					<div class="tribe-common-c-btn-border tribe-events-c-subscribe-dropdown__button" tabindex="0">
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--cal-export tribe-events-c-subscribe-dropdown__export-icon"  viewBox="0 0 23 17" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M.128.896V16.13c0 .211.145.383.323.383h15.354c.179 0 .323-.172.323-.383V.896c0-.212-.144-.383-.323-.383H.451C.273.513.128.684.128.896Zm16 6.742h-.901V4.679H1.009v10.729h14.218v-3.336h.901V7.638ZM1.01 1.614h14.218v2.058H1.009V1.614Z" />
+  <path d="M20.5 9.846H8.312M18.524 6.953l2.89 2.909-2.855 2.855" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+						<button class="tribe-events-c-subscribe-dropdown__button-text">
+							Add to calendar						</button>
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tribe-events-c-subscribe-dropdown__button-icon"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+					</div>
+					<div class="tribe-events-c-subscribe-dropdown__content">
+						<ul class="tribe-events-c-subscribe-dropdown__list" tabindex="0">
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Google Calendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										iCalendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook 365									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook Live									</a>
+								</li>
+													</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+';

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_single_custom_class__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_single_custom_class__1.php
@@ -1,0 +1,63 @@
+<?php return '	<div  class="tribe-block tribe-block__events-link custom-class" >
+		<div class="tribe-events tribe-common">
+			<div class="tribe-events-c-subscribe-dropdown__container">
+				<div class="tribe-events-c-subscribe-dropdown">
+					<div class="tribe-common-c-btn-border tribe-events-c-subscribe-dropdown__button" tabindex="0">
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--cal-export tribe-events-c-subscribe-dropdown__export-icon"  viewBox="0 0 23 17" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M.128.896V16.13c0 .211.145.383.323.383h15.354c.179 0 .323-.172.323-.383V.896c0-.212-.144-.383-.323-.383H.451C.273.513.128.684.128.896Zm16 6.742h-.901V4.679H1.009v10.729h14.218v-3.336h.901V7.638ZM1.01 1.614h14.218v2.058H1.009V1.614Z" />
+  <path d="M20.5 9.846H8.312M18.524 6.953l2.89 2.909-2.855 2.855" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+						<button class="tribe-events-c-subscribe-dropdown__button-text">
+							Add to calendar						</button>
+						<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tribe-events-c-subscribe-dropdown__button-icon"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+					</div>
+					<div class="tribe-events-c-subscribe-dropdown__content">
+						<ul class="tribe-events-c-subscribe-dropdown__list" tabindex="0">
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Google Calendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										iCalendar									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook 365									</a>
+								</li>
+															<li class="tribe-events-c-subscribe-dropdown__list-item">
+									<a
+										href=""
+										class="tribe-events-c-subscribe-dropdown__list-item-link"
+										tabindex="0"
+										target="_blank"
+										rel="noopener noreferrer nofollow noindex"
+									>
+										Outlook Live									</a>
+								</li>
+													</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+';


### PR DESCRIPTION
Ticket : [TEC-4724](https://theeventscalendar.atlassian.net/browse/TEC-4724)

Output custom CSS classes added to the `Event Links` and `Featured Image` blocks to the block output in the frontend.

This is a QA kickback so no need for a change log entry. 

**Screenshots 📸**

Custom classes added to Event Links block.

![image](https://github.com/the-events-calendar/the-events-calendar/assets/22029087/9b57b6cc-418a-4ed3-8255-60c101912ea0)

![image](https://github.com/the-events-calendar/the-events-calendar/assets/22029087/55a55543-7d98-4f59-a374-8cab43c32c05)

Custom classes added to Featured Image block.

![image](https://github.com/the-events-calendar/the-events-calendar/assets/22029087/25dc8213-6eaf-4842-8d25-897712c35ae8)


[TEC-4724]: https://theeventscalendar.atlassian.net/browse/TEC-4724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ