### PR TITLE
[ETWP-95] Series Pass Apple Wallet not opening

### DIFF
--- a/src/Events/Integrations/Plugins/Tickets_Wallet_Plus/Passes/Apple_Wallet/Event_Modifier.php
+++ b/src/Events/Integrations/Plugins/Tickets_Wallet_Plus/Passes/Apple_Wallet/Event_Modifier.php
@@ -217,7 +217,7 @@ class Event_Modifier {
 		$event_id = $pass->get_event_id();
 		$event    = tribe_get_event( $event_id );
 
-		if ( $event->multiday > 1 ) {
+		if ( $event->multiday > 1 || 'tribe_event_series' === $event->post_type ) {
 			return $data;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ETWP-95]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

While Romine was testing she found that when exporting the Apple Pass for Series Passes the file wouldn't open properly. This was due to the `pass.json` being incorrect and having the `event_date_time_range` twice. I adjusted the logic so this wouldn't happen again. I have attached the new pass with the fix as an artifact.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[event-tickets-wallet-plus-49661c0408.zip](https://github.com/the-events-calendar/the-events-calendar/files/14483203/event-tickets-wallet-plus-49661c0408.zip)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ETWP-95]: https://stellarwp.atlassian.net/browse/ETWP-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ