### PR TITLE
[ET-1843] Event Tickets email feature  Organizer email and website switched

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - When using the Event Tickets email feature the Organizer email and website will no longer be switched. [ET-1843]
+
 = [6.2.0.1] 2023-08-16 =
 
 * Fix - Ensure we pass the correct number of params to `maybe_get_new_order_from_blocks` [TEC-4889]

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
@@ -28,6 +28,7 @@ class Emails {
 	 * event, venue, and organizer placeholders to the provided placeholders array.
 	 *
 	 * @since 6.1.1
+	 * @since TBD Refactored method to move placeholder, venue, and organization logic out.
 	 *
 	 * @param array<string,mixed> $placeholders The placeholders for the Tickets Emails.
 	 * @param string              $email_id     The email ID.
@@ -47,86 +48,16 @@ class Emails {
 		if ( empty( $event ) ) {
 			return $placeholders;
 		}
-		$datetime_with_year_format    = tribe_get_datetime_format( true );
 
-		// if the context says that there's a post_id and it's a tribe_event, then add the event placeholders.
-		$tec_placeholders = [
-			'{event_id}'         => $post_id,
-			'{event_date}'       => wp_kses( $event->schedule_details->value(), [] ),
-			'{event_start_date}' => wp_kses( $event->dates->start->format( $datetime_with_year_format ), [] ),
-			'{event_end_date}'   => wp_kses( $event->dates->end->format( $datetime_with_year_format ), [] ),
-			'{event_name}'       => wp_kses( $event->post_title, [] ),
-			'{event_timezone}'   => $event->timezone,
-			'{event_url}'        => $event->permalink,
-			'{event_image_url}'  => ! empty( $event->thumbnail->exists ) ? $event->thumbnail->full->url : '',
-		];
+		$tec_placeholders = array_merge(
+			$this->get_event_placeholders( $event ),
+			$this->get_venue_placeholders( $event ),
+			$this->get_organizer_placeholders( $event )
+		);
 
-		// If the event has a venue, add the venue placeholders.
-		if ( ! empty( $event->venues->count() ) ) {
-			$venue = $event->venues[0];
 
-			$state_or_province = $venue->state;
-			if ( $venue->country !== 'US' ) {
-				$state_or_province = $venue->province;
-			}
-			if ( empty( $state_or_province ) ) {
-				$state_or_province = $venue->state_province;
-			}
 
-			$tec_placeholders = array_merge(
-				$tec_placeholders,
-				[
-					'{event_venue_id}'                => $venue->ID,
-					'{event_venue_name}'              => wp_kses( $venue->post_title, [] ),
-					'{event_venue_street_address}'    => $venue->address,
-					'{event_venue_city}'              => $venue->city,
-					'{event_venue_state_or_province}' => $state_or_province,
-					'{event_venue_province}'          => $venue->province,
-					'{event_venue_state}'             => $venue->state,
-					'{event_venue_zip}'               => $venue->zip,
-					'{event_venue_url}'               => $venue->permalink,
-				]
-			);
-		}
 
-		$tec_placeholders['{event_organizers_count}'] = $event->organizers->count();
-		$tec_placeholders['{event_organizers_names}'] = ! empty( $event->organizer_names ) ? implode( ', ', $event->organizer_names->all() ) : '';
-
-		// If the event has an organizer, add the organizer placeholders.
-		if ( ! empty( $event->organizers->count() ) ) {
-			$organizer_placeholders = [];
-
-			foreach ( $event->organizers as $index => $organizer ) {
-				$organizer_id         = $organizer->ID;
-				$organizer_post_title = wp_kses( $organizer->post_title, [] );
-				$organizer_permalink  = $organizer->permalink;
-				$organizer_url        = tribe_get_organizer_website_url( $organizer->ID );
-				$organizer_email      = tribe_get_organizer_email( $organizer->ID );
-				$organizer_phone      = $organizer->phone;
-
-				$organizer_placeholders[] = [
-					"{event_organizer:{$index}:id}"      => $organizer_id,
-					"{event_organizer:{$index}:name}"    => $organizer_post_title,
-					"{event_organizer:{$index}:url}"     => $organizer_permalink,
-					"{event_organizer:{$index}:email}"   => $organizer_email,
-					"{event_organizer:{$index}:website}" => $organizer_url,
-					"{event_organizer:{$index}:phone}"   => $organizer_phone,
-				];
-
-				if ( $index === 0 ) {
-					$organizer_placeholders[] = [
-						'{event_organizer_id}'      => $organizer_id,
-						'{event_organizer_name}'    => $organizer_post_title,
-						'{event_organizer_url}'     => $organizer_permalink,
-						'{event_organizer_email}'   => $organizer_email,
-						'{event_organizer_website}' => $organizer_url,
-						'{event_organizer_phone}'   => $organizer_phone,
-					];
-				}
-			}
-
-			$tec_placeholders = array_merge( $tec_placeholders, ...$organizer_placeholders );
-		}
 
 		return array_merge( $placeholders, $tec_placeholders );
 	}
@@ -259,4 +190,119 @@ class Emails {
 
 		return $attachments;
 	}
+
+	/**
+	 * Retrieves event-related placeholders.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $event The event object.
+	 *
+	 * @return array<string, mixed> An associative array of event-related placeholders.
+	 */
+	public function get_event_placeholders( $event ): array {
+		$datetime_with_year_format = tribe_get_datetime_format( true );
+
+		// if the context says that there's a post_id and it's a tribe_event, then add the event placeholders.
+		$placeholders = [
+			'{event_id}'         => $event->ID,
+			'{event_date}'       => wp_kses( $event->schedule_details->value(), [] ),
+			'{event_start_date}' => wp_kses( $event->dates->start->format( $datetime_with_year_format ), [] ),
+			'{event_end_date}'   => wp_kses( $event->dates->end->format( $datetime_with_year_format ), [] ),
+			'{event_name}'       => wp_kses( $event->post_title, [] ),
+			'{event_timezone}'   => $event->timezone,
+			'{event_url}'        => $event->permalink,
+			'{event_image_url}'  => ! empty( $event->thumbnail->exists ) ? $event->thumbnail->full->url : '',
+		];
+		return $placeholders;
+	}
+
+	/**
+	 * Retrieves venue-related placeholders if the event has a venue.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $event The event object.
+	 *
+	 * @return array<string, mixed> An associative array of venue-related placeholders.
+	 */
+	public function get_venue_placeholders( $event ): array {
+		$placeholders = [];
+		// If the event has a venue, add the venue placeholders.
+		if ( ! empty( $event->venues->count() ) ) {
+			$venue = $event->venues[0];
+
+			$state_or_province = $venue->state;
+			if ( $venue->country !== 'US' ) {
+				$state_or_province = $venue->province;
+			}
+			if ( empty( $state_or_province ) ) {
+				$state_or_province = $venue->state_province;
+			}
+
+			$placeholders
+				= [
+				'{event_venue_id}'                => $venue->ID,
+				'{event_venue_name}'              => wp_kses( $venue->post_title, [] ),
+				'{event_venue_street_address}'    => $venue->address,
+				'{event_venue_city}'              => $venue->city,
+				'{event_venue_state_or_province}' => $state_or_province,
+				'{event_venue_province}'          => $venue->province,
+				'{event_venue_state}'             => $venue->state,
+				'{event_venue_zip}'               => $venue->zip,
+				'{event_venue_url}'               => $venue->permalink,
+			];
+		}
+		return $placeholders;
+	}
+
+	/**
+	 * Retrieves organizer-related placeholders if the event has an organizer.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $event The event object.
+	 *
+	 * @return array<string, mixed> An associative array of organizer-related placeholders.
+	 */
+	public function get_organizer_placeholders( $event ): array {
+		$placeholders = [];
+		// If the event has an organizer, add the organizer placeholders.
+		if ( ! empty( $event->organizers->count() ) ) {
+
+			foreach ( $event->organizers as $index => $organizer ) {
+				$organizer_id         = $organizer->ID;
+				$organizer_post_title = wp_kses( $organizer->post_title, [] );
+				$organizer_permalink  = $organizer->permalink;
+				$organizer_url        = tribe_get_organizer_website_url( $organizer->ID );
+				$organizer_email      = tribe_get_organizer_email( $organizer->ID );
+				$organizer_phone      = $organizer->phone;
+
+				$placeholders[] = [
+					"{event_organizer:{$index}:id}"      => $organizer_id,
+					"{event_organizer:{$index}:name}"    => $organizer_post_title,
+					"{event_organizer:{$index}:url}"     => $organizer_permalink,
+					"{event_organizer:{$index}:email}"   => $organizer_email,
+					"{event_organizer:{$index}:website}" => $organizer_url,
+					"{event_organizer:{$index}:phone}"   => $organizer_phone,
+				];
+
+				if ( $index === 0 ) {
+					$placeholders[] = [
+						'{event_organizer_id}'      => $organizer_id,
+						'{event_organizer_name}'    => $organizer_post_title,
+						'{event_organizer_url}'     => $organizer_permalink,
+						'{event_organizer_email}'   => $organizer_email,
+						'{event_organizer_website}' => $organizer_url,
+						'{event_organizer_phone}'   => $organizer_phone,
+					];
+				}
+			}
+			$placeholders['{event_organizers_count}'] = $event->organizers->count();
+			$placeholders['{event_organizers_names}'] = ! empty( $event->organizer_names ) ? implode( ', ', $event->organizer_names->all() ) : '';
+
+		}
+		return $placeholders;
+	}
+
 }

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
@@ -300,7 +300,7 @@ class Emails {
 					];
 				}
 			}
-			$placeholders = array_merge($placeholders, ...$organizer_placeholders);
+			$placeholders = array_merge( $placeholders, ...$organizer_placeholders );
 
 		}
 		return $placeholders;

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
@@ -50,14 +50,11 @@ class Emails {
 		}
 
 		$tec_placeholders = array_merge(
+			$placeholders,
 			$this->get_event_placeholders( $event ),
 			$this->get_venue_placeholders( $event ),
 			$this->get_organizer_placeholders( $event )
 		);
-
-
-
-
 
 		return array_merge( $placeholders, $tec_placeholders );
 	}
@@ -267,8 +264,13 @@ class Emails {
 	 */
 	public function get_organizer_placeholders( $event ): array {
 		$placeholders = [];
+
+		$placeholders['{event_organizers_count}'] = $event->organizers->count();
+		$placeholders['{event_organizers_names}'] = !empty($event->organizer_names) ? implode(', ', $event->organizer_names->all()) : '';
+
 		// If the event has an organizer, add the organizer placeholders.
 		if ( ! empty( $event->organizers->count() ) ) {
+			$organizer_placeholders = [];
 
 			foreach ( $event->organizers as $index => $organizer ) {
 				$organizer_id         = $organizer->ID;
@@ -278,7 +280,7 @@ class Emails {
 				$organizer_email      = tribe_get_organizer_email( $organizer->ID );
 				$organizer_phone      = $organizer->phone;
 
-				$placeholders[] = [
+				$organizer_placeholders[] = [
 					"{event_organizer:{$index}:id}"      => $organizer_id,
 					"{event_organizer:{$index}:name}"    => $organizer_post_title,
 					"{event_organizer:{$index}:url}"     => $organizer_permalink,
@@ -288,7 +290,7 @@ class Emails {
 				];
 
 				if ( $index === 0 ) {
-					$placeholders[] = [
+					$organizer_placeholders[] = [
 						'{event_organizer_id}'      => $organizer_id,
 						'{event_organizer_name}'    => $organizer_post_title,
 						'{event_organizer_url}'     => $organizer_permalink,
@@ -298,8 +300,7 @@ class Emails {
 					];
 				}
 			}
-			$placeholders['{event_organizers_count}'] = $event->organizers->count();
-			$placeholders['{event_organizers_names}'] = ! empty( $event->organizer_names ) ? implode( ', ', $event->organizer_names->all() ) : '';
+			$placeholders = array_merge($placeholders, ...$organizer_placeholders);
 
 		}
 		return $placeholders;

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
@@ -108,8 +108,8 @@ class Emails {
 					"{event_organizer:{$index}:id}"      => $organizer_id,
 					"{event_organizer:{$index}:name}"    => $organizer_post_title,
 					"{event_organizer:{$index}:url}"     => $organizer_permalink,
-					"{event_organizer:{$index}:email}"   => $organizer_url,
-					"{event_organizer:{$index}:website}" => $organizer_email,
+					"{event_organizer:{$index}:email}"   => $organizer_email,
+					"{event_organizer:{$index}:website}" => $organizer_url,
 					"{event_organizer:{$index}:phone}"   => $organizer_phone,
 				];
 
@@ -118,8 +118,8 @@ class Emails {
 						'{event_organizer_id}'      => $organizer_id,
 						'{event_organizer_name}'    => $organizer_post_title,
 						'{event_organizer_url}'     => $organizer_permalink,
-						'{event_organizer_email}'   => $organizer_url,
-						'{event_organizer_website}' => $organizer_email,
+						'{event_organizer_email}'   => $organizer_email,
+						'{event_organizer_website}' => $organizer_url,
 						'{event_organizer_phone}'   => $organizer_phone,
 					];
 				}

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Emails.php
@@ -237,8 +237,7 @@ class Emails {
 				$state_or_province = $venue->state_province;
 			}
 
-			$placeholders
-				= [
+			$placeholders = [
 				'{event_venue_id}'                => $venue->ID,
 				'{event_venue_name}'              => wp_kses( $venue->post_title, [] ),
 				'{event_venue_street_address}'    => $venue->address,

--- a/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
+++ b/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
@@ -46,14 +46,14 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 	public function create_organizers(): void {
 
 		$this->test_organizer_id = $this->factory()->organizer->create( [
-																			'post_title'   => 'Test Organizer',
-																			'post_content' => 'Organizer Description',
-																			'meta_input'   => [
-																				'_OrganizerPhone'   => '123-555-9999',
-																				'_OrganizerWebsite' => 'http://example.com',
-																				'_OrganizerEmail'   => 'test@example.com'
-																			],
-																		]
+											'post_title'   => 'Test Organizer',
+											'post_content' => 'Organizer Description',
+											'meta_input'   => [
+																'_OrganizerPhone'   => '123-555-9999',
+																'_OrganizerWebsite' => 'http://example.com',
+																'_OrgsanizerEmail'   => 'test@example.com'
+											],
+										]
 		);
 
 	}
@@ -61,18 +61,19 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 	public function create_venues(): void {
 
 		$this->test_venue_id = $this->factory()->venue->create( [
-																	'post_title'   => 'Test Venue',
-																	'post_content' => 'Venue Description',
-																	'meta_input'   => [
-																		'_VenuePhone'    => '123-555-9999',
-																		'_VenueURL'      => 'http://example.com',
-																		'_VenueEmail'    => 'test@example.com',
-																		'_VenueZIP'      => '90210',
-																		'_VenueProvince' => 'Area 1',
-																		'_VenueCity'     => 'Area 2',
-																		'_VenueAddress'  => '123 Street',
-																	],
-																] );
+											'post_title'   => 'Test Venue',
+											'post_content' => 'Venue Description',
+											'meta_input'   => [
+																'_VenuePhone'    => '123-555-9999',
+																'_VenueURL'      => 'http://example.com',
+																'_VenueEmail'    => 'test@example.com',
+																'_VenueZIP'      => '90210',
+																'_VenueProvince' => 'Area 1',
+																'_VenueCity'     => 'Area 2',
+																'_VenueAddress'  => '123 Street',
+																],
+											]
+		);
 
 	}
 

--- a/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
+++ b/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
@@ -46,14 +46,14 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 	public function create_organizers(): void {
 
 		$this->test_organizer_id = $this->factory()->organizer->create( [
-											'post_title'   => 'Test Organizer',
-											'post_content' => 'Organizer Description',
-											'meta_input'   => [
-																'_OrganizerPhone'   => '123-555-9999',
-																'_OrganizerWebsite' => 'http://example.com',
-																'_OrgsanizerEmail'   => 'test@example.com'
-											],
-										]
+				'post_title'   => 'Test Organizer',
+				'post_content' => 'Organizer Description',
+				'meta_input'   => [
+					'_OrganizerPhone'   => '123-555-9999',
+					'_OrganizerWebsite' => 'http://example.com',
+					'_OrgsanizerEmail'  => 'test@example.com'
+				],
+			]
 		);
 
 	}
@@ -61,18 +61,18 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 	public function create_venues(): void {
 
 		$this->test_venue_id = $this->factory()->venue->create( [
-											'post_title'   => 'Test Venue',
-											'post_content' => 'Venue Description',
-											'meta_input'   => [
-																'_VenuePhone'    => '123-555-9999',
-																'_VenueURL'      => 'http://example.com',
-																'_VenueEmail'    => 'test@example.com',
-																'_VenueZIP'      => '90210',
-																'_VenueProvince' => 'Area 1',
-																'_VenueCity'     => 'Area 2',
-																'_VenueAddress'  => '123 Street',
-																],
-											]
+				'post_title'   => 'Test Venue',
+				'post_content' => 'Venue Description',
+				'meta_input'   => [
+					'_VenuePhone'    => '123-555-9999',
+					'_VenueURL'      => 'http://example.com',
+					'_VenueEmail'    => 'test@example.com',
+					'_VenueZIP'      => '90210',
+					'_VenueProvince' => 'Area 1',
+					'_VenueCity'     => 'Area 2',
+					'_VenueAddress'  => '123 Street',
+				],
+			]
 		);
 
 	}

--- a/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
+++ b/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace TEC\Events\Integrations\Plugins\Event_Tickets\Emails;
+
+use Tribe\Events\Test\Factories\Venue;
+use Tribe\Events\Test\Factories\Organizer;
+
+class EmailTest extends \Codeception\TestCase\WPTestCase {
+
+	public $event_ids         = [];
+	public $test_venue_id     = null;
+	public $test_organizer_id = null;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory()->venue     = new Venue();
+		$this->factory()->organizer = new Organizer();
+		$this->create_organizers();
+		$this->create_venues();
+		$this->create_test_event();
+
+	}
+
+	public function create_test_event(): void {
+		$created = tribe_events()->set_args(
+			[
+				'title'      => "Test Event",
+				'status'     => 'publish',
+				'start_date' => "+1 weeks 10am",
+				'duration'   => 2 * HOUR_IN_SECONDS,
+				'venue'      => $this->test_venue_id,
+				'organizer'  => $this->test_organizer_id,
+			]
+		)->create();
+
+		$this->assertInstanceOf( \WP_Post::class, $created );
+		$this->event_ids[] = $created->ID;
+	}
+
+	/**
+	 * Create our organizer so can test editing it.
+	 *
+	 * @return void
+	 */
+	public function create_organizers(): void {
+
+		$this->test_organizer_id = $this->factory()->organizer->create( [
+																			'post_title'   => 'Test Organizer',
+																			'post_content' => 'Organizer Description',
+																			'meta_input'   => [
+																				'_OrganizerPhone'   => '123-555-9999',
+																				'_OrganizerWebsite' => 'http://example.com',
+																				'_OrganizerEmail'   => 'test@example.com'
+																			],
+																		]
+		);
+
+	}
+
+	public function create_venues(): void {
+
+		$this->test_venue_id = $this->factory()->venue->create( [
+																	'post_title'   => 'Test Venue',
+																	'post_content' => 'Venue Description',
+																	'meta_input'   => [
+																		'_VenuePhone'    => '123-555-9999',
+																		'_VenueURL'      => 'http://example.com',
+																		'_VenueEmail'    => 'test@example.com',
+																		'_VenueZIP'      => '90210',
+																		'_VenueProvince' => 'Area 1',
+																		'_VenueCity'     => 'Area 2',
+																		'_VenueAddress'  => '123 Street',
+																	],
+																] );
+
+	}
+
+	public function test_get_event_placeholders() {
+		$event = tribe_get_event( $this->event_ids[0] );
+
+		$emails = new Emails();
+
+		$placeholders = $emails->get_event_placeholders( $event );
+
+		// Assert the placeholders are as expected
+		$this->assertEquals( $this->event_ids[0], $placeholders['{event_id}'] );
+		$this->assertEquals( wp_kses( $event->schedule_details->value(), [] ), $placeholders['{event_date}'] );
+		$this->assertEquals( wp_kses( $event->dates->start->format( tribe_get_datetime_format( true ) ), [] ), $placeholders['{event_start_date}'] );
+		$this->assertEquals( wp_kses( $event->dates->end->format( tribe_get_datetime_format( true ) ), [] ), $placeholders['{event_end_date}'] );
+		$this->assertEquals( wp_kses( $event->post_title, [] ), $placeholders['{event_name}'] );
+		$this->assertEquals( $event->timezone, $placeholders['{event_timezone}'] );
+		$this->assertEquals( $event->permalink, $placeholders['{event_url}'] );
+		$this->assertEquals( ! empty( $event->thumbnail->exists ) ? $event->thumbnail->full->url : '', $placeholders['{event_image_url}'] );
+
+	}
+
+	public function test_get_venue_placeholders() {
+		$event = tribe_get_event( $this->event_ids[0] );
+
+		$emails = new Emails();
+
+
+		$placeholders = $emails->get_venue_placeholders( $event );
+		// If the event has a venue, add the venue placeholders.
+		if ( ! empty( $event->venues->count() ) ) {
+			$venue = $event->venues[0];
+
+			$state_or_province = $venue->state;
+			if ( $venue->country !== 'US' ) {
+				$state_or_province = $venue->province;
+			}
+			if ( empty( $state_or_province ) ) {
+				$state_or_province = $venue->state_province;
+			}
+
+			// Assert the placeholders are as expected
+			$this->assertEquals( $venue->ID, $placeholders['{event_venue_id}'] );
+			$this->assertEquals( wp_kses( $venue->post_title, [] ), $placeholders['{event_venue_name}'] );
+			$this->assertEquals( $venue->address, $placeholders['{event_venue_street_address}'] );
+			$this->assertEquals( $venue->city, $placeholders['{event_venue_city}'] );
+			$this->assertEquals( $state_or_province, $placeholders['{event_venue_state_or_province}'] );
+			$this->assertEquals( $venue->province, $placeholders['{event_venue_province}'] );
+			$this->assertEquals( $venue->state, $placeholders['{event_venue_state}'] );
+			$this->assertEquals( $venue->zip, $placeholders['{event_venue_zip}'] );
+			$this->assertEquals( $venue->permalink, $placeholders['{event_venue_url}'] );
+		}
+	}
+
+	public function test_get_organizer_placeholders() {
+		$event = tribe_get_event( $this->event_ids[0] );
+
+		$emails = new Emails();
+
+
+		$placeholders = $emails->get_organizer_placeholders( $event );
+
+		// Assuming there's only one organizer
+		$organizer            = $event->organizers[0];
+		$organizer_id         = $organizer->ID;
+		$organizer_post_title = wp_kses( $organizer->post_title, [] );
+		$organizer_permalink  = $organizer->permalink;
+		$organizer_url        = tribe_get_organizer_website_url( $organizer->ID );
+		$organizer_email      = tribe_get_organizer_email( $organizer->ID );
+		$organizer_phone      = $organizer->phone;
+
+		$this->assertEquals( $organizer_id, $placeholders[1]['{event_organizer_id}'], 'Event Organizer ID does not match.' );
+		$this->assertEquals( $organizer_post_title, $placeholders[1]['{event_organizer_name}'], 'Event Organizer Name does not match.' );
+		$this->assertEquals( $organizer_permalink, $placeholders[1]['{event_organizer_url}'], 'Event Organizer URL does not match.' );
+		$this->assertEquals( html_entity_decode( $organizer_email ), html_entity_decode( $placeholders[1]['{event_organizer_email}'] ), 'Event Organizer Email does not match.' );
+		$this->assertEquals( $organizer_url, $placeholders[1]['{event_organizer_website}'], 'Event Organizer Website does not match.' );
+		$this->assertEquals( $organizer_phone, $placeholders[1]['{event_organizer_phone}'], 'Event Organizer Phone does not match.' );
+		$this->assertEquals( 1, $placeholders['{event_organizers_count}'], 'Event Organizers Count does not match.' );
+		$this->assertEquals( $organizer_post_title, $placeholders['{event_organizers_names}'], 'Event Organizers Names do not match.' );
+	}
+
+}

--- a/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
+++ b/tests/wpunit/TEC/Events/Integrations/Plugins/Event_Tickets/Emails/EmailTest.php
@@ -132,7 +132,6 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 
 		$emails = new Emails();
 
-
 		$placeholders = $emails->get_organizer_placeholders( $event );
 
 		// Assuming there's only one organizer
@@ -144,12 +143,12 @@ class EmailTest extends \Codeception\TestCase\WPTestCase {
 		$organizer_email      = tribe_get_organizer_email( $organizer->ID );
 		$organizer_phone      = $organizer->phone;
 
-		$this->assertEquals( $organizer_id, $placeholders[1]['{event_organizer_id}'], 'Event Organizer ID does not match.' );
-		$this->assertEquals( $organizer_post_title, $placeholders[1]['{event_organizer_name}'], 'Event Organizer Name does not match.' );
-		$this->assertEquals( $organizer_permalink, $placeholders[1]['{event_organizer_url}'], 'Event Organizer URL does not match.' );
-		$this->assertEquals( html_entity_decode( $organizer_email ), html_entity_decode( $placeholders[1]['{event_organizer_email}'] ), 'Event Organizer Email does not match.' );
-		$this->assertEquals( $organizer_url, $placeholders[1]['{event_organizer_website}'], 'Event Organizer Website does not match.' );
-		$this->assertEquals( $organizer_phone, $placeholders[1]['{event_organizer_phone}'], 'Event Organizer Phone does not match.' );
+		$this->assertEquals( $organizer_id, $placeholders['{event_organizer_id}'], 'Event Organizer ID does not match.' );
+		$this->assertEquals( $organizer_post_title, $placeholders['{event_organizer_name}'], 'Event Organizer Name does not match.' );
+		$this->assertEquals( $organizer_permalink, $placeholders['{event_organizer_url}'], 'Event Organizer URL does not match.' );
+		$this->assertEquals( html_entity_decode( $organizer_email ), html_entity_decode( $placeholders['{event_organizer_email}'] ), 'Event Organizer Email does not match.' );
+		$this->assertEquals( $organizer_url, $placeholders['{event_organizer_website}'], 'Event Organizer Website does not match.' );
+		$this->assertEquals( $organizer_phone, $placeholders['{event_organizer_phone}'], 'Event Organizer Phone does not match.' );
 		$this->assertEquals( 1, $placeholders['{event_organizers_count}'], 'Event Organizers Count does not match.' );
 		$this->assertEquals( $organizer_post_title, $placeholders['{event_organizers_names}'], 'Event Organizers Names do not match.' );
 	}


### PR DESCRIPTION
[ET-1843] Organizer email & Organizer Website were switched when using Tickets email. I refactored the `include_placeholders` method into 3 separate methods to allow us to test the variable replacement better.

![image](https://github.com/the-events-calendar/the-events-calendar/assets/12241059/c57972bd-2fb6-4b93-b5f8-2218d3808f88)



[ET-1843]: https://theeventscalendar.atlassian.net/browse/ET-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ