### PR TITLE
Add lodash as a dependency for the Block Editor Assets.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Events Gutenberg Assets. [ECP-1575]
+
 = [6.2.] TBD =
 
 * Fix - WP Rewrite was being incorrectly initialized in some scenarios due to container DI, and causing some 404s. This was affecting classes that extend the `Tribe__Rewrite`. [TEC-4844]

--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Events Gutenberg Assets. [ECP-1575]
+* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for TEC Block Assets. [ECP-1575]
 
 = [6.2.] TBD =
 


### PR DESCRIPTION
Ticket : [ECP-1575](https://theeventscalendar.atlassian.net/browse/ECP-1575)

## Overview
This PR addresses the "Uncaught ReferenceError: lodash is not defined" error that was arising when activating the Gutenberg plugin. The root cause of the issue was the missing dependency of `lodash` for our Block Editor Assets. By explicitly defining this dependency, we ensure that `lodash` is loaded before our custom scripts, thus resolving the error.

## Changes
- Updated `Tribe__Editor__Assets` class to include `lodash` as a script dependency.

## Testing
1. Activate the Gutenberg plugin.
2. Navigate to the add/edit events page.
3. Ensure that there are no console errors related to `lodash`.
4. Confirm that all events calendar blocks are functioning as expected.

**Screencast 🎥**
