### PR TITLE
TEC-4831 outlook timezone omitted with subscribe

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Adjusted how event times and time zones are handled when using Subscribe to Outlook on a single event page. [TEC-4831]
+
 = [6.2.8.2] 2023-12-04 =
 
 * Fix - Ensure correct access rights to JSON-LD data depending on the user role. [TEC-4995]

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -148,43 +148,8 @@ trait Outlook_Methods {
 		 */
 		$include_event_description = (bool) apply_filters( 'tec_events_ical_outlook_include_event_description', true );
 
-		if ( $include_event_description ) {
-			$body = $event->post_content;
-
-			// Stripping tags
-			$body = strip_tags( $body, '<p>' );
-
-			// Truncate the Event Description and add permalink if greater than 900 characters.
-			if ( strlen( $body ) > 900 ) {
-
-				$body = substr( $body, 0, 900 );
-
-				$event_url = get_permalink( $event->ID );
-
-				//Only add the permalink if it's shorter than 900 characters, so we don't exceed the browser's URL limits (~2000)
-				if ( strlen( $event_url ) < 900 ) {
-					$body .= ' ' . sprintf( esc_html__( '(View Full %1$s Description Here: %2$s)', 'the-events-calendar' ), tribe_get_event_label_singular(), $event_url );
-				}
-			}
-
-			/**
-			 * Allows filtering the length of the event description.
-			 *
-			 * @since 5.16.0
-			 *
-			 * @param bool|int $num_words
-			 */
-			$num_words = apply_filters( 'tec_events_ical_outlook_event_description_num_words', false );
-
-			// Encoding and trimming
-			if ( (int) $num_words > 0 ) {
-				$body = wp_trim_words( $body, $num_words );
-			}
-
-			// Changing the spaces to %20, Outlook can take that.
-			$body = $this->space_replace_and_encode( $body );
-		} else {
-			$body = false;
+		if ( ! $include_event_description ) {
+			return '';
 		}
 
 		$body = $event->post_content;

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -45,7 +45,7 @@ trait Outlook_Methods {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @param string $calendar Whether it's Outlook live or Outlook 365.
+	 * @param string $calendar Whether it's Outlook Live or Outlook 365.
 	 *
 	 * @return string Part of the URL containing the event information.
 	 */
@@ -64,7 +64,7 @@ trait Outlook_Methods {
 		$remove_timezone_offset = apply_filters( 'tec_remove_outlook_timezone_offset', false );
 
 		/**
-		 * If event is an all day event, then adjust the end time.
+		 * If the event is an all-day event, then adjust the end time.
 		 * Using the 'allday' parameter doesn't work well through time zones.
 		 */
 		if ( $event->all_day ) {
@@ -102,7 +102,7 @@ trait Outlook_Methods {
 			// Stripping tags
 			$body = strip_tags( $body, '<p>' );
 
-			// Truncate Event Description and add permalink if greater than 900 characters
+			// Truncate the Event Description and add permalink if greater than 900 characters
 			if ( strlen( $body ) > 900 ) {
 
 				$body = substr( $body, 0, 900 );
@@ -153,7 +153,7 @@ trait Outlook_Methods {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @return string The singe event add to calendar URL.
+	 * @return string The single event add to calendar URL.
 	 */
 	public function generate_outlook_full_url() {
 		$params   = $this->generate_outlook_add_url_parameters();
@@ -161,13 +161,13 @@ trait Outlook_Methods {
 		$url      = add_query_arg( $params, $base_url );
 
 		/**
-		 * Filter the Outlook single event import url.
+		 * Filter the Outlook single event import URL.
 		 *
 		 * @since 5.16.0
 		 *
-		 * @param string               $url      The url used to subscribe to a calendar in Outlook.
-		 * @param string               $base_url The base url used to subscribe in Outlook.
-		 * @param array<string|string> $params   An array of parameters added to the base url.
+		 * @param string               $url      The URL used to subscribe to a calendar in Outlook.
+		 * @param string               $base_url The base URL used to subscribe in Outlook.
+		 * @param array<string|string> $params   An array of parameters added to the base URL.
 		 * @param Outlook_Methods      $this     An instance of the link abstract.
 		 */
 		$url = apply_filters( 'tec_events_ical_outlook_single_event_import_url', $url, $base_url, $params, $this );
@@ -180,7 +180,7 @@ trait Outlook_Methods {
 	 *
 	 * @since 5.16.0
 	 *
-	 * @return string The subscribe url.
+	 * @return string The subscribe URL.
 	 */
 	public function generate_outlook_subscribe_url( View $view = null ) {
 		$base_url = 'https://outlook.' . static::$calendar_slug . '.com/owa?path=/calendar/action/compose';
@@ -211,10 +211,10 @@ trait Outlook_Methods {
 		 *
 		 * @since 5.16.0
 		 *
-		 * @param string                  $url      The url used to subscribe to a calendar in Outlook.
-		 * @param string                  $base_url The base url used to subscribe in Outlook.
+		 * @param string                  $url      The URL used to subscribe to a calendar in Outlook.
+		 * @param string                  $base_url The base URL used to subscribe in Outlook.
 		 * @param string                  $feed_url The subscribe url used on the site.
-		 * @param array<string|string>    $params   An array of parameters added to the base url.
+		 * @param array<string|string>    $params   An array of parameters added to the base URL.
 		 * @param Outlook_Abstract_Export $this     An instance of the link abstract.
 		 */
 		$url = apply_filters( 'tec_events_ical_outlook_subscribe_url', $url, $base_url, $feed_url, $params, $this );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -57,6 +57,13 @@ trait Outlook_Methods {
 		$rrv  = 'addevent';
 
 		/**
+		 * Filters whether the time zone offset should be removed from the URL or not.
+		 *
+		 * @var bool $remove_timezone_offset
+		 */
+		$remove_timezone_offset = apply_filters( 'tec_remove_outlook_timezone_offset', false );
+
+		/**
 		 * If event is an all day event, then adjust the end time.
 		 * Using the 'allday' parameter doesn't work well through time zones.
 		 */

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -73,11 +73,15 @@ trait Outlook_Methods {
 				. Dates::build_date_object( $event->start_date, $event->timezone )->format( 'H:i:s' );
 		} else {
 			$enddt = Dates::build_date_object( $event->end_date, $event->timezone )->format( 'c' );
-			$enddt = substr( $enddt, 0, strlen( $enddt ) - 6 );
+			if ( $remove_timezone_offset ) {
+				$enddt = substr( $enddt, 0, strlen( $enddt ) - 6 );
+			}
 		}
 
 		$startdt = Dates::build_date_object( $event->start_date, $event->timezone )->format( 'c' );
-		$startdt = substr( $startdt, 0, strlen( $startdt ) - 6 );
+		if ( $remove_timezone_offset ) {
+			$startdt = substr( $startdt, 0, strlen( $startdt ) - 6 );
+		}
 
 		$location = Venue::generate_string_address( $event );
 

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -102,7 +102,7 @@ trait Outlook_Methods {
 			// Stripping tags
 			$body = strip_tags( $body, '<p>' );
 
-			// Truncate the Event Description and add permalink if greater than 900 characters
+			// Truncate the Event Description and add permalink if greater than 900 characters.
 			if ( strlen( $body ) > 900 ) {
 
 				$body = substr( $body, 0, 900 );

--- a/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
+++ b/src/Tribe/Views/V2/iCalendar/Traits/Outlook_Methods.php
@@ -61,15 +61,15 @@ trait Outlook_Methods {
 		 * Using the 'allday' parameter doesn't work well through time zones.
 		 */
 		if ( $event->all_day ) {
-			$enddt = Dates::build_date_object( $event->end_date )->format( 'Y-m-d' )
+			$enddt = Dates::build_date_object( $event->end_date, $event->timezone )->format( 'Y-m-d' )
 				. 'T'
-				. Dates::build_date_object( $event->start_date )->format( 'H:i:s' );
+				. Dates::build_date_object( $event->start_date, $event->timezone )->format( 'H:i:s' );
 		} else {
-			$enddt = Dates::build_date_object( $event->end_date )->format( 'c' );
+			$enddt = Dates::build_date_object( $event->end_date, $event->timezone )->format( 'c' );
 			$enddt = substr( $enddt, 0, strlen( $enddt ) - 6 );
 		}
 
-		$startdt = Dates::build_date_object( $event->start_date )->format( 'c' );
+		$startdt = Dates::build_date_object( $event->start_date, $event->timezone )->format( 'c' );
 		$startdt = substr( $startdt, 0, strlen( $startdt ) - 6 );
 
 		$location = Venue::generate_string_address( $event );


### PR DESCRIPTION
[TEC-4831]

When using the Subscribe to Outlook on a single event page, then the event time zone is not taken into account.
This PR attempts to provide a fix for that.

This is what happens before the fix:
If there is an event with New York time zone in the calendar, and I click subscribe, then Outlook offers to save it with those original times using my Outlook time zone, which is different than New York, giving me wrong times as a result.

This is what happens with the fix:
If there is an event with New York time zone in the calendar, and I click subscribe, then Outlook will recalculate the start/end times and offers to save it with those using my Outlook time zone.

I could only test with Outlook Live and there it work.

I added a boolean filter to be able to revert back to the original functioning. Maybe that filter should be flipped.

There's some other Outlook-related fix planned in https://github.com/the-events-calendar/the-events-calendar/pull/4441. It would be a nice companion to that. 🙂 

[TEC-4831]: https://stellarwp.atlassian.net/browse/TEC-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ