### PR TITLE
Leverage strategy feature to ensure front end scripts are deferred

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -204,10 +204,13 @@ class Assets extends Service_Provider {
 				'priority'     => 9, // for `wp_print_footer_scripts` we are required to go before P10.
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key, static::$widget_group_key ],
+				'defer'        => true,
 				'in_footer'    => array( 'strategy'  => 'defer' ),
 			]
 		);
-		wp_script_add_data( 'jquery', 'strategy', 'defer' );
+		wp_script_add_data( 'jquery-core', 'strategy', 'defer' );
+		wp_script_add_data( 'jquery-migrate', 'strategy', 'defer' );
+		wp_script_add_data( 'underscore', 'strategy', 'defer' );
 
 		tribe_asset(
 			$plugin,

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -204,9 +204,10 @@ class Assets extends Service_Provider {
 				'priority'     => 9, // for `wp_print_footer_scripts` we are required to go before P10.
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key, static::$widget_group_key ],
-				'defer'        => true,
+				'in_footer'    => array( 'strategy'  => 'defer' ),
 			]
 		);
+		wp_script_add_data( 'jquery', 'strategy', 'defer' );
 
 		tribe_asset(
 			$plugin,
@@ -419,7 +420,7 @@ class Assets extends Service_Provider {
 				'priority'     => 10,
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key, static::$widget_group_key ],
-				'in_footer'    => false,
+				'in_footer'    => array( 'strategy'  => 'defer' ),
 			]
 		);
 

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -205,7 +205,7 @@ class Assets extends Service_Provider {
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key, static::$widget_group_key ],
 				'defer'        => true,
-				'in_footer'    => array( 'strategy'  => 'defer' ),
+				'in_footer'    => [ 'strategy' => 'defer' ],
 			]
 		);
 		wp_script_add_data( 'jquery-core', 'strategy', 'defer' );

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -423,7 +423,7 @@ class Assets extends Service_Provider {
 				'priority'     => 10,
 				'conditionals' => [ $this, 'should_enqueue_frontend' ],
 				'groups'       => [ static::$group_key, static::$widget_group_key ],
-				'in_footer'    => array( 'strategy'  => 'defer' ),
+				'in_footer'    => [ 'strategy' => 'defer' ],
 			]
 		);
 


### PR DESCRIPTION
## Context
WordPress introduced a new strategy feature in the Script API in version 6.3. See [this post](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/) for more details.

I see The Events Calendar added support for async/defer a while back in Feb 2021 - https://github.com/the-events-calendar/tribe-common/pull/1549. I believe you can leverage the new core strategy feature to benefit from the improvements there while still using the current approach for older WordPress versions (using the existing `filter_tag_async_defer`).

Using the new strategy feature, we can add the `defer` or `async` attribute to front end scripts that the plugin enqueues without risk of breakage.    This is because the core feature includes tracing of the dependency when considering whether a script can be deferred. The result is that if a script has a dependency that is not deferred, neither script will be deferred.

## Details
* Add support for the new Script API strategy feature for two front end scripts: 'views/manager.js' and 'views/breakpoints.js' along with their dependencies

A second PR adds the additional required support to tribe-common: https://github.com/the-events-calendar/tribe-common/pull/1991 - change details are explained there

## Expected results
After this and the other patch are merged, all of the scripts currently output on the front end should get the `defer` attribute

## Potential improvements
I noticed after this patch, all scripts are output in the footer, I was expecting them to move to the header where the browser would discover them a bit earlier. This is likely due to a dependent script being marked `in_footer` => true (although I didn't confirm that). The way core works currently, if a single dependent script is in the footer, all scripts are moved to the footer. This might be something we can improve now that we added support for `defer`.

