### PR TITLE
Fixes the deprecation of `${var}` in PHP 8.2.

### DIFF
--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Meta_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Meta_Query.php
@@ -376,7 +376,7 @@ class Custom_Tables_Meta_Query extends WP_Meta_Query {
 	protected function build_where_operator_sql( $table_and_column, $meta_compare, $value ) {
 		global $wpdb;
 
-		return $wpdb->prepare( "{$table_and_column} ${meta_compare} %s", $value );
+		return $wpdb->prepare( "{$table_and_column} {$meta_compare} %s", $value );
 	}
 
 	/**

--- a/src/Tribe/Repositories/Event.php
+++ b/src/Tribe/Repositories/Event.php
@@ -483,9 +483,9 @@ class Tribe__Events__Repositories__Event extends Tribe__Repository {
 
 		$alt_where = $wpdb->prepare(
 			"(
-				TIMESTAMPDIFF ( SECOND, {$join_start_key}.meta_value, '${upper_string}' ) >= %d
+				TIMESTAMPDIFF ( SECOND, {$join_start_key}.meta_value, '{$upper_string}' ) >= %d
 				AND
-				TIMESTAMPDIFF ( SECOND, '${lower_string}', {$join_end_key}.meta_value ) >= %d
+				TIMESTAMPDIFF ( SECOND, '{$lower_string}', {$join_end_key}.meta_value ) >= %d
 			)",
 			$min_sec_overlap,
 			$min_sec_overlap


### PR DESCRIPTION
Use `{$var}` instead.

[BTRIA-2088]

[BTRIA-2088]: https://stellarwp.atlassian.net/browse/BTRIA-2088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ