### PR TITLE
Fix/tec 4918 venue block not persisting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,7 @@ Remember to always make a backup of your database and files before updating!
 
 = [TBD] TBD =
 
+* Fix - Resolved an issue where adding multiple venues in block editor would not persist the second venue after the page was reloaded. [ECP-1637]
 * Fix - Fix PHP 8.2 deprecation errors `PHP Deprecated:  Creation of dynamic property Tribe__Events__Aggregator__Record__gCal::$image_uploader is deprecated`. [ECP-1603]
 
 = [6.2.9] 2023-12-14 =

--- a/src/modules/blocks/event-venue/container.js
+++ b/src/modules/blocks/event-venue/container.js
@@ -143,9 +143,9 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 			setVenue( { state, dispatch, ownProps, venueID, details } );
 		},
 		onRemove: () => {
-			const { clientId, venue } = ownProps;
+			const { venue, clientId } = ownProps;
 
-			ownProps.setAttributes( { venue: 0 } );
+			ownProps.setAttributes( { venue: null } );
 			dispatch( actions.removeVenueInBlock( clientId, venue ) );
 
 			/**

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -354,9 +354,11 @@ class EventVenue extends Component {
 	 * Gets the venue ID for the block.
 	 *
 	 * @since 6.2.0
+	 * @since TBD This will now return the value of the `venue` prop.
 	 * @returns {number|null} Venue ID or null.
 	 */
 	getVenueId() {
+		const state = this.props.store.getState();
 		let venueId = this.props.venue;
 
 		/**

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -339,7 +339,7 @@ class EventVenue extends Component {
 	 * @returns {Object} Venue details.
 	 */
 	getVenueDetails() {
-		const venueId = this.getVenueId();
+		const venueId = this.props.venue || this.getVenueId();
 
 		if ( ! isInteger( venueId ) ) {
 			return {};

--- a/src/modules/blocks/event-venue/template.js
+++ b/src/modules/blocks/event-venue/template.js
@@ -339,7 +339,7 @@ class EventVenue extends Component {
 	 * @returns {Object} Venue details.
 	 */
 	getVenueDetails() {
-		const venueId = this.props.venue || this.getVenueId();
+		const venueId = this.getVenueId();
 
 		if ( ! isInteger( venueId ) ) {
 			return {};
@@ -357,12 +357,7 @@ class EventVenue extends Component {
 	 * @returns {number|null} Venue ID or null.
 	 */
 	getVenueId() {
-		const state = this.props.store.getState();
-		const allVenueIds = selectors.getVenuesInBlock( state );
-
-		if ( isEmpty( allVenueIds ) ) {
-			return null;
-		}
+		let venueId = this.props.venue;
 
 		/**
 		 * Filters the venue ID to be used for the block.
@@ -373,9 +368,9 @@ class EventVenue extends Component {
 		 * @param {Object} state The tribe common state.
 		 * @return {number} The venue ID.
 		 */
-		const venueId = wpHooks.applyFilters(
+		venueId = wpHooks.applyFilters(
 			'tec.events.blocks.tribe_event_venue.getVenueId',
-			allVenueIds[ 0 ],
+			venueId,
 			this.props,
 			state,
 		);


### PR DESCRIPTION
[TEC-4918](https://stellarwp.atlassian.net/browse/TEC-4918)

There was some leftover single venue state logic that was referencing a single venue. Updated the blocks to reference the `venue` attribute (prop) passed into the components instead of the state.

Artifact:
https://www.loom.com/share/74a97a6901a8412cabc5f52b1e3cb62b?sid=62e8f8f7-e526-4b1c-9f6e-904f18f15269

[TEC-4918]: https://stellarwp.atlassian.net/browse/TEC-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ