### PR TITLE
Fix/ecp 1535 latest range fail

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,10 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Fix - Our Week view "Next" pagination button would fail to show in some scenarios. This was due to improper tracking of which is the next future occurrence date. [ECP-1535]
+
+= [TBD] TBD =
+
 * Fix - On the Past Events View, the nonce was incorrectly being generated twice, and one of them would be cached in our HTML transient cache. This was causing a 401 nonce errors to occur when the cached nonce expired. The nonce generation was moved outside the HTML generation that is being cached. [TEC-4936]
 * Tweak - Adjust the content in the admin welcome page to include a link to the TEC Facebook community group. [TEC-4953]
 * Fix - Wordpress 6.3 introduce some changes in filters that regressed a prior fix for authentication and our new nonce structure used in view pagination. One symptom of the issue was losing the authenticated user and failing to display user specific capabilities on event views. [ECP-1601]

--- a/src/Events/Custom_Tables/V1/Updates/Events.php
+++ b/src/Events/Custom_Tables/V1/Updates/Events.php
@@ -140,10 +140,7 @@ class Events {
 		$latest   = $this->get_latest_occurrence();
 
 		if ( $earliest ) {
-			$earliest_id = $earliest->provisional_id;
-			if ( ! $earliest_id ) {
-				$earliest_id = $earliest->post_id;
-			}
+			$earliest_id = $earliest->provisional_id ? $earliest->provisional_id : $earliest->post_id;
 			tribe_update_option( 'earliest_date', $earliest->start_date_utc );
 			tribe_update_option( 'earliest_date_markers', [ $earliest_id ] );
 		} else {
@@ -152,10 +149,7 @@ class Events {
 		}
 
 		if ( $latest ) {
-			$latest_id = $latest->provisional_id;
-			if ( ! $latest_id ) {
-				$latest_id = $latest->post_id;
-			}
+			$latest_id = $latest->provisional_id ? $latest->provisional_id : $latest->post_id;
 			tribe_update_option( 'latest_date', $latest->end_date_utc );
 			tribe_update_option( 'latest_date_markers', [ $latest_id ] );
 		} else {

--- a/src/Events/Custom_Tables/V1/Updates/Events.php
+++ b/src/Events/Custom_Tables/V1/Updates/Events.php
@@ -131,6 +131,7 @@ class Events {
 	 *
 	 * @since 6.0.0
 	 * @since 6.0.13 Fix for "markers" being computed incorrectly, and only fetching provisional IDs.
+	 * @since TBD Fix for latest not detecting provisional IDs (magic property ternary check failure).
 	 *
 	 * @return true To indicate the earliest and latest Event dates were updated.
 	 */
@@ -139,16 +140,24 @@ class Events {
 		$latest   = $this->get_latest_occurrence();
 
 		if ( $earliest ) {
+			$earliest_id = $earliest->provisional_id;
+			if ( ! $earliest_id ) {
+				$earliest_id = $earliest->post_id;
+			}
 			tribe_update_option( 'earliest_date', $earliest->start_date_utc );
-			tribe_update_option( 'earliest_date_markers', [ $earliest->provisional_id ?? $earliest->post_id ] );
+			tribe_update_option( 'earliest_date_markers', [ $earliest_id ] );
 		} else {
 			tribe_remove_option( 'earliest_date' );
 			tribe_remove_option( 'earliest_date_markers' );
 		}
 
 		if ( $latest ) {
+			$latest_id = $latest->provisional_id;
+			if ( ! $latest_id ) {
+				$latest_id = $latest->post_id;
+			}
 			tribe_update_option( 'latest_date', $latest->end_date_utc );
-			tribe_update_option( 'latest_date_markers', [ $latest->provisional_id ?? $latest->post_id ] );
+			tribe_update_option( 'latest_date_markers', [ $latest_id ] );
 		} else {
 			tribe_remove_option( 'latest_date' );
 			tribe_remove_option( 'latest_date_markers' );


### PR DESCRIPTION
[ECP-1535](https://stellarwp.atlassian.net/browse/ECP-1535)

The "Next" pagination button on week view was not always working. This was due to how we were storing the latest occurrence ID. It was failing to detect when it should store the provisional ID, and it would always store the post ID. 

Test is here (it affected recurring events): https://github.com/the-events-calendar/events-pro/pull/2334

Artifacts:
![Screenshot 2023-11-09 140855](https://github.com/the-events-calendar/the-events-calendar/assets/2826045/315de76d-1410-40c6-9cf3-d140a050c6fb)



[ECP-1535]: https://stellarwp.atlassian.net/browse/ECP-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ