### PR TITLE
[ETWP] Remove blank space at the end of the venue url.

### DIFF
--- a/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/website.php
+++ b/src/views/integrations/event-tickets-wallet-plus/pdf/pass/body/event/venue/website.php
@@ -42,8 +42,7 @@ if ( empty( $venue->website ) ) {
 								rel="noopener noreferrer"
 								class="tec-tickets__wallet-plus-pdf-event-venue-detail-link"
 							>
-								<?php echo esc_url( $venue->website ); ?>
-							</a>
+								<?php echo esc_url( $venue->website ); ?></a>
 						</div>
 					</td>
 				</tr>


### PR DESCRIPTION
Remove space at the end of the link so that we avoid having unnecessary blank space underlined (by default in PDFs)