### PR TITLE
Fix legacy widget console error.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Resolves an issue with certain versions of Wordpress already having the legacy widget block registered causing us to trigger the console error `Block "core/legacy-widget" is already registered.` would occur. Now we check if registered first. [TEC-4764]
+
 = [6.2.3.2] 2023-10-12 =
 
 * Fix - Prevent noindex code from adding tags to single event pages. [TEC-4949]

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1236,8 +1236,6 @@ class View implements View_Interface {
 			$this->url = false === $merge ?
 				new Url( add_query_arg( $query_args ) )
 				: $this->url->add_query_args( $query_args );
-
-			return;
 		}
 	}
 

--- a/src/modules/widgets/index.js
+++ b/src/modules/widgets/index.js
@@ -6,10 +6,6 @@ import './style.pcss';
 
 const { registerBlockType } = wp.blocks;
 
-// We need to register core/legacy-widget block to support
-// earlier versions of WP which don't have it registered by default.
-wp.widgets.registerLegacyWidgetBlock();
-
 const blocks = [
 	EventsList,
 ];

--- a/src/resources/js/event-editor.js
+++ b/src/resources/js/event-editor.js
@@ -46,9 +46,14 @@ var tribe_events_event_editor = tribe_events_event_editor || {};
 	 */
 	obj.init = () => {
 		obj.bindFeaturedEvents();
+
+		// We need to register core/legacy-widget block to support
+		// earlier versions of WP which don't have it registered by default.
+		if ( wp.widgets && wp.blocks && ! wp.blocks.getBlockType( 'core/legacy-widget' ) ) {
+			wp.widgets.registerLegacyWidgetBlock();
+		}
 	};
 
 	// Init our main object.
 	$( obj.init );
-
 } )( jQuery, tribe_events_event_editor );


### PR DESCRIPTION
[TEC-4764](https://stellarwp.atlassian.net/browse/TEC-4764)

Resolves an issue with certain versions of Wordpress already having the legacy widget block registered causing us to trigger the console error `Block "core/legacy-widget" is already registered.` would occur. Now we check if registered first.

Artifact:

![image](https://github.com/the-events-calendar/the-events-calendar/assets/2826045/ac61d1b2-8f13-43c7-b519-68436e051c49)


[TEC-4764]: https://stellarwp.atlassian.net/browse/TEC-4764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ