### PR TITLE
Add some filters and a new Trait to consolidate the export functionality.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Tweak - Define image sizes on the List view featured image to avoid Content Layout Shifting. [TEC-4919]
 * Tweak - Add new filters to allow customization of the subscribe and export links. [TEC-4916]
+* Tweak - Added filters: , `tec_events_subscribe_link_url`, `tec_events_{$slug}_subscribe_link_url`, `tec_events_export_link_visibility`, `tec_events_{$slug}_export_link_visibility`, `tec_events_export_link_url_single`, `tec_events_{$slug}_export_link_url_single`, `tec_events_export_link_url`, `tec_events_{$slug}_export_link_url`
 
 = [6.2.8.1] 2023-11-20 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -234,7 +234,7 @@ Remember to always make a backup of your database and files before updating!
 = TBD [TBD] =
 
 * Tweak - Add new filters to allow customization of the subscribe and export links. [TEC-4916]
-* Tweak - Added filters: , `tec_events_subscribe_link_url`, `tec_events_{$slug}_subscribe_link_url`, `tec_events_export_link_visibility`, `tec_events_{$slug}_export_link_visibility`, `tec_events_export_link_url_single`, `tec_events_{$slug}_export_link_url_single`, `tec_events_export_link_url`, `tec_events_{$slug}_export_link_url`
+* Tweak - Added filters: `tec_events_subscribe_link_url`, `tec_events_{$slug}_subscribe_link_url`, `tec_events_export_link_visibility`, `tec_events_{$slug}_export_link_visibility`, `tec_events_export_link_url_single`, `tec_events_{$slug}_export_link_url_single`, `tec_events_export_link_url`, `tec_events_{$slug}_export_link_url`
 
 = [6.2.9] 2023-12-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,11 +4,7 @@ Contributors: theeventscalendar, borkweb, bordoni, brianjessee, aguseo, camwynsp
 Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
 Requires at least: 6.2.0
-<<<<<<< HEAD
 Stable tag: 6.2.9
-=======
-Stable tag: 6.2.8.1
->>>>>>> master
 Tested up to: 6.4.1
 Requires PHP: 7.4
 License: GPLv2 or later
@@ -238,6 +234,7 @@ Remember to always make a backup of your database and files before updating!
 = [6.2.9] TBD =
 
 * Tweak - Define image sizes on the List view featured image to avoid Content Layout Shifting. [TEC-4919]
+* Tweak - Add new filters to allow customization of the subscribe and export links. [TEC-4916]
 
 = [6.2.8.1] 2023-11-20 =
 

--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -1,18 +1,41 @@
 <?php
-// Don't load directly
+/**
+ * The Events Calendar Aggregator main class
+ */
 
 use Tribe\Events\Admin\Settings;
 
-defined( 'WPINC' ) or die;
+// Don't load directly.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
-class Tribe__Events__Aggregator {
+/**
+ * Class Tribe__Events__Aggregator
+ *
+ * @since 4.3.0
+ */
+class Tribe__Events__Aggregator {// phpcs:ignore TEC.Classes.ValidClassName.NotSnakeCase, PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace.
 	/**
 	 * Cache key used to storage the services list returned by the call to:
 	 * - Tribe__Events__Aggregator__Service::instance()->get_origins();
 	 *
 	 * @since 4.6.12
+	 * @deprecated TBD use $key_cache_services instead.
+	 *
+	 * @var string
 	 */
-	public $KEY_CACHE_SERVICES = 'tribe_aggregator_services_list';
+	public $KEY_CACHE_SERVICES = 'tribe_aggregator_services_list'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * Cache key used to storage the services list returned by the call to:
+	 * - Tribe__Events__Aggregator__Service::instance()->get_origins();
+	 *
+	 * @since 4.6.12
+	 *
+	 * @var string
+	 */
+	public $key_cache_services = 'tribe_aggregator_services_list';
 
 	/**
 	 * @var Tribe__Events__Aggregator__Meta_Box Event Aggregator Meta Box object
@@ -50,7 +73,7 @@ class Tribe__Events__Aggregator {
 	public $pue_checker;
 
 	/**
-	 * @var array Collection of API objects
+	 * @var Tribe__Events__Aggregator__API__Abstract|stdClass|null|array Collection of API objects
 	 */
 	protected $api;
 
@@ -62,8 +85,9 @@ class Tribe__Events__Aggregator {
 	private $daily_limit = 100;
 
 	/**
-	 * A variable holder if Aggregator is loaded
-	 * @var boolean
+	 * A variable holder if Aggregator is loaded.
+	 *
+	 * @var boolean Whether Events Aggregator is loaded or not.
 	 */
 	private $is_loaded = false;
 
@@ -99,17 +123,18 @@ class Tribe__Events__Aggregator {
 	public function add_status_to_help() {
 		global $plugin_page;
 
+		$page                   = tribe_get_request_var( 'page' );
 		$is_multisite_help_page = is_multisite()
 								&& is_network_admin()
-								&& ! empty( $_GET['page'] )
-								&& $_GET['page'] === tribe( 'settings' )->get_help_slug();
+								&& ! empty( $page )
+								&& tribe( 'settings' )->get_help_slug() === $page;
 
 		if ( ! ( 'tribe-help' === $plugin_page || $is_multisite_help_page ) ) {
 			return;
 		}
 
-		$help = Tribe__Admin__Help_Page::instance();
-		$section_name = 'tribe-aggregator-status';
+		$help          = Tribe__Admin__Help_Page::instance();
+		$section_name  = 'tribe-aggregator-status';
 		$section_title = __( 'Event Aggregator System Status', 'the-events-calendar' );
 
 		ob_start();
@@ -131,22 +156,21 @@ class Tribe__Events__Aggregator {
 		if ( ! is_admin() || tribe( 'context' )->doing_ajax() ) {
 			return;
 		}
-
 	}
 
 	/**
 	 * Initializes and provides the API objects
 	 *
-	 * @param string $api Which API to provide
+	 * @param string $api Which API to provide.
 	 *
 	 * @return Tribe__Events__Aggregator__API__Abstract|stdClass|null
 	 */
 	public function api( $api = null ) {
 		if ( ! $this->api ) {
 			$this->api = (object) [
-				'origins' => new Tribe__Events__Aggregator__API__Origins,
-				'import'  => new Tribe__Events__Aggregator__API__Import,
-				'image'   => new Tribe__Events__Aggregator__API__Image,
+				'origins' => new Tribe__Events__Aggregator__API__Origins(),
+				'import'  => new Tribe__Events__Aggregator__API__Import(),
+				'image'   => new Tribe__Events__Aggregator__API__Image(),
 			];
 		}
 
@@ -164,21 +188,24 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Creates the Required Endpoint for the Aggregator Service to Query
 	 *
-	 * @param array $query_vars
+	 * @param Tribe__Events__Rewrite $rewrite Rewrite object.
 	 *
 	 * @return void
 	 */
 	public function action_endpoint_configuration( $rewrite ) {
 		$rewrite->add(
 			[ 'event-aggregator', '(insert)' ],
-			[ 'tribe-aggregator' => 1, 'tribe-action' => '%1' ]
+			[
+				'tribe-aggregator' => 1,
+				'tribe-action'     => '%1',
+			]
 		);
 	}
 
 	/**
 	 * Adds the required Query Vars for the Aggregator Endpoint to work
 	 *
-	 * @param array $query_vars
+	 * @param array $query_vars Query vars.
 	 *
 	 * @return array
 	 */
@@ -192,20 +219,20 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Allows the API to call the website
 	 *
-	 * @param  WP    $wp
+	 * @param  WP $wp WordPress object.
 	 *
 	 * @return void
 	 */
 	public function action_endpoint_parse_request( $wp ) {
-		// If we don't have both of these we bail
+		// If we don't have both of these we bail.
 		if ( ! isset( $wp->query_vars['tribe-aggregator'] ) || empty( $wp->query_vars['tribe-action'] ) ) {
 			return;
 		}
 
-		// Fetches which action we are talking about `/event-aggregator/{$action}`
+		// Fetches which action we are talking about `/event-aggregator/{$action}`.
 		$action = $wp->query_vars['tribe-action'];
 
-		// Bail if we don't have an action
+		// Bail if we don't have an action.
 		if ( ! $action ) {
 			return;
 		}
@@ -227,15 +254,15 @@ class Tribe__Events__Aggregator {
 		 */
 		do_action( "tribe_aggregator_endpoint_{$action}", $wp );
 
-		// If we reached this point this endpoint call was invalid
+		// If we reached this point this endpoint call was invalid.
 		return wp_send_json_error();
 	}
 
 	/**
 	 * Handles the filtering of the PUE "plugin name" for event aggregator which...isn't a plugin
 	 *
-	 * @param string $plugin_name Plugin name to filter
-	 * @param string $plugin_slug Plugin slug
+	 * @param string $plugin_name Plugin name to filter.
+	 * @param string $plugin_slug Plugin slug.
 	 *
 	 * @return string
 	 */
@@ -250,7 +277,7 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Filters the list of post types for Event Tickets to remove Import Records
 	 *
-	 * @param array $post_types Post Types
+	 * @param array $post_types Post Types.
 	 *
 	 * @return array
 	 */
@@ -265,7 +292,7 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Purges the aggregator transients that are tied to the event-aggregator license
 	 *
-	 * @param string $option Option key
+	 * @param string $option Option key.
 	 *
 	 * @return boolean
 	 */
@@ -276,7 +303,7 @@ class Tribe__Events__Aggregator {
 
 		$cache_group = $this->api( 'origins' )->cache_group;
 
-		$purged = true;
+		$purged  = true;
 		$purged &= (bool) delete_transient( "{$cache_group}_origins" );
 		$purged &= (bool) delete_transient( "{$cache_group}_origin_limit" );
 
@@ -286,12 +313,12 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Verify if Aggregator was fully loaded and is active
 	 *
-	 * @param  boolean $service  Should compare if the service is also active
+	 * @param  boolean $service  Should compare if the service is also active.
 	 *
 	 * @return boolean
 	 */
 	public function is_active( $service = false ) {
-		// If it's not loaded just bail false
+		// If it's not loaded just bail false.
 		if ( false === (bool) $this->is_loaded ) {
 			return false;
 		}
@@ -363,7 +390,7 @@ class Tribe__Events__Aggregator {
 	/**
 	 * Reduces the daily limit by the provided amount
 	 *
-	 * @param int $amount Amount to reduce the daily limit by
+	 * @param int $amount Amount to reduce the daily limit by.
 	 *
 	 * @return bool
 	 */
@@ -395,7 +422,8 @@ class Tribe__Events__Aggregator {
 	}
 
 	/**
-	 * Tells whether the legacy ical plugin is active
+	 * Tells whether the legacy ical plugin is active.
+	 * Still used to throw a notice in Tribe__Events__Aggregator__Page.
 	 *
 	 * @return boolean
 	 */
@@ -405,6 +433,7 @@ class Tribe__Events__Aggregator {
 
 	/**
 	 * Tells whether the legacy facebook plugin is active
+	 * Still used to throw a notice in Tribe__Events__Aggregator__Page.
 	 *
 	 * @return boolean
 	 */
@@ -427,32 +456,32 @@ class Tribe__Events__Aggregator {
 		 */
 		$should_load = (bool) apply_filters( 'tribe_aggregator_should_load', true );
 
-		// You shall not Load!
+		// You shall not Load!.
 		if ( true !== $should_load ) {
 			return false;
 		}
 
-		// Loads the Required Classes and saves them as proprieties
-		$this->meta_box = Tribe__Events__Aggregator__Meta_Box::instance();
-		$this->migrate = Tribe__Events__Aggregator__Migrate::instance();
-		$this->page = Tribe__Events__Aggregator__Page::instance();
-		$this->service = tribe( 'events-aggregator.service' );
-		$this->settings = tribe( 'events-aggregator.settings' );
-		$this->records = Tribe__Events__Aggregator__Records::instance();
-		$this->cron = Tribe__Events__Aggregator__Cron::instance();
-		$this->queue_processor = new Tribe__Events__Aggregator__Record__Queue_Processor;
-		$this->queue_realtime = new Tribe__Events__Aggregator__Record__Queue_Realtime( null, null, $this->queue_processor );
-		$this->errors = Tribe__Events__Aggregator__Errors::instance();
-		$this->pue_checker = new Tribe__PUE__Checker(
+		// Loads the Required Classes and saves them as proprieties.
+		$this->meta_box        = Tribe__Events__Aggregator__Meta_Box::instance();
+		$this->migrate         = Tribe__Events__Aggregator__Migrate::instance();
+		$this->page            = Tribe__Events__Aggregator__Page::instance();
+		$this->service         = tribe( 'events-aggregator.service' );
+		$this->settings        = tribe( 'events-aggregator.settings' );
+		$this->records         = Tribe__Events__Aggregator__Records::instance();
+		$this->cron            = Tribe__Events__Aggregator__Cron::instance();
+		$this->queue_processor = new Tribe__Events__Aggregator__Record__Queue_Processor();
+		$this->queue_realtime  = new Tribe__Events__Aggregator__Record__Queue_Realtime( null, null, $this->queue_processor );
+		$this->errors          = Tribe__Events__Aggregator__Errors::instance();
+		$this->pue_checker     = new Tribe__PUE__Checker(
 			'http://tri.be/',
 			'event-aggregator',
 			[ 'context' => 'service' ]
 		);
 
-		// Initializes the Classes related to the API
+		// Initializes the Classes related to the API.
 		$this->api();
 
-		// Flags that the Aggregator has been fully loaded
+		// Flags that the Aggregator has been fully loaded.
 		$this->is_loaded = true;
 
 		return $this->is_loaded;
@@ -463,7 +492,11 @@ class Tribe__Events__Aggregator {
 	 *
 	 * WordPress mime support requires a one to one mapping of an extension to a type, but CSV can come in multiple types
 	 *
-	 * @param  array $mimes supported mime types
+	 * @param  array  $info     file info.
+	 * @param  string $file     file path.
+	 * @param  string $filename file name.
+	 * @param  array  $mimes    supported mime types.
+	 *
 	 * @return array        mime types with expanded support
 	 */
 	public function add_csv_mimes( $info, $file, $filename, $mimes ) {
@@ -471,7 +504,7 @@ class Tribe__Events__Aggregator {
 		$ext = $wp_filetype['ext'];
 		$type = $wp_filetype['type'];
 
-		if ( $ext !== 'csv' ) {
+		if ( 'csv' !== $ext ) {
 			return $info;
 		}
 
@@ -481,7 +514,7 @@ class Tribe__Events__Aggregator {
 			$real_mime = finfo_file( $finfo, $file );
 			finfo_close( $finfo );
 
-			// If the extension matches an alternate mime type, let's use it
+			// If the extension matches an alternate mime type, let's use it.
 			if ( in_array( $real_mime, [ 'text/plain', 'text/csv', 'text/comma-separated-values' ] ) ) {
 				$info['ext'] = $ext;
 				$info['type'] = $type;
@@ -509,52 +542,42 @@ class Tribe__Events__Aggregator {
 
 	/**
 	 * Hooks all the filters and actions needed for Events Aggregator to work.
-     *
-     * No action or filter will be loaded if Events Aggregator has not loaded first.
-     *
-     * @return bool `true` if the hooks and filters were added, `false` otherwise.
+	 *
+	 * No action or filter will be loaded if Events Aggregator has not loaded first.
+	 *
+	 * @return bool `true` if the hooks and filters were added, `false` otherwise.
 	 */
 	public function hook() {
 		if ( ! $this->is_loaded ) {
 			return false;
 		}
 
-		// Register the Aggregator Endpoint
+		// Register the Aggregator Endpoint.
 		add_action( 'tribe_events_pre_rewrite', [ $this, 'action_endpoint_configuration' ] );
 
-		// Intercept the Endpoint and trigger actions
+		// Intercept the Endpoint and trigger actions.
 		add_action( 'parse_request', [ $this, 'action_endpoint_parse_request' ] );
 
-		// Add endpoint query vars
+		// Add endpoint query vars.
 		add_filter( 'query_vars', [ $this, 'filter_endpoint_query_vars' ] );
 
-		// Filter the "plugin name" for Event Aggregator
+		// Filter the "plugin name" for Event Aggregator.
 		add_filter( 'pue_get_plugin_name', [ $this, 'filter_pue_plugin_name' ], 10, 2 );
 
-		// To make sure that meaningful cache is purged when settings are changed
+		// To make sure that meaningful cache is purged when settings are changed.
 		add_action( 'updated_option', [ $this, 'action_purge_transients' ] );
 
-		// Remove aggregator records from ET
+		// Remove aggregator records from ET.
 		add_filter( 'tribe_tickets_settings_post_types', [ $this, 'filter_remove_record_post_type' ] );
 
-		// Notify users about expiring Facebook Token if oauth is enabled
+		// Notify users about expiring Facebook Token if oauth is enabled.
 		add_action( 'plugins_loaded', [ $this, 'setup_notices' ], 11 );
 
-		// Add admin bar items for Aggregator
+		// Add admin bar items for Aggregator.
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_admin_bar_items' ], 10 );
 
-		// Remove caches associated with the list of services
+		// Remove caches associated with the list of services.
 		add_action( 'tribe_settings_after_save', [ $this, 'clear_services_list_cache' ] );
-
-		// Let's prevent events-importer-ical from DESTROYING its saved recurring imports when it gets deactivated
-		if ( class_exists( 'Tribe__Events__Ical_Importer__Main' ) ) {
-			remove_action(
-				'deactivate_' . plugin_basename(
-					Tribe__Events__Ical_Importer__Main::$plugin_path . 'the-events-calendar-ical-importer.php'
-				),
-				'tribe_events_ical_deactivate'
-			);
-		}
 
 		add_action( 'admin_init', [ $this, 'add_status_to_help' ] );
 
@@ -571,84 +594,6 @@ class Tribe__Events__Aggregator {
 	 * @return boolean
 	 */
 	public function clear_services_list_cache() {
-		return delete_transient( $this->KEY_CACHE_SERVICES );
-	}
-
-	public function notice_facebook_oauth_feedback() {
-		_deprecated_function( __FUNCTION__, '4.6.24', 'Importing from Facebook is no longer supported in Event Aggregator.' );
-
-		if ( empty( $_GET['ea-auth'] ) || 'facebook' !== $_GET['ea-auth'] ) {
-			return false;
-		}
-
-		$html = '<p>' . esc_html__( 'Successfully connected Event Aggregator to Facebook', 'the-events-calendar' ) . '</p>';
-
-		return Tribe__Admin__Notices::instance()->render( 'tribe-aggregator-facebook-oauth-feedback', $html );
-	}
-
-	public function notice_facebook_token_expired() {
-		_deprecated_function( __FUNCTION__, '4.6.24', 'Importing from Facebook is no longer supported in Event Aggregator.' );
-
-		if ( ! Tribe__Admin__Helpers::instance()->is_screen() ) {
-			return false;
-		}
-
-		$expires = tribe_get_option( 'fb_token_expires' );
-
-		// Empty Token
-		if ( empty( $expires ) ) {
-			return false;
-		}
-
-		/**
-		 * Allow developers to filter how many seconds they want to be warned about FB token expiring
-		 * @param int
-		 */
-		$boundary = apply_filters( 'tribe_aggregator_facebook_token_expire_notice_boundary', 4 * DAY_IN_SECONDS );
-
-		// Creates a Boundary for expire warning to appear, before the actual expiring of the token
-		$boundary = $expires - $boundary;
-
-		if ( time() < $boundary ) {
-			return false;
-		}
-
-		$diff = human_time_diff( time(), $boundary );
-		$passed = ( time() - $expires );
-		$original = date( 'Y-m-d H:i:s', $expires );
-
-		$time[] = '<span title="' . esc_attr( $original ) . '">';
-		if ( $passed > 0 ) {
-			$time[] = sprintf( esc_html_x( 'about %s ago', 'human readable time ago', 'the-events-calendar' ), $diff );
-		} else {
-			$time[] = sprintf( esc_html_x( 'in about %s', 'in human readable time', 'the-events-calendar' ), $diff );
-		}
-		$time[] = '</span>';
-		$time = implode( '', $time );
-
-		ob_start();
-		?>
-		<p>
-			<?php
-			if ( $passed > 0 ) {
-				printf( esc_html__( 'Your Event Aggregator Facebook token expired %s.', 'the-events-calendar' ), esc_html( $time ) );
-			} else {
-				printf( esc_html__( 'Your Event Aggregator Facebook token will expire %s.', 'the-events-calendar' ), esc_html( $time ) );
-			}
-			?>
-		</p>
-		<p>
-			<a
-				href="<?php echo esc_url( tribe( Settings::class )->get_url( [ 'tab' => 'addons' ] ) ); ?>"
-				class="tribe-license-link"
-			>
-				<?php esc_html_e( 'Renew your Event Aggregator Facebook token', 'the-events-calendar' ); ?>
-			</a>
-		</p>
-		<?php
-
-		$html = ob_get_clean();
-
-		return Tribe__Admin__Notices::instance()->render( 'tribe-aggregator-facebook-token-expired', $html );
+		return delete_transient( $this->key_cache_services );
 	}
 }

--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -100,9 +100,9 @@ class Tribe__Events__Aggregator {
 		global $plugin_page;
 
 		$is_multisite_help_page = is_multisite()
-		                          && is_network_admin()
-		                          && ! empty( $_GET['page'] )
-		                          && $_GET['page'] === tribe( 'settings' )->get_help_slug();
+								&& is_network_admin()
+								&& ! empty( $_GET['page'] )
+								&& $_GET['page'] === tribe( 'settings' )->get_help_slug();
 
 		if ( ! ( 'tribe-help' === $plugin_page || $is_multisite_help_page ) ) {
 			return;

--- a/src/Tribe/Aggregator.php
+++ b/src/Tribe/Aggregator.php
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
  *
  * @since 4.3.0
  */
-class Tribe__Events__Aggregator {// phpcs:ignore TEC.Classes.ValidClassName.NotSnakeCase, PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace.
+class Tribe__Events__Aggregator { // phpcs:ignore TEC.Classes.ValidClassName.NotSnakeCase, PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
 	/**
 	 * Cache key used to storage the services list returned by the call to:
 	 * - Tribe__Events__Aggregator__Service::instance()->get_origins();
@@ -501,8 +501,8 @@ class Tribe__Events__Aggregator {// phpcs:ignore TEC.Classes.ValidClassName.NotS
 	 */
 	public function add_csv_mimes( $info, $file, $filename, $mimes ) {
 		$wp_filetype = wp_check_filetype( $filename, $mimes );
-		$ext = $wp_filetype['ext'];
-		$type = $wp_filetype['type'];
+		$ext         = $wp_filetype['ext'];
+		$type        = $wp_filetype['type'];
 
 		if ( 'csv' !== $ext ) {
 			return $info;
@@ -510,13 +510,13 @@ class Tribe__Events__Aggregator {// phpcs:ignore TEC.Classes.ValidClassName.NotS
 
 		if ( function_exists( 'finfo_file' ) ) {
 			// Use finfo_file if available to validate non-image files.
-			$finfo = finfo_open( FILEINFO_MIME_TYPE );
+			$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 			$real_mime = finfo_file( $finfo, $file );
 			finfo_close( $finfo );
 
 			// If the extension matches an alternate mime type, let's use it.
 			if ( in_array( $real_mime, [ 'text/plain', 'text/csv', 'text/comma-separated-values' ] ) ) {
-				$info['ext'] = $ext;
+				$info['ext']  = $ext;
 				$info['type'] = $type;
 			}
 		}

--- a/src/Tribe/Aggregator/Admin_Bar.php
+++ b/src/Tribe/Aggregator/Admin_Bar.php
@@ -80,7 +80,7 @@ class Tribe__Events__Aggregator__Admin_Bar {
 			return;
 		}
 
-		$transient_key    = tribe( 'events-aggregator.main' )->KEY_CACHE_SERVICES;
+		$transient_key    = tribe( 'events-aggregator.main' )->key_cache_services;
 		$service_response = get_transient( $transient_key );
 
 		// Save HTTP request into a transient

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -40,7 +40,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		const POSTTYPE            = 'tribe_events';
 		const VENUE_POST_TYPE     = 'tribe_venue';
 		const ORGANIZER_POST_TYPE = 'tribe_organizer';
-
 		const VERSION             = '6.3.1';
 
 		/**

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -976,6 +976,7 @@ class View implements View_Interface {
 		}
 
 		$event_display_mode = $this->context->get( 'event_display_mode', false );
+
 		if (
 			'past' === $event_display_mode
 			&& $event_display_mode !== $this->context->get( 'eventDisplay' )

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -8,11 +8,10 @@
 
 namespace Tribe\Events\Views\V2\iCalendar\Links;
 
-use Tribe__Date_Utils as Dates;
 use \Tribe\Events\Views\V2\View;
 
 /**
- * Class Abstract_Link
+ * Class Link_Abstract
  *
  * @since   5.12.0
  * @package Tribe\Events\Views\V2\iCalendar
@@ -163,10 +162,11 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @since 5.14.0
 		 *
 		 * @param boolean $visible Whether to display the link.
+		 * @param Link_Abstract $link_obj The link object the visibility is for.
 		 *
 		 * @return boolean $visible Whether to display the link.
 		 */
-		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_visibility', $visible );
+		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_visibility', $visible, $this );
 
 		/**
 		 * Allows link-specific filtering of the visibility.
@@ -174,10 +174,11 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @since 5.14.0
 		 *
 		 * @param boolean $visible Whether to display the link.
+		 * @param Link_Abstract $link_obj The link object the visibility is for.
 		 *
 		 * @return boolean $visible Whether to display the link.
 		 */
-		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', $visible );
+		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', $visible, $this );
 
 		// Set the object property to the filtered value.
 		$this->set_visibility( $visible );
@@ -248,8 +249,9 @@ abstract class Link_Abstract implements Link_Interface {
 	 * {@inheritDoc}
 	 */
 	public function get_uri( View $view = null ) {
+		$is_single = is_single();
 		// If we're on a Single Event view, let's bypass the canonical function call and logic.
-		if ( is_single() ) {
+		if ( $is_single ) {
 			$feed_url = null === $view ? tribe_get_single_ical_link() : $view->get_context()->get( 'single_ical_link', false );
 		}
 
@@ -267,9 +269,10 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @since TBD
 		 *
 		 * @param string $url The URL for the subscribe link.
+		 * @param boolean $is_single Whether the link is for a single event page.
 		 * @param Link_Abstract $link_obj The link object the url is for.
 		 */
-		$url = apply_filters( 'tec_events_subscribe_link_url', $feed_url, $this );
+		$url = apply_filters( 'tec_events_get_subscribe_link_url', $feed_url, $is_single, $this );
 
 		/**
 		 * Allows filtering of the URL for a service-specific subscribe link.
@@ -277,9 +280,10 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @since TBD
 		 *
 		 * @param string $url The URL for the subscribe link.
+		 * @param boolean $is_single Whether the link is for a single event page.
 		 * @param Link_Abstract $link_obj The link object the url is for.
 		 */
-		$url = apply_filters( 'tec_events_subscribe_link_url_' . static::$slug, $url, $this );
+		$url = apply_filters( 'tec_events_get_subscribe_link_url_' . static::$slug, $url, $is_single, $this );
 
 		$url = str_replace( [ 'http://', 'https://' ], 'webcal://', $url );
 

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -261,9 +261,29 @@ abstract class Link_Abstract implements Link_Interface {
 			return '';
 		}
 
-		$feed_url = str_replace( [ 'http://', 'https://' ], 'webcal://', $feed_url );
+		/**
+		 * Allows filtering of the URL for the subscribe links.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $url The URL for the subscribe link.
+		 * @param Link_Abstract $link_obj The link object the url is for.
+		 */
+		$url = apply_filters( 'tec_events_subscribe_link_url', $feed_url, $this );
 
-		return $feed_url;
+		/**
+		 * Allows filtering of the URL for a service-specific subscribe link.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $url The URL for the subscribe link.
+		 * @param Link_Abstract $link_obj The link object the url is for.
+		 */
+		$url = apply_filters( 'tec_events_subscribe_link_url_' . static::$slug, $url, $this );
+
+		$url = str_replace( [ 'http://', 'https://' ], 'webcal://', $url );
+
+		return $url;
 	}
 
 	/**

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -166,7 +166,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 *
 		 * @return boolean $visible Whether to display the link.
 		 */
-		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_visibility', $visible, $this );
+		$visible = (bool) apply_filters( 'tec_views_v2_subscribe_link_visibility', $visible, $this );
 
 		/**
 		 * Allows link-specific filtering of the visibility.
@@ -178,7 +178,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 *
 		 * @return boolean $visible Whether to display the link.
 		 */
-		$visible = (boolean) apply_filters( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', $visible, $this );
+		$visible = (bool) apply_filters( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', $visible, $this );
 
 		// Set the object property to the filtered value.
 		$this->set_visibility( $visible );
@@ -272,7 +272,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @param boolean $is_single Whether the link is for a single event page.
 		 * @param Link_Abstract $link_obj The link object the url is for.
 		 */
-		$url = apply_filters( 'tec_events_get_subscribe_link_url', $feed_url, $is_single, $this );
+		$url = apply_filters( 'tec_events_subscribe_link_url', $feed_url, $is_single, $this );
 
 		/**
 		 * Allows filtering of the URL for a service-specific subscribe link.
@@ -283,7 +283,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @param boolean $is_single Whether the link is for a single event page.
 		 * @param Link_Abstract $link_obj The link object the url is for.
 		 */
-		$url = apply_filters( 'tec_events_get_subscribe_link_url_' . static::$slug, $url, $is_single, $this );
+		$url = apply_filters( "tec_events_{static::get_slug()}_subscribe_link_url", $url, $is_single, $this );
 
 		$url = str_replace( [ 'http://', 'https://' ], 'webcal://', $url );
 

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -274,6 +274,8 @@ abstract class Link_Abstract implements Link_Interface {
 		 */
 		$url = apply_filters( 'tec_events_subscribe_link_url', $feed_url, $is_single, $this );
 
+		$slug = static::get_slug();
+
 		/**
 		 * Allows filtering of the URL for a service-specific subscribe link.
 		 *
@@ -283,7 +285,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 * @param boolean $is_single Whether the link is for a single event page.
 		 * @param Link_Abstract $link_obj The link object the url is for.
 		 */
-		$url = apply_filters( "tec_events_{static::get_slug()}_subscribe_link_url", $url, $is_single, $this );
+		$url = apply_filters( "tec_events_{$slug}_subscribe_link_url", $url, $is_single, $this );
 
 		$url = str_replace( [ 'http://', 'https://' ], 'webcal://', $url );
 

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -161,7 +161,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 *
 		 * @since 5.14.0
 		 *
-		 * @param boolean $visible Whether to display the link.
+		 * @param boolean       $visible  Whether to display the link.
 		 * @param Link_Abstract $link_obj The link object the visibility is for.
 		 *
 		 * @return boolean $visible Whether to display the link.
@@ -173,7 +173,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 *
 		 * @since 5.14.0
 		 *
-		 * @param boolean $visible Whether to display the link.
+		 * @param boolean       $visible  Whether to display the link.
 		 * @param Link_Abstract $link_obj The link object the visibility is for.
 		 *
 		 * @return boolean $visible Whether to display the link.

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -160,6 +160,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 * Allows filtering of the visibility for the links.
 		 *
 		 * @since 5.14.0
+		 * @since TBD Now passing the link object as a param.
 		 *
 		 * @param boolean       $visible  Whether to display the link.
 		 * @param Link_Abstract $link_obj The link object the visibility is for.
@@ -172,6 +173,7 @@ abstract class Link_Abstract implements Link_Interface {
 		 * Allows link-specific filtering of the visibility.
 		 *
 		 * @since 5.14.0
+		 * @since TBD Now passing the link object as a param.
 		 *
 		 * @param boolean       $visible  Whether to display the link.
 		 * @param Link_Abstract $link_obj The link object the visibility is for.

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_365.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_365.php
@@ -30,11 +30,6 @@ class Outlook_365 extends Link_Abstract {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static $service_slug = 'office';
-
-	/**
-	 * {@inheritDoc}
-	 */
 	public $block_slug = 'hasOutlook365';
 
 	/**
@@ -43,5 +38,8 @@ class Outlook_365 extends Link_Abstract {
 	public function register() {
 		$this->label        = __( 'Outlook 365', 'the-events-calendar' );
 		$this->single_label = $this->label;
+
+		// Defined and used in the trait.
+		self::$service_slug = 'office';
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_365.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_365.php
@@ -30,7 +30,7 @@ class Outlook_365 extends Link_Abstract {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static $calendar_slug = 'office';
+	public static $service_slug = 'office';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
@@ -55,6 +55,6 @@ class Outlook_Export extends Link_Abstract {
 	public function filter_tec_views_v2_subscribe_link_outlook_ics_visibility( $visible ) {
 		_deprecated_function( __METHOD__, 'TBD', 'Outlook_Export::filter_tec_views_v2_subscribe_link_visibility' );
 		// Don't display on single event by default.
-		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this);
+		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this );
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
@@ -35,8 +35,8 @@ class Outlook_Export extends Link_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function register() {
-		self::$query_arg = 'outlook-ical';
-		$this->label = _x( 'Export Outlook .ics file', 'The text for the link to export and Outlook ics file.', 'the-events-calendar' );
+		self::$query_arg    = 'outlook-ical';
+		$this->label        = _x( 'Export Outlook .ics file', 'The text for the link to export and Outlook ics file.', 'the-events-calendar' );
 		$this->single_label = $this->label;
 		$this->filters();
 	}

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_Export.php
@@ -10,6 +10,7 @@
 namespace Tribe\Events\Views\V2\iCalendar\Links;
 use Tribe\Events\Views\V2\View;
 use Tribe__Events__Main;
+use Tribe\Events\Views\V2\iCalendar\Traits\Export_Link;
 
 /**
  * Class Outlook
@@ -19,8 +20,14 @@ use Tribe__Events__Main;
  * @package Tribe\Events\Views\V2\iCalendar
  */
 class Outlook_Export extends Link_Abstract {
+	use Export_Link;
+
 	/**
-	 * {@inheritDoc}
+	 * The link provider slug.
+	 *
+	 * @since 5.12.0
+	 *
+	 * @var string
 	 */
 	public static $slug = 'outlook-ics';
 
@@ -28,16 +35,17 @@ class Outlook_Export extends Link_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function register() {
-		$this->label = __( 'Export Outlook .ics file', 'the-events-calendar' );
+		self::$query_arg = 'outlook-ical';
+		$this->label = _x( 'Export Outlook .ics file', 'The text for the link to export and Outlook ics file.', 'the-events-calendar' );
 		$this->single_label = $this->label;
-
-		add_filter( 'tec_views_v2_subscribe_link_outlook-ics_visibility', [ $this, 'filter_tec_views_v2_subscribe_link_outlook_ics_visibility'], 10, 2 );
+		$this->filters();
 	}
 
 	/**
 	 * Filters the is_visible() function to not display on single events.
 	 *
 	 * @since 5.16.0
+	 * @deprecated TBD
 	 *
 	 * @param boolean $visible Whether to display the link.
 	 * @param View    $view     The current View object.
@@ -45,35 +53,8 @@ class Outlook_Export extends Link_Abstract {
 	 * @return boolean $visible Whether to display the link.
 	 */
 	public function filter_tec_views_v2_subscribe_link_outlook_ics_visibility( $visible ) {
+		_deprecated_function( __METHOD__, 'TBD', 'Outlook_Export::filter_tec_views_v2_subscribe_link_visibility' );
 		// Don't display on single event by default.
-		return ! is_single();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_uri( View $view = null ) {
-		if ( null === $view || is_single( Tribe__Events__Main::POSTTYPE ) ) {
-			// Try to construct it for the event single.
-			return add_query_arg( [ 'outlook-ical' => 1 ], get_the_permalink() );
-		}
-
-		$template_vars = $view->get_template_vars();
-
-		$ical = ! empty( $template_vars['ical'] ) ? $template_vars['ical'] : $view->get_ical_data();
-
-		if ( empty( $ical->display_link ) ) {
-			return '';
-		}
-
-		if ( empty( $ical->link->url ) ) {
-			return '';
-		}
-
-		// Remove ical query argument and add Outlook.
-		$url = remove_query_arg( 'ical', $ical->link->url );
-		$url = add_query_arg( [ 'outlook-ical' => 1 ], $url );
-
-		return $url;
+		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this);
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_Live.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_Live.php
@@ -35,13 +35,11 @@ class Outlook_Live extends Link_Abstract {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static $service_slug = 'live';
-
-	/**
-	 * {@inheritDoc}
-	 */
 	public function register() {
 		$this->label        = __( 'Outlook Live', 'the-events-calendar' );
 		$this->single_label = $this->label;
+
+		// Defined and used in the trait.
+		self::$service_slug = 'live';
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/Outlook_Live.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Outlook_Live.php
@@ -35,7 +35,7 @@ class Outlook_Live extends Link_Abstract {
 	/**
 	 * {@inheritDoc}
 	 */
-	public static $calendar_slug = 'live';
+	public static $service_slug = 'live';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Tribe/Views/V2/iCalendar/Links/iCalendar_Export.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/iCalendar_Export.php
@@ -35,8 +35,8 @@ class iCalendar_Export extends Link_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function register() {
-		self::$query_arg = 'ical';
-		$this->label = __( 'Export .ics file', 'the-events-calendar' );
+		self::$query_arg    = 'ical';
+		$this->label        = __( 'Export .ics file', 'the-events-calendar' );
 		$this->single_label = $this->label;
 		$this->filters();
 	}
@@ -54,6 +54,6 @@ class iCalendar_Export extends Link_Abstract {
 	public function filter_tec_views_v2_subscribe_link_ics_visibility( $visible ) {
 		_deprecated_function( __METHOD__, 'TBD', 'iCalendar_Export::filter_tec_views_v2_subscribe_link_visibility' );
 		// Don't display on single event by default.
-		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this);
+		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this );
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/iCalendar_Export.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/iCalendar_Export.php
@@ -10,6 +10,7 @@
 namespace Tribe\Events\Views\V2\iCalendar\Links;
 use Tribe\Events\Views\V2\View;
 use Tribe__Events__Main;
+use Tribe\Events\Views\V2\iCalendar\Traits\Export_Link;
 
 /**
  * Class iCal
@@ -19,8 +20,14 @@ use Tribe__Events__Main;
  * @package Tribe\Events\Views\V2\iCalendar
  */
 class iCalendar_Export extends Link_Abstract {
+	use Export_Link;
+
 	/**
-	 * {@inheritDoc}
+	 * The link provider slug.
+	 *
+	 * @since 5.12.0
+	 *
+	 * @var string
 	 */
 	public static $slug = 'ics';
 
@@ -28,10 +35,10 @@ class iCalendar_Export extends Link_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function register() {
+		self::$query_arg = 'ical';
 		$this->label = __( 'Export .ics file', 'the-events-calendar' );
 		$this->single_label = $this->label;
-
-		add_filter( 'tec_views_v2_subscribe_link_ics_visibility', [ $this, 'filter_tec_views_v2_subscribe_link_ics_visibility'], 10, 2 );
+		$this->filters();
 	}
 
 	/**
@@ -45,29 +52,8 @@ class iCalendar_Export extends Link_Abstract {
 	 * @return boolean $visible Whether to display the link.
 	 */
 	public function filter_tec_views_v2_subscribe_link_ics_visibility( $visible ) {
+		_deprecated_function( __METHOD__, 'TBD', 'iCalendar_Export::filter_tec_views_v2_subscribe_link_visibility' );
 		// Don't display on single event by default.
-		return ! is_single();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function get_uri( View $view = null ) {
-		if ( null === $view || is_single( Tribe__Events__Main::POSTTYPE ) ) {
-			// Try to construct it for the event single.
-			return add_query_arg( [ 'ical' => 1 ], get_the_permalink() );
-		}
-
-		$ical = $view->get_ical_data();
-
-		if ( empty( $ical->display_link ) ) {
-			return '';
-		}
-
-		if ( empty( $ical->link->url ) ) {
-			return '';
-		}
-
-		return $ical->link->url;
+		return self::filter_tec_views_v2_subscribe_link_visibility( $visible, $this);
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -31,7 +31,7 @@ trait Export_Link {
 	private static $query_arg = 'ical';
 
 	/**
-	 * Add filter hooks here.
+	 * Adding our filter hooks.
 	 *
 	 * @since TBD
 	 */

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Handles common traits for export links.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Views\V2\iCalendar
+ */
+
+namespace Tribe\Events\Views\V2\iCalendar\Traits;
+
+use Tribe\Events\Views\V2\View;
+use Tribe__Events__Main;
+
+/**
+ * Trait Export_Link
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Events\Views\V2\iCalendar
+ */
+trait Export_Link {
+
+	/**
+	 * The query argument slug for the download link.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private static $query_arg = 'ical';
+
+	public function filters() {
+		// Filters the subscribe link based on the final class slug.
+		add_filter( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', [ $this, 'filter_tec_views_v2_subscribe_link_visibility'], 10, 2 );
+	}
+
+	/**
+	 * Filters the is_visible() function to not display export (download) links on single events.
+	 *
+	 * @since 5.14.0
+	 * @since TBD Moved to trait from export classes.
+	 *
+	 * @param boolean $visible Whether to display the link.
+	 * @param Link_Abstract    $link_object     The current link object.
+	 *
+	 * @return boolean $visible Whether to display the link.
+	 */
+	public function filter_tec_views_v2_subscribe_link_visibility( $visible, $link_object ) {
+		// $slug is defined in the class that uses this trait.
+		if ( $link_object::get_slug() !== static::get_slug() ) {
+			return $visible;
+		}
+
+		// Don't display on single event by default.
+		$visible = ! is_single();
+
+		/**
+		 * Allows filtering of the visibility of all export links.
+		 *
+		 * @since TBD
+		 *
+		 * @param boolean $visible Whether to display the link.
+		 * @param Link_Abstract    $link_object     The current link object.
+		 */
+		$visible = apply_filters( "tec_events_export_link_visibility", $visible, $this );
+
+		/**
+		 * Allows filtering of the visibility of a specific export link.
+		 *
+		 * @since TBD
+		 *
+		 * @param boolean $visible Whether to display the link.
+		 * @param Link_Abstract    $link_object     The current link object.
+		 */
+		return apply_filters( "tec_events_{static::get_slug()}export_link_visibility", $visible, $this );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_uri( View $view = null ) {
+		$is_single = null === $view || is_single( Tribe__Events__Main::POSTTYPE );
+		$slug      = static::get_slug();
+
+		if ( $is_single ) {
+			// Try to construct it for the event single.
+			$url = add_query_arg( [ static::$query_arg => 1 ], get_the_permalink() );
+
+			/**
+			 * Allows filtering of the URL for the view export link.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $url The URL for the link.
+			 * @param Link_Abstract $link_obj The link object the url is for.
+			 */
+			return apply_filters( "tec_events_{$slug}_export_link_url_single", $url, $this );
+		}
+
+		$template_vars = $view->get_template_vars();
+
+		$ical = ! empty( $template_vars['ical'] ) ? $template_vars['ical'] : $view->get_ical_data();
+
+		if ( empty( $ical->display_link ) ) {
+			return '';
+		}
+
+		if ( empty( $ical->link->url ) ) {
+			return '';
+		}
+
+		$url = $ical->link->url;
+
+		if ( static::$query_arg !== 'ical') {
+			// Remove ical query argument and add Outlook.
+			$url = remove_query_arg( 'ical', $url );
+			$url = add_query_arg( [ static::$query_arg => 1 ], $url );
+		}
+
+		/**
+		 * Allows filtering of the URL for the view export link.
+		 *
+		 * @since TBD
+		 *
+		 * @param string         $url       The URL for the link.
+		 * @param Outlook_Export $link_obj  The link object the url is for.
+		 */
+		return apply_filters( "tec_events_{$slug}_export_link_url", $url, $this );
+	}
+}

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -96,7 +96,18 @@ trait Export_Link {
 			$url = add_query_arg( [ static::$query_arg => 1 ], get_the_permalink() );
 
 			/**
-			 * Allows filtering of the URL for the view export link.
+			 * Allows filtering of the URL for all single export links.
+			 *
+			 * @since TBD
+			 *
+			 * @param string        $url      The URL for the link.
+			 * @param View          $view     The view object, if available.
+			 * @param Link_Abstract $link_obj The link object the url is for.
+			 */
+			$url = apply_filters( "tec_events_export_link_url_single", $url, $view, $this );
+
+			/**
+			 * Allows filtering of the URL for a specific single export link.
 			 *
 			 * @since TBD
 			 *
@@ -128,7 +139,17 @@ trait Export_Link {
 		}
 
 		/**
-		 * Allows filtering of the URL for the view export link.
+		 * Allows filtering of the URL for the view export links.
+		 *
+		 * @since TBD
+		 *
+		 * @param string         $url       The URL for the link.
+		 * @param Outlook_Export $link_obj  The link object the url is for.
+		 */
+		$url = apply_filters( "tec_events_export_link_url", $url, $this );
+
+		/**
+		 * Allows filtering of the URL for a specific view export link.
 		 *
 		 * @since TBD
 		 *

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -87,7 +87,7 @@ trait Export_Link {
 	/**
 	 * Getter function for the uri property.
 	 *
-	 * @since 5.12.0
+	 * @since TBD
 	 *
 	 * @param View|null $view The current View object.
 	 *

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -30,9 +30,15 @@ trait Export_Link {
 	 */
 	private static $query_arg = 'ical';
 
+	/**
+	 * Add filter hooks here.
+	 *
+	 * @since TBD
+	 */
 	public function filters() {
 		// Filters the subscribe link based on the final class slug.
-		add_filter( 'tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility', [ $this, 'filter_tec_views_v2_subscribe_link_visibility'], 10, 2 );
+		$slug = static::get_slug();
+		add_filter( "tec_views_v2_subscribe_link_{$slug}_visibility", [ $this, 'filter_tec_views_v2_subscribe_link_visibility' ], 10, 2 );
 	}
 
 	/**
@@ -41,8 +47,8 @@ trait Export_Link {
 	 * @since 5.14.0
 	 * @since TBD Moved to trait from export classes.
 	 *
-	 * @param boolean $visible Whether to display the link.
-	 * @param Link_Abstract    $link_object     The current link object.
+	 * @param boolean       $visible     Whether to display the link.
+	 * @param Link_Abstract $link_object The current link object.
 	 *
 	 * @return boolean $visible Whether to display the link.
 	 */
@@ -63,17 +69,19 @@ trait Export_Link {
 		 * @param boolean $visible Whether to display the link.
 		 * @param Link_Abstract    $link_object     The current link object.
 		 */
-		$visible = apply_filters( "tec_events_export_link_visibility", $visible, $this );
+		$visible = apply_filters( 'tec_events_export_link_visibility', $visible, $this );
+
+		$slug = static::get_slug();
 
 		/**
 		 * Allows filtering of the visibility of a specific export link.
 		 *
 		 * @since TBD
 		 *
-		 * @param boolean $visible Whether to display the link.
-		 * @param Link_Abstract    $link_object     The current link object.
+		 * @param boolean       $visible     Whether to display the link.
+		 * @param Link_Abstract $link_object The current link object.
 		 */
-		return apply_filters( "tec_events_{static::get_slug()}export_link_visibility", $visible, $this );
+		return apply_filters( "tec_events_{$slug}_export_link_visibility", $visible, $this );
 	}
 
 	/**
@@ -92,10 +100,11 @@ trait Export_Link {
 			 *
 			 * @since TBD
 			 *
-			 * @param string $url The URL for the link.
+			 * @param string        $url      The URL for the link.
+			 * @param View          $view     The view object, if available.
 			 * @param Link_Abstract $link_obj The link object the url is for.
 			 */
-			return apply_filters( "tec_events_{$slug}_export_link_url_single", $url, $this );
+			return apply_filters( "tec_events_{$slug}_export_link_url_single", $url, $view, $this );
 		}
 
 		$template_vars = $view->get_template_vars();
@@ -112,7 +121,7 @@ trait Export_Link {
 
 		$url = $ical->link->url;
 
-		if ( static::$query_arg !== 'ical') {
+		if ( 'ical' !== static::$query_arg ) {
 			// Remove ical query argument and add Outlook.
 			$url = remove_query_arg( 'ical', $url );
 			$url = add_query_arg( [ static::$query_arg => 1 ], $url );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -104,7 +104,7 @@ trait Export_Link {
 			 * @param View          $view     The view object, if available.
 			 * @param Link_Abstract $link_obj The link object the url is for.
 			 */
-			$url = apply_filters( "tec_events_export_link_url_single", $url, $view, $this );
+			$url = apply_filters( 'tec_events_export_link_url_single', $url, $view, $this );
 
 			/**
 			 * Allows filtering of the URL for a specific single export link.
@@ -146,7 +146,7 @@ trait Export_Link {
 		 * @param string         $url       The URL for the link.
 		 * @param Outlook_Export $link_obj  The link object the url is for.
 		 */
-		$url = apply_filters( "tec_events_export_link_url", $url, $this );
+		$url = apply_filters( 'tec_events_export_link_url', $url, $this );
 
 		/**
 		 * Allows filtering of the URL for a specific view export link.

--- a/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Export_Link.php
@@ -85,7 +85,13 @@ trait Export_Link {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Getter function for the uri property.
+	 *
+	 * @since 5.12.0
+	 *
+	 * @param View|null $view The current View object.
+	 *
+	 * @return string The url for the link calendar subscription "feed", or download.
 	 */
 	public function get_uri( View $view = null ) {
 		$is_single = null === $view || is_single( Tribe__Events__Main::POSTTYPE );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -155,16 +155,16 @@ trait Outlook_Methods {
 		 */
 		$body = apply_filters( 'tec_events_ical_outlook_event_description_content', $body );
 
-		// Truncate the Event description and add permalink if greater than 900 characters
+		// Truncate the Event description and add permalink if greater than 900 characters.
 		if ( strlen( $body ) > 900 ) {
 
 			$body = substr( $body, 0, 900 );
 
 			$event_url = get_permalink( $event->ID );
 
-			//Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000)
+			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
-				$body .= ' ' . sprintf( esc_html__( '(View Full %1$s Description Here: %2$s)', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
+				$body .= ' ' . sprintf( esc_html_x( '(View Full %1$s Description Here: %2$s)', 'Link text to full post description.', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
 			}
 		}
 
@@ -177,7 +177,7 @@ trait Outlook_Methods {
 		 */
 		$num_words = apply_filters( 'tec_events_ical_outlook_event_description_num_words', false );
 
-		// Encoding and trimming
+		// Encoding and trimming.
 		if ( (int) $num_words > 0 ) {
 			$body = wp_trim_words( $body, $num_words );
 		}

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -164,7 +164,16 @@ trait Outlook_Methods {
 
 			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
-				$body .= ' ' . sprintf( esc_html_x( '(View Full %1$s Description Here: %2$s)', 'Link text to full post description.', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
+				/* Translators %1$s singular event label %2$s URL */
+				$body .= ' ' . sprintf(
+					esc_html_x(
+						'(View Full %1$s Description Here: %2$s)',
+						'Link text to full post description.',
+						'the-events-calendar'
+					),
+					tribe_get_event_label_singular(),
+					$event_url
+				);
 			}
 		}
 

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -165,7 +165,7 @@ trait Outlook_Methods {
 			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
 				$body .= ' ' . sprintf(
-					/* Translators %1$s singular event label %2$s URL */
+					/* Translators: %1$s singular event label %2$s URL */
 					esc_html_x(
 						'(View Full %1$s Description Here: %2$s)',
 						'Link text to full post description.',

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -165,8 +165,8 @@ trait Outlook_Methods {
 			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
 				$body .= ' ' . sprintf(
+					/* Translators %1$s singular event label %2$s URL */
 					esc_html_x(
-						/* Translators %1$s singular event label %2$s URL */
 						'(View Full %1$s Description Here: %2$s)',
 						'Link text to full post description.',
 						'the-events-calendar'

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -86,7 +86,7 @@ trait Outlook_Methods {
 			'startdt'  => $start_datetime,
 			'enddt'    => $end_datetime,
 			'location' => Venue::generate_string_address( $event ),
-			'subject'  => $this->space_replace_and_encode( strip_tags( $event->post_title ) ),
+			'subject'  => $this->space_replace_and_encode( wp_strip_all_tags( $event->post_title ) ),
 			'body'     => $this->generate_outlook_event_description( $event ),
 		];
 
@@ -142,8 +142,8 @@ trait Outlook_Methods {
 
 		$body = $event->post_content;
 
-		// Stripping tags
-		$body = strip_tags( $body, '<p>' );
+		// Stripping most tags.
+		$body = wp_kses_post( $body );
 
 		/**
 		 * Allows filtering the content of the event description.

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -164,8 +164,8 @@ trait Outlook_Methods {
 
 			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
-				/* Translators %1$s singular event label %2$s URL */
 				$body .= ' ' . sprintf(
+					/* Translators %1$s singular event label %2$s URL */
 					esc_html_x(
 						'(View Full %1$s Description Here: %2$s)',
 						'Link text to full post description.',

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -41,6 +41,15 @@ trait Outlook_Methods {
 	protected static $outlook_temp_space = 'TEC_OUTLOOK_SPACE';
 
 	/**
+	 * {Holds the slug for the service we're sending to (i.e. live or office).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public static $service_slug = '';
+
+	/**
 	 * Generate the parameters for the Outlook export buttons.
 	 *
 	 * @since 5.16.0
@@ -91,7 +100,7 @@ trait Outlook_Methods {
 			// Stripping tags
 			$body = strip_tags( $body, '<p>' );
 
-			// Truncate Event Description and add permalink if greater than 900 characters
+			// Truncate the Event description and add permalink if greater than 900 characters
 			if ( strlen( $body ) > 900 ) {
 
 				$body = substr( $body, 0, 900 );
@@ -134,6 +143,17 @@ trait Outlook_Methods {
 			'body'     => $body,
 		];
 
+		/**
+		 * Allow users to Filter our Outlook Link params before constructing the URL.
+		 *
+		 * @since TBD
+		 *
+		 * @var array    $params   The params used in the add_query_arg.
+		 * @var /WP_Post $event    The Event the link is for. As decorated by tribe_get_event().
+		 * @var string   $calendar The slug of the calendar. Values can be "outlook-365" and "outlook-live".
+		 */
+		$params = apply_filters( 'tec_views_v2_single_event_outlook_link_parameters', $params, $event, $calendar );
+
 		return $params;
 	}
 
@@ -146,7 +166,7 @@ trait Outlook_Methods {
 	 */
 	public function generate_outlook_full_url() {
 		$params   = $this->generate_outlook_add_url_parameters();
-		$base_url = 'https://outlook.' . static::$calendar_slug . '.com/owa/';
+		$base_url = 'https://outlook.' . static::$service_slug . '.com/owa/';
 		$url      = add_query_arg( $params, $base_url );
 
 		/**
@@ -172,7 +192,7 @@ trait Outlook_Methods {
 	 * @return string The subscribe url.
 	 */
 	public function generate_outlook_subscribe_url( View $view = null ) {
-		$base_url = 'https://outlook.' . static::$calendar_slug . '.com/owa?path=/calendar/action/compose';
+		$base_url = 'https://outlook.' . static::$service_slug . '.com/owa?path=/calendar/action/compose';
 
 		if ( null !== $view ) {
 			$feed_url = $this->get_canonical_ics_feed_url( $view );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -41,13 +41,15 @@ trait Outlook_Methods {
 	protected static $outlook_temp_space = 'TEC_OUTLOOK_SPACE';
 
 	/**
-	 * {Holds the slug for the service we're sending to (i.e. live or office).
+	 * Holds the slug for the service we're sending to (i.e. live or office).
+	 * Used in the outlook URLs.
 	 *
-	 * @since TBD
+	 * @since 5.16.0
+	 * @since TBD Renamed from $calendar_slug to $service_slug. Moved into the trait from the classes.
 	 *
 	 * @var string
 	 */
-	public static $service_slug = '';
+	public static $service_slug;
 
 	/**
 	 * Generate the parameters for the Outlook export buttons.
@@ -62,29 +64,69 @@ trait Outlook_Methods {
 		// Getting the event details
 		$event = tribe_get_event();
 
-		$path = '/calendar/action/compose';
-		$rrv  = 'addevent';
-
 		/**
 		 * If event is an all day event, then adjust the end time.
 		 * Using the 'allday' parameter doesn't work well through time zones.
 		 */
 		if ( $event->all_day ) {
-			$enddt = Dates::build_date_object( $event->end_date )->format( 'Y-m-d' )
+			$end_datetime = Dates::build_date_object( $event->end_date )->format( 'Y-m-d' )
 				. 'T'
 				. Dates::build_date_object( $event->start_date )->format( 'H:i:s' );
 		} else {
-			$enddt = Dates::build_date_object( $event->end_date )->format( 'c' );
-			$enddt = substr( $enddt, 0, strlen( $enddt ) - 6 );
+			$end_datetime = Dates::build_date_object( $event->end_date )->format( 'c' );
+			$end_datetime = substr( $end_datetime, 0, -6 );
 		}
 
-		$startdt = Dates::build_date_object( $event->start_date )->format( 'c' );
-		$startdt = substr( $startdt, 0, strlen( $startdt ) - 6 );
+		$start_datetime = Dates::build_date_object( $event->start_date )->format( 'c' );
+		$start_datetime = substr( $start_datetime, 0, -6 );
 
-		$location = Venue::generate_string_address( $event );
+		$params = [
+			'path'     => '/calendar/action/compose',
+			'rrv'      => 'addevent',
+			'startdt'  => $start_datetime,
+			'enddt'    => $end_datetime,
+			'location' => Venue::generate_string_address( $event ),
+			'subject'  => $this->space_replace_and_encode( strip_tags( $event->post_title ) ),
+			'body'     => $this->generate_outlook_event_description( $event ),
+		];
 
-		$subject = $this->space_replace_and_encode( strip_tags( $event->post_title ) );
+		/**
+		 * Allow users to filter the params for our Outlook links before constructing the URL.
+		 *
+		 * @since TBD
+		 *
+		 * @var array    $params   The params used in the add_query_arg.
+		 * @var /WP_Post $event    The Event the link is for. As decorated by tribe_get_event().
+		 * @var string   $calendar The slug of the calendar. Values can be "outlook-365" and "outlook-live".
+		 */
+		$params = apply_filters( 'tec_events_single_event_outlook_link_parameters', $params, $event, $calendar );
 
+		$service_slug = static::$service_slug;
+
+		/**
+		 * Allow users to filter the params for a specific Outlook link before constructing the URL.
+		 *
+		 * @since TBD
+		 *
+		 * @var array    $params   The params used in the add_query_arg.
+		 * @var /WP_Post $event    The Event the link is for. As decorated by tribe_get_event().
+		 * @var string   $calendar The slug of the calendar. Values can be "outlook-365" and "outlook-live".
+		 */
+		$params = apply_filters( "tec_events_single_event_outlook_link_parameters_{$service_slug}", $params, $event, $calendar );
+
+		return $params;
+	}
+
+	/**
+	 * Generate the event description for Outlook.
+	 *
+	 * @since TBD
+	 *
+	 * @param /WP_Post $event The Event the link is for. As decorated by tribe_get_event().
+	 *
+	 * @return string The event description.
+	 */
+	public function generate_outlook_event_description( $event ) {
 		/**
 		 * A filter to hide or show the event description.
 		 *
@@ -94,67 +136,56 @@ trait Outlook_Methods {
 		 */
 		$include_event_description = (bool) apply_filters( 'tec_events_ical_outlook_include_event_description', true );
 
-		if ( $include_event_description ) {
-			$body = $event->post_content;
-
-			// Stripping tags
-			$body = strip_tags( $body, '<p>' );
-
-			// Truncate the Event description and add permalink if greater than 900 characters
-			if ( strlen( $body ) > 900 ) {
-
-				$body = substr( $body, 0, 900 );
-
-				$event_url = get_permalink( $event->ID );
-
-				//Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000)
-				if ( strlen( $event_url ) < 900 ) {
-					$body .= ' ' . sprintf( esc_html__( '(View Full %1$s Description Here: %2$s)', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
-				}
-			}
-
-			/**
-			 * Allows filtering the length of the event description.
-			 *
-			 * @since 5.16.0
-			 *
-			 * @param bool|int $num_words
-			 */
-			$num_words = apply_filters( 'tec_events_ical_outlook_event_description_num_words', false );
-
-			// Encoding and trimming
-			if ( (int) $num_words > 0 ) {
-				$body = wp_trim_words( $body, $num_words );
-			}
-
-			// Changing the spaces to %20, Outlook can take that.
-			$body = $this->space_replace_and_encode( $body );
-		} else {
-			$body = false;
+		if ( ! $include_event_description ) {
+			return '';
 		}
 
-		$params = [
-			'path'     => $path,
-			'rrv'      => $rrv,
-			'startdt'  => $startdt,
-			'enddt'    => $enddt,
-			'location' => $location,
-			'subject'  => $subject,
-			'body'     => $body,
-		];
+		$body = $event->post_content;
+
+		// Stripping tags
+		$body = strip_tags( $body, '<p>' );
 
 		/**
-		 * Allow users to Filter our Outlook Link params before constructing the URL.
+		 * Allows filtering the content of the event description.
+		 * Note: This happens before space conversion and truncation happens!
 		 *
 		 * @since TBD
 		 *
-		 * @var array    $params   The params used in the add_query_arg.
-		 * @var /WP_Post $event    The Event the link is for. As decorated by tribe_get_event().
-		 * @var string   $calendar The slug of the calendar. Values can be "outlook-365" and "outlook-live".
+		 * @param string $body The event description.
 		 */
-		$params = apply_filters( 'tec_views_v2_single_event_outlook_link_parameters', $params, $event, $calendar );
+		$body = apply_filters( 'tec_events_ical_outlook_event_description_content', $body );
 
-		return $params;
+		// Truncate the Event description and add permalink if greater than 900 characters
+		if ( strlen( $body ) > 900 ) {
+
+			$body = substr( $body, 0, 900 );
+
+			$event_url = get_permalink( $event->ID );
+
+			//Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000)
+			if ( strlen( $event_url ) < 900 ) {
+				$body .= ' ' . sprintf( esc_html__( '(View Full %1$s Description Here: %2$s)', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
+			}
+		}
+
+		/**
+		 * Allows filtering the length of the event description.
+		 *
+		 * @since 5.16.0
+		 *
+		 * @param bool|int $num_words
+		 */
+		$num_words = apply_filters( 'tec_events_ical_outlook_event_description_num_words', false );
+
+		// Encoding and trimming
+		if ( (int) $num_words > 0 ) {
+			$body = wp_trim_words( $body, $num_words );
+		}
+
+		// Changing the spaces to %20, Outlook can take that.
+		$body = $this->space_replace_and_encode( $body );
+
+		return $body;
 	}
 
 	/**
@@ -162,7 +193,7 @@ trait Outlook_Methods {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @return string The singe event add to calendar URL.
+	 * @return string The single event add to calendar URL.
 	 */
 	public function generate_outlook_full_url() {
 		$params   = $this->generate_outlook_add_url_parameters();
@@ -170,13 +201,13 @@ trait Outlook_Methods {
 		$url      = add_query_arg( $params, $base_url );
 
 		/**
-		 * Filter the Outlook single event import url.
+		 * Filter the Outlook single event import URL.
 		 *
 		 * @since 5.16.0
 		 *
-		 * @param string               $url      The url used to subscribe to a calendar in Outlook.
-		 * @param string               $base_url The base url used to subscribe in Outlook.
-		 * @param array<string|string> $params   An array of parameters added to the base url.
+		 * @param string               $url      The URL used to subscribe to a calendar in Outlook.
+		 * @param string               $base_url The base URL used to subscribe in Outlook.
+		 * @param array<string|string> $params   An array of parameters added to the base URL.
 		 * @param Outlook_Methods      $this     An instance of the link abstract.
 		 */
 		$url = apply_filters( 'tec_events_ical_outlook_single_event_import_url', $url, $base_url, $params, $this );
@@ -189,7 +220,7 @@ trait Outlook_Methods {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @return string The subscribe url.
+	 * @return string The subscribe URL.
 	 */
 	public function generate_outlook_subscribe_url( View $view = null ) {
 		$base_url = 'https://outlook.' . static::$service_slug . '.com/owa?path=/calendar/action/compose';
@@ -198,7 +229,7 @@ trait Outlook_Methods {
 			$feed_url = $this->get_canonical_ics_feed_url( $view );
 		}
 
-		// Remove ical query and add back after urlencoding the rest of the url.
+		// Remove ical query and add back after urlencoding the rest of the URL.
 		$feed_url = remove_query_arg( 'ical', $feed_url );
 
 		$feed_url = str_replace( [ 'http://', 'https://' ], 'webcal://', $feed_url );
@@ -216,14 +247,14 @@ trait Outlook_Methods {
 		$url = add_query_arg( $params, $base_url );
 
 		/**
-		 * Filter the Outlook subscribe url.
+		 * Filter the Outlook subscribe URL.
 		 *
 		 * @since 5.16.0
 		 *
-		 * @param string                  $url      The url used to subscribe to a calendar in Outlook.
-		 * @param string                  $base_url The base url used to subscribe in Outlook.
-		 * @param string                  $feed_url The subscribe url used on the site.
-		 * @param array<string|string>    $params   An array of parameters added to the base url.
+		 * @param string                  $url      The URL used to subscribe to a calendar in Outlook.
+		 * @param string                  $base_url The base URL used to subscribe in Outlook.
+		 * @param string                  $feed_url The subscribe URL used on the site.
+		 * @param array<string|string>    $params   An array of parameters added to the base URL.
 		 * @param Outlook_Abstract_Export $this     An instance of the link abstract.
 		 */
 		$url = apply_filters( 'tec_events_ical_outlook_subscribe_url', $url, $base_url, $feed_url, $params, $this );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -45,11 +45,11 @@ trait Outlook_Methods {
 	 * Used in the outlook URLs.
 	 *
 	 * @since 5.16.0
-	 * @since TBD Renamed from $calendar_slug to $service_slug. Moved into the trait from the classes.
+	 * @since TBD Renamed from $calendar_slug to $service_slug. Protected, moved into the trait from the classes.
 	 *
 	 * @var string
 	 */
-	public static $service_slug;
+	protected static $service_slug;
 
 	/**
 	 * Generate the parameters for the Outlook export buttons.
@@ -101,7 +101,7 @@ trait Outlook_Methods {
 		 */
 		$params = apply_filters( 'tec_events_single_event_outlook_link_parameters', $params, $event, $calendar );
 
-		$service_slug = static::$service_slug;
+		$service_slug = static::get_service_slug();
 
 		/**
 		 * Allow users to filter the params for a specific Outlook link before constructing the URL.
@@ -206,7 +206,7 @@ trait Outlook_Methods {
 	 */
 	public function generate_outlook_full_url() {
 		$params   = $this->generate_outlook_add_url_parameters();
-		$base_url = 'https://outlook.' . static::$service_slug . '.com/owa/';
+		$base_url = 'https://outlook.' . static::get_service_slug() . '.com/owa/';
 		$url      = add_query_arg( $params, $base_url );
 
 		/**
@@ -232,7 +232,7 @@ trait Outlook_Methods {
 	 * @return string The subscribe URL.
 	 */
 	public function generate_outlook_subscribe_url( View $view = null ) {
-		$base_url = 'https://outlook.' . static::$service_slug . '.com/owa?path=/calendar/action/compose';
+		$base_url = 'https://outlook.' . static::get_service_slug() . '.com/owa?path=/calendar/action/compose';
 
 		if ( null !== $view ) {
 			$feed_url = $this->get_canonical_ics_feed_url( $view );
@@ -303,5 +303,16 @@ trait Outlook_Methods {
 		}
 
 		return $this->generate_outlook_subscribe_url( $view );
+	}
+
+	/**
+	 * Public getter for protected service slug property.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The service slug.
+	 */
+	public static function get_service_slug(): string {
+		return static::$service_slug;
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -165,8 +165,8 @@ trait Outlook_Methods {
 			// Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000).
 			if ( strlen( $event_url ) < 900 ) {
 				$body .= ' ' . sprintf(
-					/* Translators %1$s singular event label %2$s URL */
 					esc_html_x(
+						/* Translators %1$s singular event label %2$s URL */
 						'(View Full %1$s Description Here: %2$s)',
 						'Link text to full post description.',
 						'the-events-calendar'


### PR DESCRIPTION
The new Trait contains all the shared functionality of the two export links - which is pretty much all of it.
The old trait has been modified to not throw weird PHPCS issues about calling the class prop. 👃🏼 

There are now a slew of new filters for folks who desire to modify the links:

 - `tec_events_subscribe_link_url`
 - `tec_events_{$slug}_subscribe_link_url`
 - `tec_events_export_link_visibility`
 - `tec_events_{$slug}_export_link_visibility`
 - `tec_events_export_link_url`
 - `tec_events_{$slug}_export_link_url`
 - `tec_events_export_link_url_single`
 - `tec_events_{$slug}_export_link_url_single`

Note they all use "tec", and none use "views_v2"

[TEC-4916](https://theeventscalendar.atlassian.net/browse/TEC-4916)

PS: I apologize for the PHPCS noise, I touched a bit of older code here 😉 

[TEC-4916]: https://stellarwp.atlassian.net/browse/TEC-4916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ