### PR TITLE
Allow dropdown to be wider

### DIFF
--- a/changelog/TEC-5430-allow-auto-width-on-subscribe-button
+++ b/changelog/TEC-5430-allow-auto-width-on-subscribe-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: tweak
 
-Add auto-width to Subscribe to Calendar button to accommodate translations. [TEC-5430]
+Add auto-width to Subscribe to Calendar button to accommodate translations. Props to @huubl [TEC-5430]

--- a/changelog/TEC-5430-allow-auto-width-on-subscribe-button
+++ b/changelog/TEC-5430-allow-auto-width-on-subscribe-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add auto-width to Subscribe to Calendar button to accommodate translations. [TEC-5430]

--- a/src/modules/blocks/event-links/style.pcss
+++ b/src/modules/blocks/event-links/style.pcss
@@ -1,5 +1,6 @@
 .tribe-events-c-subscribe-dropdown__container {
-	width: 200px;
+	min-width: 200px;
+	width: auto;
 }
 
 .tribe-events-c-subscribe-dropdown__button {
@@ -16,7 +17,8 @@
 	text-align: center;
 	text-decoration: none;
 	transition: var(--tec-transition);
-	width: 200px;
+	min-width: 200px;
+	width: auto;
 
 	button {
 		background-color: transparent;

--- a/src/resources/postcss/components/full/_ical-link.pcss
+++ b/src/resources/postcss/components/full/_ical-link.pcss
@@ -166,7 +166,8 @@
 	.tribe-events {
 
 		.tribe-events-c-subscribe-dropdown__container {
-			width: 200px;
+			min-width: 200px;
+			width: auto;
 		}
 
 		.tribe-events-c-subscribe-dropdown {
@@ -187,7 +188,8 @@
 
 	.tribe-events-c-subscribe-dropdown__button {
 		padding: var(--tec-spacer-1) var(--tec-spacer-2);
-		width: 200px;
+		min-width: 200px;
+		width: auto;
 	}
 
 	.tribe-events-c-subscribe-dropdown__export-icon {


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5430](https://stellarwp.atlassian.net/browse/TEC-5430)

### 🗒️ Description

Some translations make the 'Add to Calendar' string longer and breaks the formatting of the subscribe button. This PR allows for width to be `auto` to accommodate these scenarios. 



### 🎥 Artifacts 
Before: 
![TEC-5430-Before](https://github.com/user-attachments/assets/eb8b9871-0df7-444d-941a-9a5e4ea0a9eb)


After:
![TEC-5430-After](https://github.com/user-attachments/assets/034e5b25-79f9-442c-bd2e-8c4f1d96584d)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.



[TEC-5430]: https://stellarwp.atlassian.net/browse/TEC-5430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ