### PR TITLE
If height or width is numeric, tack on `px` for map dimensions

### DIFF
--- a/src/Tribe/Embedded_Maps.php
+++ b/src/Tribe/Embedded_Maps.php
@@ -96,6 +96,14 @@ class Tribe__Events__Embedded_Maps {
 
 		ob_start();
 
+		if ( is_numeric( $width ) ) {
+			$width .= 'px';
+		}
+
+		if ( is_numeric( $height ) ) {
+			$height .= 'px';
+		}
+
 		if ( tribe_is_using_basic_gmaps_api() ) {
 
 			// Get a basic embed that doesn't use the JavaScript API


### PR DESCRIPTION
This resolves an issue where height/width values were getting passed to the template as int values rather than units.

![Screenshot 2023-08-14 133237](https://github.com/the-events-calendar/the-events-calendar/assets/430385/c4abff64-c112-4e29-8f2d-8f1ceef9342f)
