### PR TITLE
Tweak `tribe_get_venues` to work with provisional IDs.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,7 +231,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
-* Tweak - Updated the `tribe_get_venues` function to work with recurring events that have provisonal IDs. [ECP-1597]
+* Tweak - Updated the `tribe_get_venues` function to work with recurring events that have provisional IDs. [ECP-1597]
 
 = [TBD] TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,11 @@ Contributors: theeventscalendar, borkweb, bordoni, brianjessee, aguseo, camwynsp
 Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
 Requires at least: 6.2.0
+<<<<<<< HEAD
+Stable tag: 6.2.9
+=======
 Stable tag: 6.2.8.1
+>>>>>>> master
 Tested up to: 6.4.1
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -231,12 +231,17 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Tweak - Updated the `tribe_get_venues` function to work with recurring events that have provisonal IDs. [ECP-1597]
+
+= [TBD] TBD =
+
 * Fix - On the Past Events View, the nonce was incorrectly being generated twice, and one of them would be cached in our HTML transient cache. This was causing a 401 nonce errors to occur when the cached nonce expired. The nonce generation was moved outside the HTML generation that is being cached. [TEC-4936]
 * Tweak - Adjust the content in the admin welcome page to include a link to the TEC Facebook community group. [TEC-4953]
 * Fix - Wordpress 6.3 introduce some changes in filters that regressed a prior fix for authentication and our new nonce structure used in view pagination. One symptom of the issue was losing the authenticated user and failing to display user specific capabilities on event views. [ECP-1601]
 * Fix - Resolves issue where a deleted venue still attached to an event would cause an `PHP Warning: Undefined variable $data in /code/wp-content/plugins/the-events-calendar/src/Tribe/REST/V1/Post_Repository.php on line 327` error. [TEC-4954]
 * Fix - Resolves an issue with certain versions of Wordpress already having the legacy widget block registered causing us to trigger the console error `Block "core/legacy-widget" is already registered.` would occur. Now we check if registered first. [TEC-4764]
 * Fix - Resolved several `Deprecated: Creation of dynamic property` warnings on: `\Tribe__Events__Linked_Posts__Chooser_Meta_Box::$singular_name_lowercase` and `\TEC\Events\Custom_Tables\V1\Models\Builder::$query` [BTRIA-2088]
+
 = [6.2.6.1] 2023-11-09 =
 
 * Version - The Events Calendar 6.2.6.1 is only compatible with Event Tickets 5.6.8.1 and higher

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -758,7 +758,7 @@ function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $s
 	 *
 	 * @since TBD
 	 *
-	 * @param array $args The array of arguments passed to the tribe_get_venues function.
+	 * @param int $event The provisional event ID.
 	 *
 	 * @return array Modified $args with normalized 'event' ID.
 	 */

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -733,6 +733,8 @@ function tribe_get_phone( $postId = null ) {
 
 /**
  * Get all the venues
+ * 
+ * @since TBD - Applied the `tec_events_custom_tables_v1_normalize_occurrence_id` filter to convert provisional IDs into regular IDs.
  *
  * @param bool  $only_with_upcoming Only return venues with upcoming events attached to them.
  * @param int   $posts_per_page
@@ -750,6 +752,11 @@ function tribe_get_phone( $postId = null ) {
 function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $suppress_filters = true, array $args = [] ) {
 	// filter out the `null` values
 	$args = array_diff_key( $args, array_filter( $args, 'is_null' ) );
+
+	// Convert provisional IDs into regular post IDs. 
+	if ( isset( $args['event'] ) ) {
+		$args['event'] = apply_filters( 'tec_events_custom_tables_v1_normalize_occurrence_id', $args['event'] );
+	}
 
 	if ( tribe_is_truthy( $only_with_upcoming ) ) {
 		$args['only_with_upcoming'] = true;

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -760,7 +760,7 @@ function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $s
 	 *
 	 * @param int $event The provisional event ID.
 	 *
-	 * @return array Modified $args with normalized 'event' ID.
+	 * @return int The normalized event ID.
 	 */
 	if ( isset( $args['event'] ) ) {
 		$args['event'] = apply_filters( 'tec_events_custom_tables_v1_normalize_occurrence_id', $args['event'] );

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -725,8 +725,8 @@ function tribe_get_phone( $postId = null ) {
 	 * @since ??
 	 * @since 4.5.11 Added docblock and venue ID to filter
 	 *
-	 * @param bool $output The escaped phone number for the venue.
-	 * @param int  $venue_id The venue ID
+	 * @param string $output The escaped phone number for the venue.
+	 * @param int    $venue_id The venue ID
 	 */
 	return apply_filters( 'tribe_get_phone', $output, $venue_id );
 }

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -734,7 +734,7 @@ function tribe_get_phone( $postId = null ) {
 /**
  * Get all the venues
  * 
- * @since TBD - Applied the `tec_events_custom_tables_v1_normalize_occurrence_id` filter to convert provisional IDs into regular IDs.
+ * @since TBD Applied the `tec_events_custom_tables_v1_normalize_occurrence_id` filter to convert provisional IDs into regular IDs.
  *
  * @param bool  $only_with_upcoming Only return venues with upcoming events attached to them.
  * @param int   $posts_per_page

--- a/src/functions/template-tags/venue.php
+++ b/src/functions/template-tags/venue.php
@@ -753,7 +753,15 @@ function tribe_get_venues( $only_with_upcoming = false, $posts_per_page = -1, $s
 	// filter out the `null` values
 	$args = array_diff_key( $args, array_filter( $args, 'is_null' ) );
 
-	// Convert provisional IDs into regular post IDs. 
+	/**
+	 * Convert provisional IDs into regular post IDs.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The array of arguments passed to the tribe_get_venues function.
+	 *
+	 * @return array Modified $args with normalized 'event' ID.
+	 */
 	if ( isset( $args['event'] ) ) {
 		$args['event'] = apply_filters( 'tec_events_custom_tables_v1_normalize_occurrence_id', $args['event'] );
 	}

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -459,4 +459,25 @@ class venueTest extends Events_TestCase {
 		$this->assertNotContains( $state_province_string, $full_address_html_with_province_id, 'Full Address for a Venue not the US without StateProvince should NOT contain the StateProvince' );
 		$this->assertNotContains( $state_string, $full_address_html_with_province_id, 'Full Address for a Venue not the US without StateProvince should NOT contain the State' );
 	}
+
+	/**
+	 * Tests whether or not the `tec_events_custom_tables_v1_normalize_occurrence_id` filter is applied to provisional IDs.
+	 *
+	 * @test
+	 */
+	public function test_normalize_provisional_id() {
+		$provisional_id = 10000641;
+		$filter_applied = false;
+
+		// Mock the filter to set $filter_applied to true
+		tests_add_filter( 'tec_events_custom_tables_v1_normalize_occurrence_id', function ( $id ) use ( &$filter_applied ) {
+			$filter_applied = true;
+
+			return $id; // Return the ID unchanged
+		} );
+
+		tribe_get_venues( false, - 1, true, [ 'event' => $provisional_id ] );
+
+		$this->assertTrue( $filter_applied, 'The `tec_events_custom_tables_v1_normalize_occurrence_id` filter should be applied.' );
+	}
 }

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -466,7 +466,7 @@ class venueTest extends Events_TestCase {
 	 * @test
 	 */
 	public function test_normalize_provisional_id() {
-		$provisional_id = 10000641;
+		$provisional_id = 123;
 		$filter_applied = false;
 
 		// Mock the filter to set $filter_applied to true

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -470,11 +470,13 @@ class venueTest extends Events_TestCase {
 		$filter_applied = false;
 
 		// Mock the filter to set $filter_applied to true
-		tests_add_filter( 'tec_events_custom_tables_v1_normalize_occurrence_id', function ( $id ) use ( &$filter_applied ) {
-			$filter_applied = true;
-
-			return $id; // Return the ID unchanged
-		} );
+		tests_add_filter(
+			'tec_events_custom_tables_v1_normalize_occurrence_id', 
+			function ( $id ) use ( &$filter_applied ) {
+				$filter_applied = true;
+				return $id; // Return the ID unchanged
+			}
+		);
 
 		tribe_get_venues(
 			false,

--- a/tests/wpunit/functions/template-tags/venueTest.php
+++ b/tests/wpunit/functions/template-tags/venueTest.php
@@ -476,7 +476,12 @@ class venueTest extends Events_TestCase {
 			return $id; // Return the ID unchanged
 		} );
 
-		tribe_get_venues( false, - 1, true, [ 'event' => $provisional_id ] );
+		tribe_get_venues(
+			false,
+			- 1,
+			true,
+			[ 'event' => $provisional_id ]
+		);
 
 		$this->assertTrue( $filter_applied, 'The `tec_events_custom_tables_v1_normalize_occurrence_id` filter should be applied.' );
 	}


### PR DESCRIPTION
## Ticket
[ECP-1597](https://stellarwp.atlassian.net/browse/ECP-1597)

### Description 🛠️
Update the `tribe_get_venues` function to work with recurring events that have provisional IDs by applying the `tec_events_custom_tables_v1_normalize_occurrence_id` filter.

### Screencast 🎥
https://drive.google.com/file/d/1PZHi0z9BzQx6mF4cU1NvxUn-B1vkEbbZ/view?usp=sharing

[ECP-1597]: https://stellarwp.atlassian.net/browse/ECP-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ