### PR TITLE
[ET-2047] Added `has_tickets` to get correct data.

### DIFF
--- a/src/Events/Integrations/Plugins/Event_Tickets/Site_Health/Subsection.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Site_Health/Subsection.php
@@ -76,7 +76,7 @@ class Subsection extends Abstract_Info_Subsection {
 	 * @return int Count of ticketed events currently happening.
 	 */
 	private function get_number_of_ticketed_events_happening_now(): int {
-		return tribe( 'tickets.event-repository' )->where(
+		return tribe( 'tickets.event-repository' )->where( 'has_tickets' )->where(
 			'ends_after',
 			'now'
 		)->count();


### PR DESCRIPTION
### 🎫 Ticket

[ET-2047]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

While fixing ET-2047 I noticed that `get_number_of_ticketed_events_happening_now` was not taking into account ticketed events, but rather all events happening now. I added an extra where to only take into account ticketed events.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[et_2047_artifact.webm](https://github.com/the-events-calendar/the-events-calendar/assets/12241059/51c0d266-31e6-4c9b-bc10-88b89e3bfe64)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2047]: https://stellarwp.atlassian.net/browse/ET-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ