### PR TITLE
Fix/ecp 1601 hijack user auth filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Wordpress 6.3 introduce some changes in filters that regressed a prior fix for authentication and our new nonce structure used in view pagination. One symptom of the issue was losing the authenticated user and failing to display user specific capabilities on event views. [ECP-1601]
+
 = [6.2.3.2] 2023-10-12 =
 
 * Fix - Prevent noindex code from adding tags to single event pages. [TEC-4949]

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -129,7 +129,7 @@ class Hooks extends Service_Provider {
 		add_filter( 'rest_authentication_errors', [ Rest_Endpoint::class, 'did_rest_authentication_errors' ], 150 );
 
 		// Need to handle our custom nonce user auth.
-		add_filter( 'rest_send_nocache_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 10,1 );
+		add_filter( 'rest_allowed_cors_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 10, 2 );
 
 		add_filter( 'tribe_support_registered_template_systems', [ $this, 'filter_register_template_updates' ] );
 		add_filter( 'tribe_events_event_repository_map', [ $this, 'add_period_repository' ], 10, 3 );

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -129,7 +129,7 @@ class Hooks extends Service_Provider {
 		add_filter( 'rest_authentication_errors', [ Rest_Endpoint::class, 'did_rest_authentication_errors' ], 150 );
 
 		// Need to handle our custom nonce user auth.
-		add_filter( 'rest_allowed_cors_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 10, 2 );
+		add_filter( 'rest_allowed_cors_headers', [ Rest_Endpoint::class, 'preserve_user_for_custom_nonces' ], 10, 1 );
 
 		add_filter( 'tribe_support_registered_template_systems', [ $this, 'filter_register_template_updates' ] );
 		add_filter( 'tribe_events_event_repository_map', [ $this, 'add_period_repository' ], 10, 3 );

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -8,6 +8,7 @@
  */
 namespace Tribe\Events\Views\V2;
 
+use WP_REST_Request;
 use WP_REST_Request as Request;
 use WP_REST_Server as Server;
 use WP_User;
@@ -91,27 +92,29 @@ class Rest_Endpoint {
 	 * This stores the user (if authenticated) for use when we check that our custom nonce(s) are valid.
 	 *
 	 * @since 6.2.3
+	 * @since TBD Moved to new hook with new params in order to intercede in user auth flow for REST requests.
 	 *
-	 * @param bool $send_nocache_headers
+	 * @param array $cors_headers List of headers to be filtered.
+	 * @param WP_REST_Request $rest_request This request.
 	 *
-	 * @return bool
+	 * @return array List of headers.
 	 * @see   rest_cookie_check_errors()
 	 *
 	 */
-	public static function preserve_user_for_custom_nonces( $send_nocache_headers ) {
+	public static function preserve_user_for_custom_nonces( $cors_headers, $rest_request ) {
 		if ( ! is_user_logged_in() ) {
-			return $send_nocache_headers;
+			return $cors_headers;
 		}
 
 		$user = wp_get_current_user();
 		if ( ! $user instanceof WP_User || ! $user->ID ) {
-			return $send_nocache_headers;
+			return $cors_headers;
 		}
 
 		// Save user for our nonce checks.
 		self::$user_id = (int) $user->ID;
 
-		return $send_nocache_headers;
+		return $cors_headers;
 	}
 
 	/**

--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -95,13 +95,12 @@ class Rest_Endpoint {
 	 * @since TBD Moved to new hook with new params in order to intercede in user auth flow for REST requests.
 	 *
 	 * @param array $cors_headers List of headers to be filtered.
-	 * @param WP_REST_Request $rest_request This request.
 	 *
 	 * @return array List of headers.
 	 * @see   rest_cookie_check_errors()
 	 *
 	 */
-	public static function preserve_user_for_custom_nonces( $cors_headers, $rest_request ) {
+	public static function preserve_user_for_custom_nonces( $cors_headers ) {
 		if ( ! is_user_logged_in() ) {
 			return $cors_headers;
 		}


### PR DESCRIPTION
[ECP-1601](https://stellarwp.atlassian.net/browse/ECP-1601)

This was a regression of https://github.com/the-events-calendar/the-events-calendar/pull/4377 caused by the order of filters changed in REST request server on WP version 6.3.

Artifacts:
See https://github.com/the-events-calendar/the-events-calendar/pull/4377

[ECP-1601]: https://stellarwp.atlassian.net/browse/ECP-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ