### PR TITLE
Ensure that the EventShowMap(Link) values are always set

### DIFF
--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -787,6 +787,22 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				}
 			}
 
+			$is_post_editor = ! empty( $args['action'] ) && $args['action'] === 'editpost';
+
+			if ( $is_post_editor ) {
+				if ( ! empty( $args['EventShowMap'] ) ) {
+					$args['EventShowMap'] = false;
+				} else {
+					$args['EventShowMap'] = true;
+				}
+
+				if ( empty( $args['EventShowMapLink'] ) ) {
+					$args['EventShowMapLink'] = false;
+				} else {
+					$args['EventShowMapLink'] = true;
+				}
+			}
+
 			return $args;
 		}
 

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -790,17 +790,8 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 			$is_post_editor = ! empty( $args['action'] ) && $args['action'] === 'editpost';
 
 			if ( $is_post_editor ) {
-				if ( ! empty( $args['EventShowMap'] ) ) {
-					$args['EventShowMap'] = false;
-				} else {
-					$args['EventShowMap'] = true;
-				}
-
-				if ( empty( $args['EventShowMapLink'] ) ) {
-					$args['EventShowMapLink'] = false;
-				} else {
-					$args['EventShowMapLink'] = true;
-				}
+				$args['EventShowMap']     = ! empty( $args['EventShowMap'] );
+				$args['EventShowMapLink'] = ! empty( $args['EventShowMapLink'] );
 			}
 
 			return $args;


### PR DESCRIPTION
This prevents weird cases where the form fields are not passed when checkboxes are unchecked, thus, failing to update the desired state.  Instead, we say:

* If the field is missing when coming from the post editor, consider it false
* If the field is present when coming from the post editor, use the value

:ticket: [ECP-1540]
:movie_camera: https://www.loom.com/share/782199045be94f6bb9d0f13e1ed9f749

[ECP-1540]: https://theeventscalendar.atlassian.net/browse/ECP-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ