### PR TITLE
Fix undefined var error, and added test coverage.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Resolves issue where a deleted venue still attached to an event would cause an `PHP Warning: Undefined variable $data in /code/wp-content/plugins/the-events-calendar/src/Tribe/REST/V1/Post_Repository.php on line 327` error. [TEC-4954]
+
 = [6.2.3.2] 2023-10-12 =
 
 * Fix - Prevent noindex code from adding tags to single event pages. [TEC-4949]

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -165,7 +165,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 		$data = $this->add_global_id_fields( $data, $event_id );
 
 		/**
-		 * Filters the data that will be returnedf for a single event.
+		 * Filters the data that will be returned for a single event.
 		 *
 		 * @param array   $data  The data that will be returned in the response.
 		 * @param WP_Post $event The requested event.
@@ -188,6 +188,8 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 	 * @since 4.6 Added $context param
 	 */
 	public function get_venue_data( $event_or_venue_id, $context = '' ) {
+		$data = [];
+
 		if ( tribe_is_event( $event_or_venue_id ) ) {
 			$venues = tec_get_venue_ids( $event_or_venue_id );
 			if ( empty( $venues ) ) {
@@ -214,8 +216,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 
 		foreach ( $venues as $venue_id ) {
 			if ( is_object( $venue_id ) ) {
-				$venue = $venue_id;
-
+				$venue    = $venue_id;
 				$venue_id = $venue->ID;
 			}
 


### PR DESCRIPTION
[TEC-4954](https://stellarwp.atlassian.net/browse/TEC-4954)

Fix a warning on our single event REST endpoint, when retrieving a venue attached to an event after the venue was deleted.

```Undefined variable: data at src/Tribe/REST/V1/Post_Repository.php:326```

[TEC-4954]: https://stellarwp.atlassian.net/browse/TEC-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ