### PR TITLE
This brings back some asserts that I removed accidentally

### DIFF
--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -10,10 +10,10 @@
  namespace TEC\Events\SEO;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use Tribe\Events\Views\V2\View_Interface;
 use Tribe\Events\Views\V2\Views;
 use Tribe__Date_Utils as Dates;
 use Tribe__Context;
-
 
 /**
  * Class Provider
@@ -98,6 +98,8 @@ class Controller extends Controller_Contract {
 	 *     add_filter( "tec_events_seo_robots_meta_include_{$view}", '__return_true' );
 	 *
 	 *  Where `$view` above is the view slug, e.g. `month`, `day`, `list`, etc.
+	 *
+	 * @param View_Interface $instance The view instance.
 	 */
 	public function issue_noindex( $instance ): void {
 		$context = $instance->get_context();
@@ -195,6 +197,8 @@ class Controller extends Controller_Contract {
 	 * Determine if a nonindex should be added for list based views that don't have events.
 	 *
 	 * @since 6.2.6
+	 *
+	 * @param View_Interface $instance The view instance.
 	 *
 	 * @return bool
 	 */

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
@@ -53,7 +53,7 @@ class With_NoindexTest extends ViewTestCase {
 	 */
 	public function test_noindex_render_empty( $class ) {
 		$tester = $this;
-		add_filter( 'tribe_events_add_no_index_meta', function( $add_noindex ) use ( $tester ) {
+		add_filter( 'tec_events_seo_robots_meta_include', function( $add_noindex ) use ( $tester ) {
 			$tester->assertTrue( $add_noindex );
 
 			return $add_noindex;
@@ -136,6 +136,24 @@ class With_NoindexTest extends ViewTestCase {
 
 		$view = View::make( $class, $this->context );
 		$view->get_html();
+
+		// Add our insertion on the filter so we can test the value. Month always gets noindex, so skip it.
+		add_filter( 'tec_events_seo_robots_meta_include', function( $add_noindex ) use ( $tester, $view ) {
+			if ( $view->get_slug() === 'month' ) {
+				return $add_noindex;
+			}
+
+			$tester->assertFalse( $add_noindex );
+
+			return $add_noindex;
+		});
+
+		// Make sure that month still has noindex.
+		add_filter( 'tec_events_seo_robots_meta_include_month', function( $add_noindex ) use ( $tester, $view ) {
+			$tester->assertTrue( $add_noindex );
+
+			return $add_noindex;
+		});
 
 		// Manually run the noindex check, triggering the assertion.
 		tribe( Controller::class )->issue_noindex( $view );


### PR DESCRIPTION
During the 6.2.6 release, I was too aggressive with removing some unnecessary code in the test for noindex and actually removed some asserts. This brings them back and adapts them to what they should be with the new filters.