### PR TITLE
Fix CSS class application in Month view for past and current days.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
 Requires at least: 6.2.0
 Stable tag: 6.2.7
-Tested up to: 6.4.0
+Tested up to: 6.4.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -229,7 +229,7 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [6.2.7] 2023-11-13 =
+= [6.2.7] 2023-11-14 =
 
 * Fix - On the Past Events View, the nonce was incorrectly being generated twice, and one of them would be cached in our HTML transient cache. This was causing a 401 nonce errors to occur when the cached nonce expired. The nonce generation was moved outside the HTML generation that is being cached. [TEC-4936]
 * Fix - Wordpress 6.3 introduce some changes in filters that regressed a prior fix for authentication and our new nonce structure used in view pagination. One symptom of the issue was losing the authenticated user and failing to display user specific capabilities on event views. [ECP-1601]

--- a/readme.txt
+++ b/readme.txt
@@ -238,7 +238,6 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Resolved several `Deprecated: Creation of dynamic property` warnings on: `\Tribe__Events__Linked_Posts__Chooser_Meta_Box::$singular_name_lowercase` and `\TEC\Events\Custom_Tables\V1\Models\Builder::$query` [BTRIA-2088]
 * Tweak - Adjust the content in the admin welcome page to include a link to the TEC Facebook community group. [TEC-4953]
 * Tweak - Added filters: `tec_events_get_full_site_block_template_services`, `tec_events_views_v2_get_rest_nonce_html`
-* Tweak - Added actions: `tribe_log`
 * Tweak - Changed views: `blocks/archive-events`, `blocks/single-event`
 * Language - 11 new strings added, 119 updated, 0 fuzzied, and 5 obsoleted.
 

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Resolves an issue where the `tribe-events-calendar-month__day--past` and `tribe-events-calendar-month__day--current` classes were not consistently applied after navigating through different months in the Month View. [TEC-4898]
+
 = [6.2.7] 2023-11-14 =
 
 * Fix - On the Past Events View, the nonce was incorrectly being generated twice, and one of them would be cached in our HTML transient cache. This was causing a 401 nonce errors to occur when the cached nonce expired. The nonce generation was moved outside the HTML generation that is being cached. [TEC-4936]

--- a/readme.txt
+++ b/readme.txt
@@ -229,14 +229,19 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
-= [TBD] TBD =
+= [6.2.7] 2023-11-13 =
 
 * Fix - On the Past Events View, the nonce was incorrectly being generated twice, and one of them would be cached in our HTML transient cache. This was causing a 401 nonce errors to occur when the cached nonce expired. The nonce generation was moved outside the HTML generation that is being cached. [TEC-4936]
-* Tweak - Adjust the content in the admin welcome page to include a link to the TEC Facebook community group. [TEC-4953]
 * Fix - Wordpress 6.3 introduce some changes in filters that regressed a prior fix for authentication and our new nonce structure used in view pagination. One symptom of the issue was losing the authenticated user and failing to display user specific capabilities on event views. [ECP-1601]
 * Fix - Resolves issue where a deleted venue still attached to an event would cause an `PHP Warning: Undefined variable $data in /code/wp-content/plugins/the-events-calendar/src/Tribe/REST/V1/Post_Repository.php on line 327` error. [TEC-4954]
 * Fix - Resolves an issue with certain versions of Wordpress already having the legacy widget block registered causing us to trigger the console error `Block "core/legacy-widget" is already registered.` would occur. Now we check if registered first. [TEC-4764]
 * Fix - Resolved several `Deprecated: Creation of dynamic property` warnings on: `\Tribe__Events__Linked_Posts__Chooser_Meta_Box::$singular_name_lowercase` and `\TEC\Events\Custom_Tables\V1\Models\Builder::$query` [BTRIA-2088]
+* Tweak - Adjust the content in the admin welcome page to include a link to the TEC Facebook community group. [TEC-4953]
+* Tweak - Added filters: `tec_events_get_full_site_block_template_services`, `tec_events_views_v2_get_rest_nonce_html`
+* Tweak - Added actions: `tribe_log`
+* Tweak - Changed views: `blocks/archive-events`, `blocks/single-event`
+* Language - 11 new strings added, 119 updated, 0 fuzzied, and 5 obsoleted.
+
 = [6.2.6.1] 2023-11-09 =
 
 * Version - The Events Calendar 6.2.6.1 is only compatible with Event Tickets 5.6.8.1 and higher

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -127,7 +127,7 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 	 * @param array<mixed> $day             The current day data.
 	 * @param string       $today_date      Today's date in the `Y-m-d` format.
 	 */
-	$comparison_date =  apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day, $today_date  );
+	$comparison_date =  apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day, $today_date );
 
 	// Convert it to a date object.
 	$comparison_date = Dates::immutable( $comparison_date );

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -127,7 +127,7 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 	 * @param array<mixed> $day             The current day data.
 	 * @param string       $today_date      Today's date in the `Y-m-d` format.
 	 */
-	$comparison_date =  apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day, $today_date );
+	$comparison_date = apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day, $today_date );
 
 	// Convert it to a date object.
 	$comparison_date = Dates::immutable( $comparison_date );

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -112,22 +112,20 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
  * @return array<string,bool> $day_classes The classes to add to the day "cell".
  */
 function month_day_classes( array $day, string $day_date, \DateTime $request_date, string $today_date ) {
-	// The date used for comparisons is today's date by default.
-	$comparison_date = $today_date;
-
 	/**
 	 * Allows filtering the date used for comparison when generating the Month View day cell classes.
 	 *
 	 * @since 6.0.2
 	 * @since TBD Added `$today_date` parameter to the filter.
+	 * @since TBD Comparison date now defaults to today's date instead of the request date.
 	 *
-	 * @param string       $comparison_date The date used for comparisons.
+	 * @param string       $comparison_date The date used for comparisons. Defaults to today's date ($today_date).
 	 * @param \DateTime    $request_date    The request date for the view.
 	 * @param string       $day_date        The current day date, in the `Y-m-d` format.
 	 * @param array<mixed> $day             The current day data.
 	 * @param string       $today_date      Today's date in the `Y-m-d` format.
 	 */
-	$comparison_date = apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day, $today_date );
+	$comparison_date = apply_filters( 'tec_events_month_day_classes_comparison_date', $today_date, $request_date, $day_date, $day, $today_date );
 
 	// Convert it to a date object.
 	$comparison_date = Dates::immutable( $comparison_date );

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -121,7 +121,7 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 	 * @since 6.0.2
 	 *
 	 * @param string       $comparison_date The date used for comparisons.
-	 * @param DateTime     $request_date    The request date for the view.
+	 * @param \DateTime    $request_date    The request date for the view.
 	 * @param string       $day_date        The current day date, in the `Y-m-d` format.
 	 * @param array<mixed> $day             The current day data.
 	 */

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -102,6 +102,7 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
  * Outputs classes for each day "cell".
  *
  * @since 6.0.2
+ * @since TBD Updated to use $today_date for class comparisons, fixing issues with incorrect class application when navigating between months.
  *
  * @param array<mixed> $day          The current day data.
  * @param string       $day_date     The current day date, in the `Y-m-d` format.
@@ -133,9 +134,9 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 	$day_classes = [
 		'tribe-events-calendar-month__day'              => true,
 		// Add a class for the current day.
-		'tribe-events-calendar-month__day--current'     => $comparison_date->format( 'Y-m-d' ) === $day_date,
+		'tribe-events-calendar-month__day--current'     => $today_date === $day_date,
 		// Add a class for the past days (includes days in the requested month).
-		'tribe-events-calendar-month__day--past'        => $comparison_date->format( 'Y-m-d' ) > $day_date,
+		'tribe-events-calendar-month__day--past'        => $today_date > $day_date,
 		// Not the requested month.
 		'tribe-events-calendar-month__day--other-month' => $day[ 'month_number' ] !== $comparison_date->format( 'm' ),
 		// Past month.

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -4,6 +4,7 @@
  *
  * @since 5.1.1
  */
+
 namespace Tribe\Events\Views\V2;
 
 use Tribe__Date_Utils as Dates;
@@ -51,12 +52,12 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
 		 *
 		 * @since 5.1.1
 		 *
-		 * @param array<string> $classes    An array of thee classes to be applied.
-		 * @param WP_Post $event            An event post object with event-specific properties added from the the `tribe_get_event`
-		 *                                  function.
-		 * @param string  $day_date         The `Y-m-d` date of the day currently being displayed.
-		 * @param bool    $is_start_of_week Whether the current grid day being rendered is the first day of the week or not.
-		 * @param string  $today_date       Today's date in the `Y-m-d` format.
+		 * @param array<string> $classes          An array of thee classes to be applied.
+		 * @param WP_Post       $event            An event post object with event-specific properties added from the the `tribe_get_event`
+		 *                                        function.
+		 * @param string        $day_date         The `Y-m-d` date of the day currently being displayed.
+		 * @param bool          $is_start_of_week Whether the current grid day being rendered is the first day of the week or not.
+		 * @param string        $today_date       Today's date in the `Y-m-d` format.
 		 */
 		return apply_filters( 'tribe_events_views_v2_month_multiday_classes', $classes, $event, $day_date, $is_start_of_week, $today_date );
 	}
@@ -87,12 +88,12 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
 	 *
 	 * @since 5.1.1
 	 *
-	 * @param array<string> $classes    An array of thee classes to be applied.
-	 * @param WP_Post $event            An event post object with event-specific properties added from the the `tribe_get_event`
-	 *                                  function.
-	 * @param string  $day_date         The `Y-m-d` date of the day currently being displayed.
-	 * @param bool    $is_start_of_week Whether the current grid day being rendered is the first day of the week or not.
-	 * @param string  $today_date       Today's date in the `Y-m-d` format.
+	 * @param array<string> $classes          An array of thee classes to be applied.
+	 * @param WP_Post       $event            An event post object with event-specific properties added from the the `tribe_get_event`
+	 *                                        function.
+	 * @param string        $day_date         The `Y-m-d` date of the day currently being displayed.
+	 * @param bool          $is_start_of_week Whether the current grid day being rendered is the first day of the week or not.
+	 * @param string        $today_date       Today's date in the `Y-m-d` format.
 	 */
 	return apply_filters( 'tribe_events_views_v2_month_multiday_classes', $classes, $event, $day_date, $is_start_of_week, $today_date );
 }
@@ -102,7 +103,8 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
  * Outputs classes for each day "cell".
  *
  * @since 6.0.2
- * @since TBD Updated to use $today_date for class comparisons, fixing issues with incorrect class application when navigating between months.
+ * @since TBD Updated to use `$today_date` for class comparisons by default, fixing issues with incorrect class application when navigating between months.
+ *        Users can still override the default behavior through the `tec_events_month_day_classes_comparison_date` filter.
  *
  * @param array<mixed> $day          The current day data.
  * @param string       $day_date     The current day date, in the `Y-m-d` format.
@@ -112,20 +114,23 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
  * @return array<string,bool> $day_classes The classes to add to the day "cell".
  */
 function month_day_classes( array $day, string $day_date, \DateTime $request_date, string $today_date ) {
-	// If for some reason we don't have a request date, use today's date.
-	$comparison_date = ! empty( $request_date ) ? $request_date->format( 'Y-m-d' ) : $today_date;
+	// If there's no request date, initialize it with today's date.
+	$request_date = ! empty( $request_date ) ? $request_date : \DateTime::createFromFormat( 'Y-m-d', $today_date );
 
 	/**
 	 * Allows filtering the date used for comparison when generating the Month View day cell classes.
 	 *
 	 * @since 6.0.2
+	 * @since TBD Updated to reflect the default use of `$today_date` for class comparisons.
 	 *
-	 * @param string       $comparison_date The date used for comparisons.
+	 * @param string       $comparison_date The date used for comparisons. Defaults to the `$request_date` if provided, otherwise `$today_date`.
 	 * @param \DateTime    $request_date    The request date for the view.
 	 * @param string       $day_date        The current day date, in the `Y-m-d` format.
 	 * @param array<mixed> $day             The current day data.
+	 *
+	 * @return string $comparison_date The final date used for comparisons.
 	 */
-	$comparison_date =  apply_filters( 'tec_events_month_day_classes_comparison_date', $comparison_date, $request_date, $day_date, $day  );
+	$comparison_date = apply_filters( 'tec_events_month_day_classes_comparison_date', $request_date->format( 'Y-m-d' ), $request_date, $day_date, $day );
 
 	// Convert it to a date object.
 	$comparison_date = Dates::immutable( $comparison_date );
@@ -135,14 +140,14 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 		'tribe-events-calendar-month__day'              => true,
 		// Add a class for the current day.
 		'tribe-events-calendar-month__day--current'     => $today_date === $day_date,
-		// Add a class for the past days (includes days in the requested month).
+		// Add a class for the past days.
 		'tribe-events-calendar-month__day--past'        => $today_date > $day_date,
 		// Not the requested month.
-		'tribe-events-calendar-month__day--other-month' => $day[ 'month_number' ] !== $comparison_date->format( 'm' ),
+		'tribe-events-calendar-month__day--other-month' => $day['month_number'] !== $comparison_date->format( 'm' ),
 		// Past month.
-		'tribe-events-calendar-month__day--past-month'  => $day[ 'month_number' ] < $comparison_date->format( 'm' ),
+		'tribe-events-calendar-month__day--past-month'  => $day['month_number'] < $comparison_date->format( 'm' ),
 		// Future month.
-		'tribe-events-calendar-month__day--next-month'  => $day[ 'month_number' ] > $comparison_date->format( 'm' ),
+		'tribe-events-calendar-month__day--next-month'  => $day['month_number'] > $comparison_date->format( 'm' ),
 	];
 
 	/**


### PR DESCRIPTION
## Ticket
[TEC-4898](https://stellarwp.atlassian.net/browse/TEC-4898)

### Description 🛠️
This update addresses an issue in the Month View where the `tribe-events-calendar-month__day--past` and `tribe-events-calendar-month__day--current` classes were not consistently applied when users navigated away from and back to the current month.

This fix ensures that any custom styling applied to the classes is consistent and persists even after paginating to different months.

### Screencast 🎥
https://drive.google.com/file/d/1l5rEByThHHUUvgP6UY5Eierx2MsG03HA/view?usp=sharing

[TEC-4898]: https://stellarwp.atlassian.net/browse/TEC-4898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ