### PR TITLE
Don't activate block editor on FSE theme switch.

### DIFF
--- a/src/Tribe/Editor/Compatibility.php
+++ b/src/Tribe/Editor/Compatibility.php
@@ -50,7 +50,6 @@ class Tribe__Events__Editor__Compatibility {
 		add_filter( 'tribe_editor_should_load_blocks', [ $this, 'filter_tribe_editor_should_load_blocks' ], 100 );
 		add_filter( 'classic_editor_enabled_editors_for_post_type', [ $this, 'filter_classic_editor_enabled_editors_for_post_type' ], 10, 2 );
 		add_filter( 'tribe_general_settings_tab_fields', [ $this, 'insert_toggle_blocks_editor_field' ] );
-		add_action( 'after_switch_theme', [ $this, 'enable_block_editor_on_fse_theme_activation' ], 10, 1 );
 	}
 
 	/**
@@ -239,20 +238,4 @@ class Tribe__Events__Editor__Compatibility {
 
 		return $is_classic_editor;
 	}
-
-	/**
-     * Enables the 'Activate Block Editor for Events' setting when a full site editor theme is activated.
-	 * 
-	 * @since TBD
-	 * 
-	 * @param string   $old_name  The name of the old theme that was active before switching.
-	 * @param WP_Theme $old_theme WP_Theme instance of the old theme.
-     *
-     * @return void
-     */
-    public function enable_block_editor_on_fse_theme_activation( $old_name, $old_theme = false ) {
-        if ( tec_is_full_site_editor() ) {
-            tribe_update_option( static::$blocks_editor_key, true );
-        }
-    }
 }


### PR DESCRIPTION
Ticket : [TEC-4790](https://stellarwp.atlassian.net/browse/TEC-4790)

As a result of the following [strategy decision](https://stellarwp.atlassian.net/browse/TEC-4790?focusedCommentId=115827), we won't enforce the block editor on FSE themes.

The ACs in the ticket have been updated to reflect this change.

[TEC-4790]: https://stellarwp.atlassian.net/browse/TEC-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ