### PR TITLE
Set recursion guard later

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2979,12 +2979,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				return;
 			}
 
-			$avoid_recursion = true;
-
 			if ( wp_is_post_revision( $postId ) ) {
 				// Do not save meta for revisions: it would be saved to the original post anyway.
 				return;
 			}
+
+			$avoid_recursion = true;
 
 			// When not an instance of Post we bail to avoid revision problems.
 			if ( ! $post instanceof WP_Post ) {

--- a/tests/integration/RevisionTest.php
+++ b/tests/integration/RevisionTest.php
@@ -17,7 +17,9 @@ class RevisionTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function should_not_save_revision_meta_on_post_update(): void {
 		// Let's make sure revisions are set to be saved after the post insertion per WordPress 6.4.
-		if ( ! has_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' ) ) {
+		if ( function_exists( 'wp_save_post_revision_on_insert' )
+		     && ! has_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' )
+		) {
 			add_action( 'wp_after_insert_post', 'wp_save_post_revision_on_insert' );
 		}
 		// Create an Event.


### PR DESCRIPTION
During work done to fix the revision-related issue ([commit](https://github.com/the-events-calendar/the-events-calendar/pull/4326/commits/597a7153ff124cf37cc8ace650c4b45fa33c95c5)), I've forgotten to move the recursion guard down with the effect of preventing the save operation on WordPress versions < 6.4.

The change is already covered by automated tests where possible.

Screencast: [link](https://share.cleanshot.com/JVBpg13n)
