### PR TITLE
Add a no index to alltheviews!

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,9 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.2.6] 2023-11-07 =
 
+* Tweak - Add a `noindex, nofollow` meta tag to all event views except if the calendar is set to the home page. [TBD]
+* Tweak - Added filter `tec_events_views_v2_noindex` to short-circuit the noindex meta tag addition.
+
 = [6.2.5] 2023-11-01 =
 
 * Tweak - Updated hook for showing Event name in the event tickets order report pages. [ET-1810]

--- a/readme.txt
+++ b/readme.txt
@@ -231,8 +231,8 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.2.6] 2023-11-07 =
 
-* Tweak - Add a `noindex, nofollow` meta tag to all event views except if the calendar is set to the home page. [TBD]
-* Tweak - Added filter `tec_events_views_v2_noindex` to short-circuit the noindex meta tag addition.
+* Tweak - Add a `noindex, nofollow` meta tag to all event views except if the calendar is set to the home page. [TEC-4976]
+* Tweak - Added filter `tec_events_views_v2_noindex` to short-circuit the noindex meta tag addition. [TEC-4976]
 
 = [6.2.5] 2023-11-01 =
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -71,6 +71,7 @@ class Hooks extends Service_Provider {
 		add_action( 'tribe_events_parse_query', [ $this, 'parse_query' ] );
 		add_action( 'template_redirect', [ $this, 'action_initialize_legacy_views' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_customizer_in_block_editor' ] );
+		add_action( 'wp_head', [ $this, 'action_add_noindex' ] );
 	}
 
 	/**
@@ -1178,6 +1179,38 @@ class Hooks extends Service_Provider {
 	public function action_include_global_elements_settings( $section, $manager, $customizer ) {
 		_deprecated_function( __METHOD__, '5.9.0' );
 		tribe( 'customizer' )->include_global_elements_settings( $section, $manager, $customizer );
+	}
+
+	/**
+	 * Conditionally adds a noindex meta tag to all event views.
+	 *
+	 * @since 6.2.6
+	 */
+	public function action_add_noindex(): void {
+		/**
+		 * Filter to disable the noindex meta tag on Views V2.
+		 *
+		 * @since 6.2.6
+		 *
+		 * @param bool $add Whether to add the noindex meta tag or not.
+		 */
+		$add = (bool) apply_filters( 'tec_events_views_v2_noindex', true );
+
+		// Don't add if the above filter has been changed,
+		// we're on the home page (event if the calendar is set to the home page)
+		// or we're not on an event view.
+		if (
+			! $add
+			|| is_home()
+			|| ! function_exists( 'tribe_context' )
+			|| is_null( tribe_context()->get( 'view' ) )
+		) {
+				return;
+		}
+
+		?>
+        <meta name="robots" content="noindex, nofollow" />
+        <?php
 	}
 
 	/**


### PR DESCRIPTION
Don't add one on:

- the site home page
- pages where tribe_context is not available
- any non-event views/pages
- if the filter is used

[TEC-4976]

[TEC-4976]: https://stellarwp.atlassian.net/browse/TEC-4976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ