### PR TITLE
Alter robots noindex, nofollow to be more flexible | TEC-4976

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -234,7 +234,8 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Add a `noindex, nofollow` meta tag to all event views except if the calendar is set to the home page. [TEC-4976]
 * Tweak - Add an X-Robots-Tag to the response headers for ical download links to help prevent search engine crawling. [TEC-4976]
 * Tweak - Added filter: `tec_events_ical_header_noindex` to allow preventing the X-Robots-Tag addition. [TEC-4976]
-* Tweak - Added filter `tec_events_views_v2_noindex` to short-circuit the noindex meta tag addition. [TEC-4976]
+* Tweak - Added filter `tec_events_views_v2_robots_meta_include` and `tec_events_views_v2_robots_meta_include_{$view}` to short-circuit the robots meta tag addition. [TEC-4976]
+* Tweak - Added filter `tec_events_views_v2_robots_meta_content` and `tec_events_views_v2_robots_meta_content_{$view}` to alter the content attribute of the robots meta tag addition. [TEC-4976]
 
 = [6.2.5] 2023-11-01 =
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -1255,8 +1255,8 @@ class Hooks extends Service_Provider {
 		}
 
 		?>
-		<!-- The following robots meta is from The Events Calendar: <?php esc_html_e( __METHOD__ ); ?> -->
-		<meta name="robots" content="<?php esc_attr_e( $robots_meta_content ); ?>"/>
+		<!-- The following robots meta is from The Events Calendar: <?php echo esc_html( __METHOD__ ); ?> -->
+		<meta name="robots" content="<?php echo esc_attr( $robots_meta_content ); ?>"/>
 		<?php
 	}
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -1195,7 +1195,7 @@ class Hooks extends Service_Provider {
 		}
 
 		// Don't noindex, nofollow on the home page.
-		if ( is_home() ) {
+		if ( is_home() || is_front_page() ) {
 			return;
 		}
 

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -1214,8 +1214,9 @@ class Hooks extends Service_Provider {
 		 * @since 6.2.6
 		 *
 		 * @param bool $do_include Whether to add the noindex, nofollow meta tag or not.
+		 * @param string $view The current view slug.
 		 */
-		$do_include = (bool) apply_filters( 'tec_events_views_v2_robots_meta_include', $do_include );
+		$do_include = (bool) apply_filters( 'tec_events_views_v2_robots_meta_include', $do_include, $view );
 
 		/**
 		 * Filter to disable the noindex meta tag on Views V2 for a specific view.
@@ -1223,8 +1224,9 @@ class Hooks extends Service_Provider {
 		 * @since 6.2.6
 		 *
 		 * @param bool $do_include Whether to add the noindex, nofollow meta tag or not.
+		 * @param string $view The current view slug.
 		 */
-		$do_include = (bool) apply_filters( "tec_events_views_v2_robots_meta_include_{$view}", $do_include );
+		$do_include = (bool) apply_filters( "tec_events_views_v2_robots_meta_include_{$view}", $do_include, $view );
 
 		if ( ! $do_include ) {
 			return;
@@ -1238,8 +1240,9 @@ class Hooks extends Service_Provider {
 		 * @since 6.2.6
 		 *
 		 * @param string $robots_meta_content The contents of the robots meta tag.
+		 * @param string $view The current view slug.
 		 */
-		$robots_meta_content = (string) apply_filters( 'tec_events_views_v2_robots_meta_content', $robots_meta_content );
+		$robots_meta_content = (string) apply_filters( 'tec_events_views_v2_robots_meta_content', $robots_meta_content, $view );
 
 		/**
 		 * Filter to disable the noindex meta tag on Views V2 for a specific view.
@@ -1247,8 +1250,9 @@ class Hooks extends Service_Provider {
 		 * @since 6.2.6
 		 *
 		 * @param string $robots_meta_content The contents of the robots meta tag.
+		 * @param string $view The current view slug.
 		 */
-		$robots_meta_content = (string) apply_filters( "tec_events_views_v2_robots_meta_content_{$view}", $robots_meta_content );
+		$robots_meta_content = (string) apply_filters( "tec_events_views_v2_robots_meta_content_{$view}", $robots_meta_content, $view );
 
 		if ( ! $robots_meta_content ) {
 			return;

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -1187,30 +1187,77 @@ class Hooks extends Service_Provider {
 	 * @since 6.2.6
 	 */
 	public function action_add_noindex(): void {
+		$view = tribe_context()->get( 'view' );
+
+		// If we don't have a view, bail.
+		if ( empty( $view ) ) {
+			return;
+		}
+
+		// Don't noindex, nofollow on the home page.
+		if ( is_home() ) {
+			return;
+		}
+
+		$do_include = false;
+		$manager    = tribe( Manager::class );
+		$view_class = $manager->get_view_class_by_slug( $view );
+
+		// If we have a view class and it is a subclass of the By_Day_View class (grid views), default to including noindex, nofollow.
+		if ( ! empty( $view_class ) && is_subclass_of( $view_class, Views\By_Day_View::class ) ) {
+			$do_include = true;
+		}
+
 		/**
 		 * Filter to disable the noindex meta tag on Views V2.
 		 *
 		 * @since 6.2.6
 		 *
-		 * @param bool $add Whether to add the noindex meta tag or not.
+		 * @param bool $do_include Whether to add the noindex, nofollow meta tag or not.
 		 */
-		$add = (bool) apply_filters( 'tec_events_views_v2_noindex', true );
+		$do_include = (bool) apply_filters( 'tec_events_views_v2_robots_meta_include', $do_include );
 
-		// Don't add if the above filter has been changed,
-		// we're on the home page (event if the calendar is set to the home page)
-		// or we're not on an event view.
-		if (
-			! $add
-			|| is_home()
-			|| ! function_exists( 'tribe_context' )
-			|| is_null( tribe_context()->get( 'view' ) )
-		) {
-				return;
+		/**
+		 * Filter to disable the noindex meta tag on Views V2 for a specific view.
+		 *
+		 * @since 6.2.6
+		 *
+		 * @param bool $do_include Whether to add the noindex, nofollow meta tag or not.
+		 */
+		$do_include = (bool) apply_filters( "tec_events_views_v2_robots_meta_include_{$view}", $do_include );
+
+		if ( ! $do_include ) {
+			return;
+		}
+
+		$robots_meta_content = 'noindex, nofollow';
+
+		/**
+		 * Filter to disable the noindex meta tag on Views V2.
+		 *
+		 * @since 6.2.6
+		 *
+		 * @param string $robots_meta_content The contents of the robots meta tag.
+		 */
+		$robots_meta_content = (string) apply_filters( 'tec_events_views_v2_robots_meta_content', $robots_meta_content );
+
+		/**
+		 * Filter to disable the noindex meta tag on Views V2 for a specific view.
+		 *
+		 * @since 6.2.6
+		 *
+		 * @param string $robots_meta_content The contents of the robots meta tag.
+		 */
+		$robots_meta_content = (string) apply_filters( "tec_events_views_v2_robots_meta_content_{$view}", $robots_meta_content );
+
+		if ( ! $robots_meta_content ) {
+			return;
 		}
 
 		?>
-        <meta name="robots" content="noindex, nofollow" />
-        <?php
+		<!-- The following robots meta is from The Events Calendar: <?php esc_html_e( __METHOD__ ); ?> -->
+		<meta name="robots" content="<?php esc_attr_e( $robots_meta_content ); ?>"/>
+		<?php
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Events/Views/V2/RobotsTest.php
+++ b/tests/wpunit/Tribe/Events/Views/V2/RobotsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tribe\Events\Views\V2;
+
+use Tribe__Events__Main as Main;
+use Tribe__Settings_Manager as Settings;
+
+class RobotsTest extends \Codeception\TestCase\WPTestCase {
+
+	public function get_view_robots_state() {
+		return [
+			'day' => [
+				'view' => 'day',
+				'include' => false,
+			],
+			'list' => [
+				'view' => 'list',
+				'include' => false,
+			],
+			'month' => [
+				'view' => 'month',
+				'include' => true,
+			],
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_view_robots_state
+	 */
+	public function it_should_contextually_output_robots_meta_tag_from_view( $view, $do_include ) {
+		$override_context = static function() use ( $view ) {
+			return $view;
+		};
+
+		add_filter( 'tribe_context_pre_view', $override_context );
+
+		ob_start();
+		tribe( 'events.views.v2.hooks' )->action_add_noindex();
+		$results = trim( ob_get_clean() );
+
+		$this->assertEquals( $do_include, !! $results );
+
+		remove_filter( 'tribe_context_pre_view', $override_context );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_view_robots_state
+	 */
+	public function it_should_not_output_robots_meta_tag_if_on_home( $view, $do_include ) {
+		global $wp_query;
+
+		$wp_query->is_home = true;
+
+		$override_context = static function() use ( $view ) {
+			return $view;
+		};
+
+		add_filter( 'tribe_context_pre_view', $override_context );
+
+		ob_start();
+		tribe( 'events.views.v2.hooks' )->action_add_noindex();
+		$results = trim( ob_get_clean() );
+
+		$this->assertFalse( !! $results );
+
+		remove_filter( 'tribe_context_pre_view', $override_context );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_view_robots_state
+	 */
+	public function it_should_output_robots_meta_tag_if_filtered_true( $view, $do_include ) {
+		$override_context = static function() use ( $view ) {
+			return $view;
+		};
+
+		add_filter( 'tribe_context_pre_view', $override_context );
+		add_filter( 'tec_events_views_v2_robots_meta_include', '__return_true' );
+
+		ob_start();
+		tribe( 'events.views.v2.hooks' )->action_add_noindex();
+		$results = trim( ob_get_clean() );
+
+		$this->assertTrue( !! $results );
+		$this->assertContains( 'noindex, nofollow', $results );
+
+		remove_filter( 'tec_events_views_v2_robots_meta_include', '__return_true' );
+		remove_filter( 'tribe_context_pre_view', $override_context );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_view_robots_state
+	 */
+	public function it_should_not_output_robots_meta_tag_if_filtered_false( $view, $do_include ) {
+		$override_context = static function() use ( $view ) {
+			return $view;
+		};
+
+		add_filter( 'tribe_context_pre_view', $override_context );
+		add_filter( 'tec_events_views_v2_robots_meta_include', '__return_false' );
+
+		ob_start();
+		tribe( 'events.views.v2.hooks' )->action_add_noindex();
+		$results = trim( ob_get_clean() );
+
+		$this->assertFalse( !! $results );
+
+		remove_filter( 'tec_events_views_v2_robots_meta_include', '__return_false' );
+		remove_filter( 'tribe_context_pre_view', $override_context );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_view_robots_state
+	 */
+	public function it_should_output_custom_robots_meta_tag( $view, $do_include ) {
+		$override_context = static function() use ( $view ) {
+			return $view;
+		};
+
+		$override_content = static function() {
+			return 'bacon';
+		};
+
+		add_filter( 'tribe_context_pre_view', $override_context );
+		add_filter( 'tec_events_views_v2_robots_meta_include', '__return_true' );
+		add_filter( 'tec_events_views_v2_robots_meta_content', $override_content );
+
+		ob_start();
+		tribe( 'events.views.v2.hooks' )->action_add_noindex();
+		$results = trim( ob_get_clean() );
+
+		$this->assertContains( 'bacon', $results );
+		$this->assertNotContains( 'noindex, nofollow', $results );
+
+		remove_filter( 'tec_events_views_v2_robots_meta_content', $override_content );
+		remove_filter( 'tec_events_views_v2_robots_meta_include', '__return_true' );
+		remove_filter( 'tribe_context_pre_view', $override_context );
+	}
+}


### PR DESCRIPTION
This allows for very targeted alterations of the robots meta tag for whether it appears and what its contents are.

Default state: robots meta tag is present with `noindex, nofollow` for grid-based views (Month and Week)

🎫 [TEC-4976]
🎥 https://www.loom.com/share/1d121c97cb354887aeee4f7c99644b50?sid=f9861749-76d0-430d-b3e5-9c87927046fa

[TEC-4976]: https://stellarwp.atlassian.net/browse/TEC-4976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ