### PR TITLE
[ET-1778] Change Organizer Name Sanitization to Encode Less Characters

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - When using the Event Tickets email feature the Organizer email and website will no longer be switched. [ET-1843]
+* Fix - When subscribing to an event, the organizer name will not encode as many characters, especially spaces. [ET-1778]
 
 = [6.2.0.1] 2023-08-16 =
 

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -754,7 +754,8 @@ class Tribe__Events__iCal {
 	/**
 	 * Get the iCal Output for the provided event object.
 	 *
-	 * @since5.1.6
+	 * @since 5.1.6
+	 * @since TBD   Sanitize organizer name using new method.
 	 *
 	 * @param \WP_Post             $event_post The event post object.
 	 * @param \Tribe__Events__Main $tec        An instance of the main TEC Class.

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -728,6 +728,30 @@ class Tribe__Events__iCal {
 	}
 
 	/**
+	 * Sanitize organizer name.
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string $name
+	 * 
+	 * @return string
+	 */
+	private function sanitize_organizer_name( string $name ): string {
+		// Characters not allowed in organizer name: CTLs, DQUOTE, ";", ":", ","
+		$sanitized_name = rawurlencode( $name );
+
+		// Array of characters to allow in organizer name.
+		$chars = [ ' ', '&', '!', '?', "'", '*', '(', ')', '@', '#', '$', '%', '^', '+', '=', '{', '}', '[', ']', '|', '\\', '/', '<', '>', '`', '~' ];
+		$encoded_chars = array_map( 'rawurlencode', $chars );
+
+		// Since single quotes are allowed, let's convert any double quotes to single quotes.
+		$encoded_chars[] = rawurlencode( '"' );
+		$chars[] = "'";
+
+		return str_replace( $encoded_chars, $chars, $sanitized_name );
+	}
+
+	/**
 	 * Get the iCal Output for the provided event object.
 	 *
 	 * @since5.1.6
@@ -847,7 +871,8 @@ class Tribe__Events__iCal {
 			$organizer    = get_post( $organizer_id );
 
 			if ( $organizer_id ) {
-				$item['ORGANIZER'] = sprintf( 'ORGANIZER;CN="%s":MAILTO:%s', rawurlencode( $organizer->post_title ), $organizer_email );
+				$sanitized_name = $this->sanitize_organizer_name( $organizer->post_title );
+				$item['ORGANIZER'] = sprintf( 'ORGANIZER;CN="%s":MAILTO:%s', $sanitized_name, $organizer_email );
 			} else {
 				$item['ORGANIZER'] = sprintf( 'ORGANIZER:MAILTO:%s', $organizer_email );
 			}


### PR DESCRIPTION
### Ticket
[ET-1778]

### Description
It was reported that spaces were being encoded as '%20' and we found that we were using `urlrawencode()` to encode the entire name. The iCalendar documentation states that the only disallowed characters are CTLs, DQUOTE, ";", "," and ":". This fix allows more characters to be used in Organizer names. It also converts double quotes to single quotes.



[ET-1778]: https://theeventscalendar.atlassian.net/browse/ET-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ