### PR TITLE
Use absolute image path for PDF images to avoid TCPDF failures.

### DIFF
--- a/src/Events/Integrations/Plugins/Tickets_Wallet_Plus/Passes/Pdf.php
+++ b/src/Events/Integrations/Plugins/Tickets_Wallet_Plus/Passes/Pdf.php
@@ -9,18 +9,18 @@ use Tribe__Events__Main;
 
 /**
  * Class Pdf
- * 
+ *
  * @since TBD
- * 
+ *
  * @package TEC\Events\Integrations\Plugins\Tickets_Wallet_Plus\Passes
  */
 class Pdf {
 
 	/**
 	 * Template instance.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @var \Tribe__Template
 	 */
 	private $template;
@@ -48,9 +48,9 @@ class Pdf {
 	 * Filter template context.
 	 *
 	 * @since TBD
-	 * 
-	 * @param array $context
-	 * 
+	 *
+	 * @param array $context The template context.
+	 *
 	 * @return array
 	 */
 	public function filter_template_context( $context ): array {
@@ -68,7 +68,7 @@ class Pdf {
 			return $context;
 		}
 
-		$context['event'] = $event;
+		$context['event']  = $event;
 		$context['venues'] = $event->venues->all();
 
 		return $context;
@@ -76,13 +76,13 @@ class Pdf {
 
 	/**
 	 * Add styles.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @param string           $file     Path to the file.
 	 * @param string           $name     Name of the file.
 	 * @param \Tribe__Template $template Template instance.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function add_tec_styles( $file, $name, $template ): void {
@@ -95,13 +95,13 @@ class Pdf {
 
 	/**
 	 * Add venue.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @param string           $file     Path to the file.
 	 * @param string           $name     Name of the file.
 	 * @param \Tribe__Template $template Template instance.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function add_venue( $file, $name, $template ): void {
@@ -109,18 +109,26 @@ class Pdf {
 			return;
 		}
 
-		$this->get_template()->template( 'pdf/pass/body/event/venue', $template->get_local_values(), true );
+		$plugin_path = TEC::instance()->plugin_path;
+
+		$args                            = $template->get_local_values();
+		$args['venue_phone_image_src']   = $plugin_path . 'src/resources/images/icons/bitmap/phone.png';
+		$args['venue_map_pin_image_src'] = $plugin_path . 'src/resources/images/icons/bitmap/map-pin.png';
+		$args['venue_link_image_src']    = $plugin_path . 'src/resources/images/icons/bitmap/link.png';
+
+
+		$this->get_template()->template( 'pdf/pass/body/event/venue', $args, true );
 	}
 
 	/**
 	 * Add event date.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @param string           $file     Path to the file.
 	 * @param string           $name     Name of the file.
 	 * @param \Tribe__Template $template Template instance.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function add_event_date( $file, $name, $template ): void {
@@ -133,15 +141,14 @@ class Pdf {
 
 	/**
 	 * Add attendee fields.
-	 * 
+	 *
 	 * @since TBD
-	 * 
+	 *
 	 * @param array $context Path to the file.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function add_event_data_to_sample( $context ): array {
-		
 		$sample_event = (object) [
 			'ID'               => 213123123,
 			'permalink'        => '#',

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/date.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/date.php
@@ -7,7 +7,7 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue.php
@@ -7,11 +7,15 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *
  * @version TBD
+ *
+ * @var string $venue_map_pin_image_src The image source of the venue map pin icon.
+ * @var string $venue_phone_image_src The image source of the venue phone icon.
+ * @var string $venue_link_image_src The image source of the venue link icon.
  */
 
 if ( empty( $venues ) ) {

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/address.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/address.php
@@ -7,11 +7,15 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *
  * @version TBD
+ *
+ * @var string $venue_map_pin_image_src The image source of the venue map pin icon.
+ * @var string $venue_phone_image_src The image source of the venue phone icon.
+ * @var string $venue_link_image_src The image source of the venue link icon.
  */
 
 if ( empty( $venue ) ) {
@@ -29,10 +33,10 @@ $append_after_address = array_map( 'trim', array_filter( [ $venue->state_provinc
 			<table>
 				<tr>
 					<td width="24">
-						<img 
-							width="9" 
-							height="12" 
-							src="<?php echo esc_url( tribe_resource_url( 'images/icons/bitmap/map-pin.png', false, null, Tribe__Events__Main::instance() ) ); ?>" 
+						<img
+							width="9"
+							height="12"
+							src="<?php echo esc_url( $venue_map_pin_image_src ); ?>"
 						/>
 					</td>
 					<td width="211">
@@ -60,8 +64,8 @@ $append_after_address = array_map( 'trim', array_filter( [ $venue->state_provinc
 								if ( ! empty( $venue->directions_link ) ) :
 									echo $line_separator;
 									?>
-									<a href="<?php echo esc_url( $venue->directions_link ); ?>"><?php 
-										echo esc_html_x( 'Get Directions', 'Link on the Ticket Email', 'the-events-calendar' ); 
+									<a href="<?php echo esc_url( $venue->directions_link ); ?>"><?php
+										echo esc_html_x( 'Get Directions', 'Link on the Ticket Email', 'the-events-calendar' );
 									?></a>
 								<?php
 								endif;

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/phone.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/phone.php
@@ -7,11 +7,15 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *
  * @version TBD
+ *
+ * @var string $venue_map_pin_image_src The image source of the venue map pin icon.
+ * @var string $venue_phone_image_src The image source of the venue phone icon.
+ * @var string $venue_link_image_src The image source of the venue link icon.
  */
 
 if ( empty( $venue->phone ) ) {
@@ -25,10 +29,10 @@ if ( empty( $venue->phone ) ) {
 			<table>
 				<tr>
 					<td width="24">
-						<img 
-							width="12" 
-							height="11" 
-							src="<?php echo esc_url( tribe_resource_url( 'images/icons/bitmap/phone.png', false, null, Tribe__Events__Main::instance() ) ); ?>"
+						<img
+							width="12"
+							height="11"
+							src="<?php echo esc_url( $venue_phone_image_src ); ?>"
 						/>
 					</td>
 					<td width="211">

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/title.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/title.php
@@ -7,7 +7,7 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/website.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/website.php
@@ -7,11 +7,15 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *
  * @version TBD
+ *
+ * @var string $venue_map_pin_image_src The image source of the venue map pin icon.
+ * @var string $venue_phone_image_src The image source of the venue phone icon.
+ * @var string $venue_link_image_src The image source of the venue link icon.
  */
 
 if ( empty( $venue->website ) ) {
@@ -25,10 +29,10 @@ if ( empty( $venue->website ) ) {
 			<table>
 				<tr>
 					<td width="24">
-						<img 
-							width="9" 
-							height="9" 
-							src="<?php echo esc_url( tribe_resource_url( 'images/icons/bitmap/link.png', false, null, Tribe__Events__Main::instance() ) ); ?>"
+						<img
+							width="9"
+							height="9"
+							src="<?php echo esc_url( $venue_link_image_src ); ?>"
 						/>
 					</td>
 					<td width="211">

--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/tec-events-styles.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/tec-events-styles.php
@@ -7,7 +7,7 @@
  *
  * See more documentation about our views templating system.
  *
- * @link https://evnt.is/1amp
+ * @link https://evnt.is/event-tickets-wallet-plus-tpl Help article for Wallet Plus template files.
  *
  * @since TBD
  *
@@ -30,7 +30,7 @@
 		padding-top: 0;
 	}
 	.tec-tickets__wallet-plus-pdf-event-venue-title {
-		font-size: 10.5pt; 
+		font-size: 10.5pt;
 		font-weight: bold;
 	}
 	.tec-tickets__wallet-plus-pdf-event-venue-detail-table {


### PR DESCRIPTION
- Using absolute image path for the venue icons to avoid TCPDF failures. `tribe_resource_url` returns the URL and that can fail in different scenarios.
- Updating template vars and docs linking to the ETWP templating article (where the docs live).