### PR TITLE
ETWP DQA Fix: Remove whitespace from directions link

### DIFF
--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/address.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/address.php
@@ -60,9 +60,9 @@ $append_after_address = array_map( 'trim', array_filter( [ $venue->state_provinc
 								if ( ! empty( $venue->directions_link ) ) :
 									echo $line_separator;
 									?>
-									<a href="<?php echo esc_url( $venue->directions_link ); ?>">
-										<?php echo esc_html_x( 'Get Directions', 'Link on the Ticket Email', 'the-events-calendar' ); ?>
-									</a>
+									<a href="<?php echo esc_url( $venue->directions_link ); ?>"><?php 
+										echo esc_html_x( 'Get Directions', 'Link on the Ticket Email', 'the-events-calendar' ); 
+									?></a>
 								<?php
 								endif;
 							?>


### PR DESCRIPTION
### Description
This removes the whitespace that was in the "Get Directions" link for the venue address.

### Artifacts
Before:
![image](https://github.com/the-events-calendar/the-events-calendar/assets/7432506/79ac7904-6ad2-4709-855b-14ab3df1b429)

After:
![image](https://github.com/the-events-calendar/the-events-calendar/assets/7432506/a49c9eeb-6525-4c65-a162-3d1fd4d3d1c9)
