### PR TITLE
We need wpnonce to validate user and show user caps.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Block Editor Assets. [ECP-1575]
+* Fix - Resolves an issue around our new nonce structure used in view pagination, losing the authenticated user and failing to display user specific capabilities. [ECP-1581]
 
 = [6.2.1] 2023-09-05 =
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -127,8 +127,9 @@ class Hooks extends Service_Provider {
 		add_filter( 'tribe_events_views_v2_after_make_view', [ $this, 'action_include_filters_excerpt' ] );
 		// 100 is the WordPress cookie-based auth check.
 		add_filter( 'rest_authentication_errors', [ Rest_Endpoint::class, 'did_rest_authentication_errors' ], 150 );
-	// @todo
-			add_filter( 'rest_send_nocache_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 150,1 );
+
+		// Need to handle our custom nonce user auth.
+		add_filter( 'rest_send_nocache_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 10,1 );
 
 		add_filter( 'tribe_support_registered_template_systems', [ $this, 'filter_register_template_updates' ] );
 		add_filter( 'tribe_events_event_repository_map', [ $this, 'add_period_repository' ], 10, 3 );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -127,6 +127,9 @@ class Hooks extends Service_Provider {
 		add_filter( 'tribe_events_views_v2_after_make_view', [ $this, 'action_include_filters_excerpt' ] );
 		// 100 is the WordPress cookie-based auth check.
 		add_filter( 'rest_authentication_errors', [ Rest_Endpoint::class, 'did_rest_authentication_errors' ], 150 );
+	// @todo
+			add_filter( 'rest_send_nocache_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 150,1 );
+
 		add_filter( 'tribe_support_registered_template_systems', [ $this, 'filter_register_template_updates' ] );
 		add_filter( 'tribe_events_event_repository_map', [ $this, 'add_period_repository' ], 10, 3 );
 

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -10,6 +10,7 @@ namespace Tribe\Events\Views\V2;
 
 use WP_REST_Request as Request;
 use WP_REST_Server as Server;
+use WP_User;
 
 /**
  * Class Rest_Endpoint
@@ -74,6 +75,81 @@ class Rest_Endpoint {
 	 */
 	protected static $did_rest_authentication_errors;
 
+	/**
+	 * When in a REST request, store the authenticated user ID for use later.
+	 *
+	 * @since TBD
+	 *
+	 * @var null|int The authenticated user ID.
+	 */
+	protected static $user_id;
+
+	/**
+	 * Due to our custom nonce usage on the REST auth, the _wpnonce is missing and WP core
+	 * will fail to retain the authenticated user and removes it.
+	 *
+	 * This stores the user (if authenticated) for use when we check that our custom nonce(s) are valid.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $send_nocache_headers
+	 *
+	 * @return bool
+	 * @see   rest_cookie_check_errors()
+	 *
+	 */
+	public static function preserve_user_for_custom_nonces( $send_nocache_headers ) {
+		if ( ! is_user_logged_in() ) {
+			return $send_nocache_headers;
+		}
+
+		$user = wp_get_current_user();
+		if ( ! $user instanceof WP_User || ! $user->ID ) {
+			return $send_nocache_headers;
+		}
+
+		// Save user for our nonce checks.
+		self::$user_id = $user->ID;
+
+		return $send_nocache_headers;
+	}
+
+	/**
+	 * Ensures the nonce(s) are valid.
+	 *
+	 * @since TBD
+	 *
+	 * @param Request $request
+	 *
+	 * @return bool
+	 */
+	public function is_valid_request(Request $request) {
+		/*
+		* Since WordPress 4.7 the REST API cannot be disabled completely.
+		* The "disabling" happens by returning falsy or error values from the `rest_authentication_errors`
+		* filter.
+		* If false or error, we follow through and and do not authorize the callback.
+		* If null, the site is using alternate authentication such as SAML
+		*/
+		$auth = apply_filters( 'rest_authentication_errors', null );
+
+		if ( self::$user_id && ! is_user_logged_in() ) {
+			/**
+			 * This user was set but lost, because we use custom nonces which can not be handled by Wordpress auth.
+			 *
+
+			 */
+			wp_set_current_user( self::$user_id );
+		}
+
+		// Did either our unauth or authed nonce pass? If neither, something is fishy.
+		$nonce_check = wp_verify_nonce( $request->get_param( static::PRIMARY_NONCE_KEY ), static::NONCE_ACTION )
+		               || wp_verify_nonce( $request->get_param( static::SECONDARY_NONCE_KEY ), static::NONCE_ACTION );
+
+		return ( $auth || is_null( $auth ) )
+		       && ! is_wp_error( $auth )
+		       && $nonce_check;
+	}
 
 	/**
 	 * Get the nonces being passed to the V2 views used for our REST requests.
@@ -84,6 +160,7 @@ class Rest_Endpoint {
 	 */
 	public static function get_rest_nonces(): array {
 		$generated_nonces = [];
+
 		/*
 		 * Some plugins, like WooCommerce, will modify the UID of logged out users; avoid that filtering here.
 		 *
@@ -106,6 +183,7 @@ class Rest_Endpoint {
 				if ( ! $uid ) {
 					return '';
 				}
+
 				// We are logged in, now generate an unauthenticated user nonce.
 				wp_set_current_user( 0 );
 				$nonce = wp_create_nonce( static::NONCE_ACTION );
@@ -114,11 +192,6 @@ class Rest_Endpoint {
 				return $nonce;
 			}
 		);
-
-		if ( is_admin() ) {
-			// Admin needs to auth against cookie for user caps.
-			$generated_nonces['_wpnonce'] = wp_create_nonce( 'wp_rest' );
-		}
 
 		/**
 		 * Filter the list of nonces being used on REST requests for V2 views.
@@ -259,26 +332,8 @@ class Rest_Endpoint {
 		return register_rest_route( static::ROOT_NAMESPACE, '/html', [
 			// Support both GET and POST HTTP methods: we originally used GET.
 			'methods'             => [ Server::READABLE, Server::CREATABLE ],
-			 // @todo [BTRIA-600]: Make sure we do proper handling of caches longer then 12h.
-			'permission_callback' => static function ( Request $request ) {
-
-				/*
-				 * Since WordPress 4.7 the REST API cannot be disabled completely.
-				 * The "disabling" happens by returning falsy or error values from the `rest_authentication_errors`
-				 * filter.
-				 * If false or error, we follow through and and do not authorize the callback.
-				 * If null, the site is using alternate authentication such as SAML
-				 */
-				$auth = apply_filters( 'rest_authentication_errors', null );
-
-				// Did either our unauth or authed nonce pass? If neither, something is fishy.
-				$nonce_check = wp_verify_nonce( $request->get_param( static::PRIMARY_NONCE_KEY ), static::NONCE_ACTION )
-				               || wp_verify_nonce( $request->get_param( static::SECONDARY_NONCE_KEY ), static::NONCE_ACTION );
-
-				return ( $auth || is_null( $auth ) )
-				       && ! is_wp_error( $auth )
-				       && $nonce_check;
-			},
+			// @todo [BTRIA-600]: Make sure we do proper handling of caches longer then 12h.
+			'permission_callback' => [ $this, 'is_valid_request' ],
 			'callback'            => static function ( Request $request ) {
 				if ( ! headers_sent() ) {
 					header( 'Content-Type: text/html; charset=' . esc_attr( get_bloginfo( 'charset' ) ) );

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -115,6 +115,11 @@ class Rest_Endpoint {
 			}
 		);
 
+		if ( is_admin() ) {
+			// Admin needs to auth against cookie for user caps.
+			$generated_nonces['_wpnonce'] = wp_create_nonce( 'wp_rest' );
+		}
+
 		/**
 		 * Filter the list of nonces being used on REST requests for V2 views.
 		 *

--- a/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/iCalendar/RequestTest.php
@@ -159,6 +159,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 			'without_date_list_view' => [
 				[
 					'view' => 'list',
+					'timezone' => 'Europe/Paris',
 				],
 				[ // Expected events.
 					'this week sunday',
@@ -241,6 +242,7 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 				[
 					'view' => 'month',
 					'event_date' => date( 'Y-m', strtotime( 'next month' ) ),
+					'timezone' => 'Europe/Paris',
 				],
 				[
 					date( 'Y-m-01', strtotime( 'next month' ) ),
@@ -263,16 +265,16 @@ class RequestTest extends \Codeception\TestCase\WPTestCase {
 					'view' => 'month',
 					'featured' => true,
 					'event_date' => date( 'Y-m-10', strtotime( 'last month' ) ),
+					'timezone' => 'Europe/Paris',
 				],
 				[],
 				[],
 				'create_and_get_month_events',
 			],
-
-
 			'without_date_day_view' => [
 				[
 					'view' => 'day',
+					'timezone' => 'Europe/Paris',
 				],
 				[ // Expected events.
 					'today',


### PR DESCRIPTION
[ECP-1581](https://theeventscalendar.atlassian.net/browse/ECP-1581)

In some situations the user capabilities were failing because the user session was not found. This would result in Event Manager pagination screens to lose the various event actions, and user authenticated logic.

The cause was the `_wpnonce` is used to auth the user.

Artifacts:
![f1bc57c1-fbba-4a4a-8617-9f4d22e6d89b](https://github.com/the-events-calendar/the-events-calendar/assets/2826045/d28799b9-6971-4211-93c6-71f2149d808f)
![b2cf55e5-f0b7-4f28-afc2-160a3b1e009d](https://github.com/the-events-calendar/the-events-calendar/assets/2826045/c05cec1c-45f0-459a-8e3c-94c443c434fa)


[ECP-1581]: https://theeventscalendar.atlassian.net/browse/ECP-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ