### PR TITLE
Enable meta tag on Venues, Organizers, and Event Category pages

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,7 @@ Remember to always make a backup of your database and files before updating!
 * Tweak - Added filter: `tec_events_ical_header_noindex` to allow preventing the X-Robots-Tag addition. [TEC-4976]
 * Tweak - Added filter `tec_events_seo_robots_meta_include` and `tec_events_seo_robots_meta_include_{$view}` to short-circuit the robots meta tag addition. [TEC-4976]
 * Tweak - Added filter `tec_events_seo_robots_meta_content` to alter the content attribute of the robots meta tag addition. [TEC-4976]
+* Tweak - Added filter `tec_events_seo_robots_meta_allowable_post_types` to allow for the filtering of single post types that can have robots meta tags added.
 * Tweak - Deprecated filters `tec_events_add_no_index_meta_tag`, `tribe_events_add_no_index_meta`, and `tec_events_{$view}_add_no_index_meta` in favor of the above new filters.
 
 = [6.2.5] 2023-11-01 =

--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -49,8 +49,30 @@ class Controller extends Controller_Contract {
 	 * @return void
 	 */
 	public function hook_issue_noindex() {
-		if ( is_home() || is_front_page() || is_single() ) {
+		if ( is_home() || is_front_page() ) {
 			return;
+		}
+
+		if ( is_single() ) {
+			$post_type = get_post_type();
+
+			$linked_post_types           = (array) \Tribe__Events__Linked_Posts::instance()->get_linked_post_types();
+			$robots_enabled_post_types   = array_keys( $linked_post_types );
+			$robots_enabled_post_types[] = \Tribe__Events__Main::TAXONOMY;
+
+			/**
+			 * Allows for the filtering of post types that should allow noindex tags.
+			 *
+			 * @since 6.2.6
+			 *
+			 * @param array $robots_enabled_post_types The post types that should allow noindex tags.
+			 * @param string $post_type The current post type.
+			 */
+			$robots_enabled_post_types = (array) apply_filters( 'tec_events_seo_robots_meta_allowable_post_types', $robots_enabled_post_types, $post_type );
+
+			if ( ! in_array( $post_type, $robots_enabled_post_types ) ) {
+				return;
+			}
 		}
 
 		add_action( 'tribe_views_v2_after_setup_loop', [ $this, 'issue_noindex' ] );

--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -64,8 +64,8 @@ class Controller extends Controller_Contract {
 			 *
 			 * @since 6.2.6
 			 *
-			 * @param array $robots_enabled_post_types The post types that should allow noindex tags.
-			 * @param string $post_type The current post type.
+			 * @param array  $robots_enabled_post_types The post types that should allow noindex tags.
+			 * @param string $post_type                 The current post type.
 			 */
 			$robots_enabled_post_types = (array) apply_filters( 'tec_events_seo_robots_meta_allowable_post_types', $robots_enabled_post_types, $post_type );
 

--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -58,7 +58,6 @@ class Controller extends Controller_Contract {
 
 			$linked_post_types           = (array) \Tribe__Events__Linked_Posts::instance()->get_linked_post_types();
 			$robots_enabled_post_types   = array_keys( $linked_post_types );
-			$robots_enabled_post_types[] = \Tribe__Events__Main::TAXONOMY;
 
 			/**
 			 * Allows for the filtering of post types that should allow noindex tags.


### PR DESCRIPTION
This allows single pages for Venues, Organizers, and Event Categories to have meta tags injected.