### PR TITLE
Fixed deprecation errors.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -231,6 +231,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fix PHP 8.2 deprecation errors `PHP Deprecated:  Creation of dynamic property Tribe__Events__Aggregator__Record__gCal::$image_uploader is deprecated`. [ECP-1603]
+
 = [6.2.9] 2023-12-14 =
 
 * Fix - Resolves an issue where the `tribe-events-calendar-month__day--past` and `tribe-events-calendar-month__day--current` classes were not consistently applied after navigating through different months in the Month View. [TEC-4898]

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -114,6 +114,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract {
 	public $origin;
 
 	/**
+	 * The image uploader service.
+	 *
+	 * @since TBD
+	 *
+	 * @var Tribe__Image__Uploader
+	 */
+	public $image_uploader;
+
+	/**
 	 * Setup all the hooks and filters
 	 *
 	 * @return void


### PR DESCRIPTION
[ECP-1603](https://stellarwp.atlassian.net/browse/ECP-1603)

This resolves several php 8.2 deprecation errors. 

Artifact:
```
PHP Deprecated:  Creation of dynamic property Tribe__Events__Aggregator__Record__gCal::$image_uploader is deprecated
```

[ECP-1603]: https://stellarwp.atlassian.net/browse/ECP-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ