### PR TITLE
Fix path in doc comment

### DIFF
--- a/src/views/v2/widgets/widget-events-list/event/date-tag.php
+++ b/src/views/v2/widgets/widget-events-list/event/date-tag.php
@@ -3,7 +3,7 @@
  * Widget: Events List Event Venue
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/events/v2/widgets/widget-events-list/event/venue.php
+ * [your-theme]/tribe/events/v2/widgets/widget-events-list/event/date-tag.php
  *
  * See more documentation about our views templating system.
  *


### PR DESCRIPTION
Summary: 
This edit fixes a typo to the template override path in the comment block. 

Backstory:
I noticed while I was upgrading a site to new V2 templates that the path suggested for the template override was not overriding. I tested changing the file name from `venue.php` to `date-tag.php` and it worked in overriding. I believe this possibly was a typo.
