### PR TITLE
This adds a noindex X-Robots-Tag 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Tweak - Add an X-Robots-Tag to the response headers for ical download links to help prevent search engine crawling. [BTRIA-2096]
+* Tweak - Added filter: `tec_ical_header_noindex` to allow preventing the X-Robots-Tag addition. [BTRIA-2096]
 
 = [6.2.5] 2023-11-01 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add an X-Robots-Tag to the response headers for ical download links to help prevent search engine crawling. [BTRIA-2096]
+
 = [6.2.5] 2023-11-01 =
 
 * Tweak - Updated hook for showing Event name in the event tickets order report pages. [ET-1810]

--- a/readme.txt
+++ b/readme.txt
@@ -232,7 +232,7 @@ Remember to always make a backup of your database and files before updating!
 = [TBD] TBD =
 
 * Tweak - Add an X-Robots-Tag to the response headers for ical download links to help prevent search engine crawling. [BTRIA-2096]
-* Tweak - Added filter: `tec_ical_header_noindex` to allow preventing the X-Robots-Tag addition. [BTRIA-2096]
+* Tweak - Added filter: `tec_events_ical_header_noindex` to allow preventing the X-Robots-Tag addition. [BTRIA-2096]
 
 = [6.2.5] 2023-11-01 =
 

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -241,6 +241,8 @@ class iCalendar_Handler extends Service_Provider {
 	public function ical_header_properties() {
 		/**
 		 * Allows short-circuiting the logic to prevent the x-robots tag from being added to the response headers.
+		 *
+		 * @param bool $add If the x-robots tag should be added to the response headers.
 		 */
 		$add = (bool) apply_filters( 'tec_ical_header_noindex', true );
 

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -83,6 +83,7 @@ class iCalendar_Handler extends Service_Provider {
 	 */
 	public function register_hooks() {
 		add_action( 'tribe_events_views_v2_before_make_view', [ $this, 'get_feeds' ] );
+		add_action( 'send_headers', [ $this, 'ical_header_properties' ] );
 
 		add_filter( 'tribe_events_views_v2_view_template_vars', [ $this, 'filter_template_vars' ], 10, 2 );
 		add_filter( 'tribe_events_ical_single_event_links', [ $this, 'single_event_links' ], 20 );
@@ -230,5 +231,12 @@ class iCalendar_Handler extends Service_Provider {
 		$content .= "X-PUBLISHED-TTL:PT1H\r\n";
 
 		return $content;
+	}
+
+	public function ical_header_properties() {
+		if ( ! tribe_get_request_var( 'ical' ) && ! tribe_get_request_var( 'outlook-ical' ) ) {
+			return;
+		}
+		header( 'X-Robots-Tag:noindex, nofollow' );
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -233,6 +233,11 @@ class iCalendar_Handler extends Service_Provider {
 		return $content;
 	}
 
+	/**
+	 * Add x-robots tag to response headers for ical download links.
+	 *
+	 * @since TBD
+	 */
 	public function ical_header_properties() {
 		if ( ! tribe_get_request_var( 'ical' ) && ! tribe_get_request_var( 'outlook-ical' ) ) {
 			return;

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -244,7 +244,7 @@ class iCalendar_Handler extends Service_Provider {
 		 *
 		 * @param bool $add If the x-robots tag should be added to the response headers.
 		 */
-		$add = (bool) apply_filters( 'tec_ical_header_noindex', true );
+		$add = (bool) apply_filters( 'tec_events_ical_header_noindex', true );
 
 		if ( ! $add ) {
 			return;

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -239,9 +239,19 @@ class iCalendar_Handler extends Service_Provider {
 	 * @since TBD
 	 */
 	public function ical_header_properties() {
+		/**
+		 * Allows short-circuiting the logic to prevent the x-robots tag from being added to the response headers.
+		 */
+		$add = (bool) apply_filters( 'tec_ical_header_noindex', true );
+
+		if ( ! $add ) {
+			return;
+		}
+
 		if ( ! tribe_get_request_var( 'ical' ) && ! tribe_get_request_var( 'outlook-ical' ) ) {
 			return;
 		}
+
 		header( 'X-Robots-Tag:noindex, nofollow' );
 	}
 }


### PR DESCRIPTION
to the response headers for all `ical` and `outlook-ical` download "pages".

Reducing the amount of crawling and indexing of said pages.

[TEC-4966]


[TEC-4966]: https://stellarwp.atlassian.net/browse/TEC-4966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ