### PR TITLE
Make the widgets register and enqueue their own styles.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-events-calendar",
-  "version": "6.3.5",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "the-events-calendar",
-      "version": "6.3.0",
+      "version": "6.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/runtime": "^7.15.3",
@@ -5971,9 +5971,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
       "dev": true,
       "funding": [
         {
@@ -32688,9 +32688,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
       "dev": true
     },
     "cardinal": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "_glotPressUrl": "https://translate.wordpress.org",
   "_glotPressSlug": "wp-plugins/the-events-calendar/stable",
   "_glotPressFileFormat": "%textdomain%-%wp_locale%.%format%",
-  "_glotPressFormats": ["po", "mo"],
+  "_glotPressFormats": [
+    "po",
+    "mo"
+  ],
   "_glotPressFilter": {
     "translation_sets": false,
     "minimum_percentage": 30,
@@ -68,7 +71,10 @@
     "zip": "node node_modules/@the-events-calendar/product-taskmaster/util/zip.js",
     "glotpress": "gulp glotpress"
   },
-  "engines": { "node": "18.13.0", "npm": "8.19.3" },
+  "engines": {
+    "node": "18.13.0",
+    "npm": "8.19.3"
+  },
   "devDependencies": {
     "@the-events-calendar/product-taskmaster": "^3.0.0",
     "@wordpress/hooks": "^1.3.2",
@@ -128,7 +134,11 @@
     "whatwg-fetch": "^2.0.4",
     "zero-fill": "^2.2.3"
   },
-  "overrides": { "babel-plugin-lodash": { "@babel/types": "~7.20.0" } },
+  "overrides": {
+    "babel-plugin-lodash": {
+      "@babel/types": "~7.20.0"
+    }
+  },
   "browserslist": [
     "last 2 Chrome versions",
     "last 2 Firefox versions",

--- a/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
+++ b/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
@@ -101,43 +101,9 @@ class Assets_Manager extends Controller {
 	 * @since TBD
 	 */
 	public function register_widget_assets() {
-		tribe_assets(
-			tribe( 'tec.main' ),
-			[
-				[
-					'tec-events-elementor-event_categories-widget-styles',
-					'integrations/plugins/elementor/widgets/event-categories.css',
-				],
-				[
-					'tec-events-elementor-event_export-widget-styles',
-					'integrations/plugins/elementor/widgets/event-export.css',
-				],
-				[
-					'tec-events-elementor-event_navigation-widget-styles',
-					'integrations/plugins/elementor/widgets/event-navigation.css',
-				],
-				[
-					'tec-events-elementor-event_organizer-widget-styles',
-					'integrations/plugins/elementor/widgets/event-organizer.css',
-				],
-				[
-					'tec-events-elementor-event_tags-widget-styles',
-					'integrations/plugins/elementor/widgets/event-tags.css',
-				],
-				[
-					'tec-events-elementor-event_venue-widget-styles',
-					'integrations/plugins/elementor/widgets/event-venue.css',
-				],
-				[
-					'tec-events-elementor-event_website-widget-styles',
-					'integrations/plugins/elementor/widgets/event-website.css',
-				],
-			],
-			null,
-			[
-				'groups' => [ static::$group_key ],
-			]
-		);
+		foreach ( $this->get_widgets() as $widget ) {
+			tribe( $widget )->register_style();
+		}
 
 		do_action( 'tec_events_elementor_register_widget_assets', $this );
 	}
@@ -159,8 +125,7 @@ class Assets_Manager extends Controller {
 	 */
 	public function enqueue_preview_styles() {
 		foreach ( $this->get_widgets() as $widget ) {
-			$slug = str_replace( '_', '-', $widget::get_slug() );
-			tribe_asset_enqueue( 'tec-events-elementor-' . $slug . '-widget-styles' );
+			tribe( $widget )->enqueue_style();
 		}
 	}
 
@@ -194,13 +159,11 @@ class Assets_Manager extends Controller {
 			return;
 		}
 
-		$slug = str_replace( '_', '-', $widget::get_slug() );
-
-		if ( ! in_array( $slug, array_keys( $widgets ), true ) ) {
+		if ( ! method_exists( $widget, 'enqueue_style' ) ) {
 			return;
 		}
 
-		tribe_asset_enqueue( 'tec-events-elementor-' . $slug . '-widget-styles' );
+		tribe( $widget )->enqueue_style();
 	}
 
 	/**

--- a/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
+++ b/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
@@ -101,6 +101,13 @@ class Assets_Manager extends Controller {
 	 * @since TBD
 	 */
 	public function register_widget_assets() {
+		tribe_asset(
+			tribe( 'tec.main' ),
+			'tec-events-elementor-widgets-base-styles',
+			'integrations/plugins/elementor/widgets/widget-base.css',
+			[],
+		);
+
 		foreach ( $this->get_widgets() as $widget ) {
 			tribe( $widget )->register_style();
 		}
@@ -137,6 +144,7 @@ class Assets_Manager extends Controller {
 	public function enqueue_frontend_resources(): void {
 		tribe_asset_enqueue( 'tribe-events-v2-single-skeleton' );
 		tribe_asset_enqueue( 'tribe-events-v2-single-skeleton-full' );
+		tribe_asset_enqueue( 'tec-events-elementor-widgets-base-styles' );
 	}
 
 	/**
@@ -155,7 +163,7 @@ class Assets_Manager extends Controller {
 		$widgets = $this->get_widgets();
 
 		// Not one of ours.
-		if ( ! method_exists( $widget, 'get_slug' ) ) {
+		if ( strpos( $name, 'tec_events_elementor_widget_' ) === false ) {
 			return;
 		}
 

--- a/src/Events/Integrations/Plugins/Elementor/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Controller.php
@@ -51,8 +51,8 @@ class Controller extends Integration_Abstract {
 	 */
 	public function load(): void {
 		$this->container->register_on_action( 'elementor/init', Template_Controller::class );
-		$this->container->register_on_action( 'elementor/loaded', Assets_Manager::class );
 		$this->container->register_on_action( 'elementor/widgets/register', Widgets_Manager::class );
+		$this->container->register_on_action( 'elementor/loaded', Assets_Manager::class );
 
 		$this->register_actions();
 		$this->register_filters();

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Contracts/Abstract_Widget.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Contracts/Abstract_Widget.php
@@ -11,10 +11,10 @@ namespace TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts;
 
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Template_Engine;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+use TEC\Events\Integrations\Plugins\Elementor\Assets_Manager;
 use Tribe__Events__Main as TEC;
 
 use Elementor\Widget_Base;
-use WP_Post;
 
 /**
  * Abstract Widget class
@@ -32,6 +32,16 @@ abstract class Abstract_Widget extends Widget_Base {
 	 */
 	protected static string $slug_prefix = 'tec_events_elementor_widget_';
 
+
+	/**
+	 * Widget asset prefix.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected static string $asset_prefix = 'tec-events-elementor-widget-';
+
 	/**
 	 * Widget slug.
 	 *
@@ -42,13 +52,13 @@ abstract class Abstract_Widget extends Widget_Base {
 	protected static string $slug;
 
 	/**
-	 * Widget CSS class.
+	 * Whether the widget has styles to register/enqueue.
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string>
+	 * @var bool
 	 */
-	protected array $css_classes;
+	protected static bool $has_styles = false;
 
 	/**
 	 * Widget categories.
@@ -190,7 +200,7 @@ abstract class Abstract_Widget extends Widget_Base {
 	 */
 	public function get_element_classes( string $format = 'attribute' ) {
 		// If the property is empty, generate and use the widget class.
-		$classes = $this->css_classes ?? [ $this->get_widget_class() ];
+		$classes = $this->get_widget_class();
 		$slug    = static::get_slug();
 
 		/**
@@ -504,6 +514,40 @@ abstract class Abstract_Widget extends Widget_Base {
 		$args['widget'] = $this;
 
 		return $args;
+	}
+
+	/**
+	 * Register the styles for the widget.
+	 *
+	 * @since TBD
+	 */
+	public function register_style(): void {
+		if ( ! static::$has_styles ) {
+			return;
+		}
+
+		$slug = str_replace( '_', '-', $this::get_slug() );
+
+		// Register the styles for the widget.
+		tribe_asset(
+			tribe( 'tec.main' ),
+			static::$asset_prefix . str_replace( '_', '-', $this::get_slug() ) . '-styles',
+			'integrations/plugins/elementor/widgets/' . $slug . '.css',
+			[],
+			null,
+			[ 'groups' => [ Assets_Manager::$group_key ] ]
+		);
+	}
+
+	/**
+	 * Enqueue the styles for the widget.
+	 *
+	 * @since TBD
+	 */
+	public function enqueue_style(): void {
+		$slug = str_replace( '_', '-', $this::get_slug() );
+
+		tribe_asset_enqueue( static::$asset_prefix . $slug . '-styles' );
 	}
 
 	/**

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Contracts/Abstract_Widget.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Contracts/Abstract_Widget.php
@@ -545,6 +545,10 @@ abstract class Abstract_Widget extends Widget_Base {
 	 * @since TBD
 	 */
 	public function enqueue_style(): void {
+		if ( ! static::$has_styles ) {
+			return;
+		}
+
 		$slug = str_replace( '_', '-', $this::get_slug() );
 
 		tribe_asset_enqueue( static::$asset_prefix . $slug . '-styles' );

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Categories.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Categories.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 use Tribe__Events__Main;
 
@@ -26,6 +21,8 @@ use Tribe__Events__Main;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Categories extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
+
 	/**
 	 * Widget slug.
 	 *
@@ -56,17 +53,6 @@ class Event_Categories extends Abstract_Widget {
 	}
 
 	/**
-	 * Create the widget title.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function get_label_text(): string {
-		return _x( 'Event Categories:', 'The label/header text for the event categories widget', 'the-events-calendar' );
-	}
-
-	/**
 	 * Get the template args for the widget.
 	 *
 	 * @since TBD
@@ -79,12 +65,24 @@ class Event_Categories extends Abstract_Widget {
 		$tec_main = Tribe__Events__Main::instance();
 
 		return [
-			'show_heading' => tribe_is_truthy( $settings['show_categories_heading'] ?? true ),
-			'heading_tag'  => $settings['categories_heading_tag'] ?? 'h3',
-			'categories'   => get_the_terms( $event_id, $tec_main->get_event_taxonomy() ),
-			'settings'     => $settings,
-			'event_id'     => $event_id,
+			'show_header' => tribe_is_truthy( $settings['show_categories_header'] ?? true ),
+			'header_tag'  => $settings['categories_header_tag'] ?? 'h3',
+			'header_text' => $this->get_header_text(),
+			'categories'  => get_the_terms( $event_id, $tec_main->get_event_taxonomy() ),
+			'settings'    => $settings,
+			'event_id'    => $event_id,
 		];
+	}
+
+	/**
+	 * Create the widget title.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_text(): string {
+		return _x( 'Categories:', 'The label/header text for the event categories widget', 'the-events-calendar' );
 	}
 
 	/**
@@ -99,9 +97,9 @@ class Event_Categories extends Abstract_Widget {
 		$categories = tribe_get_event_taxonomy(
 			$event_id,
 			[
+				'after'  => '',
 				'before' => '',
 				'sep'    => ', ',
-				'after'  => '',
 			]
 		);
 
@@ -144,8 +142,8 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @return string
 	 */
-	public function get_label_class() {
-		$class = $this->get_widget_class() . '-label';
+	public function get_header_class(): string {
+		$class = $this->get_widget_class() . '-header';
 
 		/**
 		 * Filters the class used for the category label.
@@ -157,7 +155,7 @@ class Event_Categories extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_category_widget_label_class', $class, $this );
+		return apply_filters( 'tec_events_elementor_event_category_widget_header_class', $class, $this );
 	}
 
 	/**
@@ -167,7 +165,7 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @return string
 	 */
-	public function get_wrapper_class() {
+	public function get_wrapper_class(): string {
 		$class = $this->get_widget_class() . '-link-wrapper';
 
 		/**
@@ -188,7 +186,7 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function register_controls() {
+	protected function register_controls(): void {
 		// Content tab.
 		$this->content_panel();
 		// Style tab.
@@ -200,7 +198,7 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_panel() {
+	protected function content_panel(): void {
 		$this->content_options();
 	}
 
@@ -209,9 +207,9 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_panel() {
-		$this->heading_styling();
-		$this->categories_styling();
+	protected function style_panel(): void {
+		$this->header_styling();
+		$this->content_styling();
 	}
 
 	/**
@@ -219,74 +217,29 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_options() {
+	protected function content_options(): void {
 		$this->start_controls_section(
-			'section_title',
+			'header_content_section',
 			[
-				'label' => esc_html__( 'Event Categories', 'the-events-calendar' ),
+				'label' => esc_html__( 'Header ', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_responsive_control(
-			'align',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
+				'id'    => 'show_categories_header',
+				'label' => esc_html__( 'Show Header', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'show_categories_heading',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Heading', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Show', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'Hide', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		$this->add_control(
-			'categories_heading_tag',
-			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
+				'id'        => 'header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
 				'condition' => [
-					'show_categories_heading' => 'yes',
+					'show_header' => 'yes',
 				],
 			]
 		);
@@ -295,87 +248,35 @@ class Event_Categories extends Abstract_Widget {
 	}
 
 	/**
-	 * Add controls for text styling of the section heading.
+	 * Add controls for text styling of the section header.
 	 *
 	 * @since TBD
 	 */
-	protected function heading_styling() {
+	protected function header_styling(): void {
 		$this->start_controls_section(
-			'heading_section_title',
+			'header_style_section',
 			[
-				'label'     => esc_html__( 'Section Heading', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Header Styles', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
-					'show_categories_heading' => 'yes',
+					'show_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'heading_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_label_class() => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'heading_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_label_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'heading_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_wrapper_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'heading_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_label_class(),
-			]
-		);
-
-		$this->add_control(
-			'heading_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_label_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'header_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() ],
 			]
 		);
 
@@ -387,80 +288,28 @@ class Event_Categories extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function categories_styling() {
+	protected function content_styling(): void {
 		$this->start_controls_section(
-			'categories_section_title',
+			'content_style_section',
 			[
-				'label' => esc_html__( 'Event Categories', 'the-events-calendar' ),
+				'label' => esc_html__( 'Content Styles', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_wrapper_class() . ',{{WRAPPER}} .' . $this->get_wrapper_class() . ' a' => 'color: {{VALUE}}; border-bottom-color: {{VALUE}};',
-				],
+				'prefix'   => 'content',
+				'selector' => '{{WRAPPER}} .' . $this->get_wrapper_class() . ' a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_wrapper_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_wrapper_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_wrapper_class(),
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_wrapper_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'content_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_wrapper_class() ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Categories.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Categories.php
@@ -36,6 +36,15 @@ class Event_Categories extends Abstract_Widget {
 	protected static string $slug = 'event_categories';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Cost.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Cost.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -25,6 +20,7 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Cost extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -47,20 +43,6 @@ class Event_Cost extends Abstract_Widget {
 	}
 
 	/**
-	 * Determine the HTML tag to use for the event cost based on settings.
-	 *
-	 * @since TBD
-	 *
-	 * @return string The HTML tag to use for the event cost.
-	 */
-	protected function get_header_tag() {
-
-		$settings = $this->get_settings_for_display();
-
-		return $settings['header_tag'] ?? 'p';
-	}
-
-	/**
 	 * Get the template args for the widget.
 	 *
 	 * @since TBD
@@ -73,10 +55,74 @@ class Event_Cost extends Abstract_Widget {
 		$cost       = tribe_get_formatted_cost( $event_id );
 
 		return [
-			'header_tag' => $header_tag,
-			'event_id'   => $event_id,
-			'cost'       => $cost,
+			'show_header' => tribe_is_truthy( $settings['show_header'] ?? false ),
+			'header_tag'  => $header_tag,
+			'html_tag'    => $this->get_html_tag(),
+			'event_id'    => $event_id,
+			'cost'        => $cost,
 		];
+	}
+
+	/**
+	 * Determine the HTML tag to use for the event cost based on settings.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The HTML tag to use for the event cost.
+	 */
+	protected function get_html_tag(): string {
+
+		$settings = $this->get_settings_for_display();
+
+		return $settings['html_tag'] ?? 'p';
+	}
+
+	/**
+	 * Determine the HTML tag to use for the event cost based on settings.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The HTML tag to use for the event cost.
+	 */
+	protected function get_header_tag() {
+
+		$settings = $this->get_settings_for_display();
+
+		return $settings['header_tag'] ?? 'h3';
+	}
+
+	/**
+	 * Create the widget title.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_text(): string {
+		return _x( 'Cost:', 'The header text for the event cost widget', 'the-events-calendar' );
+	}
+
+	/**
+	 * Get the class used for the category header.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_class(): string {
+		$class = $this->get_widget_class() . '-header';
+
+		/**
+		 * Filters the class used for the category header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string          $class The class used for the category header.
+		 * @param Abstract_Widget $this  The widget instance.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_category_widget_header_class', $class, $this );
 	}
 
 	/**
@@ -96,7 +142,8 @@ class Event_Cost extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_panel() {
+	protected function content_panel(): void {
+		$this->header_options();
 		$this->content_options();
 	}
 
@@ -105,9 +152,45 @@ class Event_Cost extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_panel() {
-		// Styling options.
-		$this->styling_options();
+	protected function style_panel(): void {
+		$this->header_styling_options();
+		$this->content_styling_options();
+	}
+
+	/**
+	 * Add controls for the header of the event cost.
+	 *
+	 * @since TBD
+	 */
+	protected function header_options(): void {
+		$this->start_controls_section(
+			'cost_header_section',
+			[
+				'label' => esc_html__( 'Cost Header', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'      => 'show_header',
+				'label'   => esc_html__( 'Show Header', 'the-events-calendar' ),
+				'default' => 'no',
+			]
+		);
+
+		$this->add_shared_control(
+			'tag',
+			[
+				'id'        => 'header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'condition' => [
+					'show_header' => 'yes',
+				],
+			]
+		);
+
+		$this->end_controls_section();
 	}
 
 	/**
@@ -115,61 +198,56 @@ class Event_Cost extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_options() {
+	protected function content_options(): void {
 		$this->start_controls_section(
-			'section_title',
+			'cost_content_section',
 			[
-				'label' => $this->get_title(),
+				'label' => esc_html__( 'Cost Content', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
+				'id'      => 'html_tag',
 				'label'   => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'    => Controls_Manager::SELECT,
-				'options' => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
 				'default' => 'p',
 			]
 		);
 
-		$this->add_responsive_control(
-			'align',
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Add controls for text styling of the event cost header.
+	 *
+	 * @since TBD
+	 */
+	protected function header_styling_options(): void {
+		$this->start_controls_section(
+			'styling_section_header',
 			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
+				'label'     => esc_html__( 'Header Styling', 'the-events-calendar' ),
+				'tab'       => Controls_Manager::TAB_STYLE,
+				'condition' => [
+					'show_header' => 'yes',
 				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
+			]
+		);
+
+		$this->add_shared_control(
+			'typography',
+			[
+				'prefix'   => 'header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
+			]
+		);
+
+		$this->add_shared_control(
+			'alignment',
+			[
+				'id'        => 'align_header',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_header_class() ],
 			]
 		);
 
@@ -181,80 +259,28 @@ class Event_Cost extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function styling_options() {
+	protected function content_styling_options(): void {
 		$this->start_controls_section(
-			'styling_section_title',
+			'styling_section_content',
 			[
-				'label' => $this->get_title(),
+				'label' => esc_html__( 'Content Styling', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'cost_content',
 				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'align_content',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Datetime.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Datetime.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -25,6 +20,7 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Datetime extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -47,6 +43,98 @@ class Event_Datetime extends Abstract_Widget {
 	}
 
 	/**
+	 * Get the template args for the widget.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The template args.
+	 */
+	public function get_template_args(): array {
+		$event_id = $this->get_event_id();
+		$event    = tribe_get_event( $event_id );
+
+		if ( empty( $event ) ) {
+			return [ 'show' => false ];
+		}
+
+		$settings = $this->get_settings_for_display();
+
+		// Date and time settings.
+		$show_year   = tribe_is_truthy( $settings['show_year'] ?? false );
+		$date_format = tribe_get_date_format( $show_year );
+		$start_date  = $event->dates->start->format( $date_format ) ?? '';
+		$end_date    = $event->dates->end->format( $date_format ) ?? '';
+
+		$time_format = tribe_get_time_format();
+		$start_time  = $event->dates->start->format( $time_format ) ?? '';
+		$end_time    = $event->dates->end->format( $time_format ) ?? '';
+
+		return [
+			'show'              => true,
+			'show_header'       => tribe_is_truthy( $settings['show_header'] ?? false ),
+			'html_tag'          => $this->get_html_tag(),
+			'show_date'         => tribe_is_truthy( $settings['show_date'] ?? false ),
+			'show_time'         => tribe_is_truthy( $settings['show_time'] ?? false ),
+			'show_year'         => $show_year,
+			'start_date'        => $start_date,
+			'end_date'          => $end_date,
+			'start_time'        => $start_time,
+			'end_time'          => $end_time,
+			'is_same_day'       => $start_date === $end_date,
+			'is_all_day'        => tribe_event_is_all_day( $event_id ),
+			'is_same_start_end' => $start_date === $end_date && $start_time === $end_time,
+			'event_id'          => $event_id,
+		];
+	}
+
+	/**
+	 * Create the widget title.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_text(): string {
+		return _x( 'Date & Time:', 'The header text for the event date and time widget', 'the-events-calendar' );
+	}
+
+	/**
+	 * Get the class used for the category header.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_class() {
+		$class = $this->get_widget_class() . '-header';
+
+		/**
+		 * Filters the class used for the category header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string          $class The class used for the category header.
+		 * @param Abstract_Widget $this  The widget instance.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_category_widget_header_class', $class, $this );
+	}
+
+	/**
+	 * Get the HTML tag used for the category header.
+	 *
+	 * @since TBD
+	 */
+	public function get_header_tag(): string {
+		$settings = $this->get_settings_for_display();
+
+		$tag = $settings['header_tag'] ?? 'h3';
+
+		return (string) $tag;
+	}
+
+	/**
 	 * Get the class used for the datetime separators.
 	 *
 	 * @since TBD
@@ -54,7 +142,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime separators.
 	 */
 	public function get_separator_class() {
-		// tec-events-elementor-event-widget__datetime-separator.
 		return $this->get_widget_class() . '-separator';
 	}
 
@@ -66,7 +153,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The base class used for the datetime date.
 	 */
 	public function get_date_class() {
-		// tec-events-elementor-event-widget__datetime-date.
 		return $this->get_widget_class() . '-date';
 	}
 
@@ -78,7 +164,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime start date.
 	 */
 	public function get_start_date_class() {
-		// tec-events-elementor-event-widget__datetime-date--start.
 		return $this->get_date_class() . '--start';
 	}
 
@@ -90,7 +175,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime end date.
 	 */
 	public function get_end_date_class() {
-		// tec-events-elementor-event-widget__datetime-date--end.
 		return $this->get_date_class() . '--end';
 	}
 
@@ -102,7 +186,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime all day indication.
 	 */
 	public function get_all_day_class() {
-		// tec-events-elementor-event-widget__datetime--all-day.
 		return $this->get_widget_class() . '--all-day';
 	}
 
@@ -114,7 +197,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The base class used for the datetime time.
 	 */
 	public function get_time_class() {
-		// tec-events-elementor-event-widget__datetime-time.
 		return $this->get_widget_class() . '-time';
 	}
 
@@ -126,7 +208,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime start time.
 	 */
 	public function get_start_time_class() {
-		// tec-events-elementor-event-widget__datetime-time--start.
 		return $this->get_time_class() . '--start';
 	}
 
@@ -138,7 +219,6 @@ class Event_Datetime extends Abstract_Widget {
 	 * @return string The class used for the datetime end time.
 	 */
 	public function get_end_time_class() {
-		// tec-events-elementor-event-widget__datetime-time--end.
 		return $this->get_time_class() . '--end';
 	}
 
@@ -205,7 +285,7 @@ class Event_Datetime extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function register_controls() {
+	protected function register_controls(): void {
 		// Content tab.
 		$this->content_panel();
 		// Style tab.
@@ -217,8 +297,9 @@ class Event_Datetime extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_panel() {
-		$this->content_options();
+	protected function content_panel(): void {
+		$this->header_content_section();
+		$this->datetime_content_section();
 	}
 
 	/**
@@ -226,110 +307,42 @@ class Event_Datetime extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_panel() {
+	protected function style_panel(): void {
 		// Styling options.
-		$this->styling_options();
+		$this->style_datetime_header();
+		$this->style_datetime_content();
 	}
 
 	/**
-	 * Add controls for text content of the event datetime.
+	 * Add controls for header of the event datetime.
 	 *
 	 * @since TBD
 	 */
-	protected function content_options() {
+	protected function header_content_section(): void {
 		$this->start_controls_section(
-			'section_title',
+			'header_section',
 			[
-				'label' => $this->get_title(),
+				'label' => 'Date & Time Header',
 			]
 		);
 
-		// Toggle for yearless date format.
-		$this->add_control(
-			'show_datetime_year',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Show Year', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Show', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'Hide', 'the-events-calendar' ),
-				'default'   => 'no',
-				'separator' => 'before',
+				'id'      => 'show_header',
+				'label'   => esc_html__( 'Show Header', 'the-events-calendar' ),
+				'default' => 'no',
 			]
 		);
 
-		// Toggle to show or hide the date.
-		$this->add_control(
-			'show_datetime_date',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Date (Day, Month)', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Show', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'Hide', 'the-events-calendar' ),
-				'default'   => 'yes',
-				'separator' => 'before',
-			]
-		);
-
-		// Toggle to show or hide the time.
-		$this->add_control(
-			'show_datetime_time',
-			[
-				'label'     => esc_html__( 'Show Time', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Show', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'Hide', 'the-events-calendar' ),
-				'default'   => 'yes',
-				'separator' => 'before',
-			]
-		);
-
-		$this->add_control(
-			'html_tag',
-			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'p',
-				'separator' => 'before',
-			]
-		);
-
-		$this->add_responsive_control(
-			'align',
-			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
+				'id'        => 'header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'default'   => 'h3',
+				'condition' => [
+					'show_header' => 'yes',
 				],
 			]
 		);
@@ -338,12 +351,62 @@ class Event_Datetime extends Abstract_Widget {
 	}
 
 	/**
-	 * Add controls for text styling of the event datetime.
+	 * Add controls for text content of the event datetime.
 	 *
 	 * @since TBD
 	 */
-	protected function styling_options() {
-		$this->style_datetime();
+	protected function datetime_content_section(): void {
+		$this->start_controls_section(
+			'content_section',
+			[
+				'label' => $this->get_title(),
+			]
+		);
+
+		// Toggle for yearless date format.
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_year',
+				'label'     => esc_html__( 'Show Year', 'the-events-calendar' ),
+				'default'   => 'no',
+				'separator' => 'before',
+			]
+		);
+
+		// Toggle to show or hide the date.
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_date',
+				'label'     => esc_html__( 'Show Date (Day, Month)', 'the-events-calendar' ),
+				'default'   => 'yes',
+				'separator' => 'before',
+			]
+		);
+
+		// Toggle to show or hide the time.
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_time',
+				'label'     => esc_html__( 'Show Time', 'the-events-calendar' ),
+				'default'   => 'yes',
+				'separator' => 'before',
+			]
+		);
+
+		$this->add_shared_control(
+			'tag',
+			[
+				'id'        => 'html_tag',
+				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
+				'default'   => 'p',
+				'separator' => 'before',
+			]
+		);
+
+		$this->end_controls_section();
 	}
 
 	/**
@@ -353,80 +416,66 @@ class Event_Datetime extends Abstract_Widget {
 	 *
 	 * @return void
 	 */
-	protected function style_datetime() {
+	protected function style_datetime_header(): void {
 		$this->start_controls_section(
-			'datetime_styling',
+			'datetime_header_styling',
+			[
+				'label'     => esc_html__( 'Date & Time Header', 'the-events-calendar' ),
+				'tab'       => Controls_Manager::TAB_STYLE,
+				'condition' => [
+					'show_header' => 'yes',
+				],
+			]
+		);
+
+		$this->add_shared_control(
+			'typography',
+			[
+				'prefix'   => 'datetime_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
+			]
+		);
+
+		$this->add_shared_control(
+			'alignment',
+			[
+				'id'        => 'align_header',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_header_class() ],
+			]
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Assembles the styling controls for the datetime.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function style_datetime_content(): void {
+		$this->start_controls_section(
+			'datetime_content_styling',
 			[
 				'label' => esc_html__( 'Date & Time Content', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'datetime_content',
 				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'align_content',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Description.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Description.php
@@ -25,6 +25,7 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Description extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -134,9 +135,7 @@ class Event_Description extends Abstract_Widget {
 					],
 				],
 				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};' ],
 			]
 		);
 
@@ -162,12 +161,7 @@ class Event_Description extends Abstract_Widget {
 			[
 				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};' ],
 			]
 		);
 
@@ -175,9 +169,6 @@ class Event_Description extends Abstract_Widget {
 			Group_Control_Typography::get_type(),
 			[
 				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_TEXT,
-				],
 				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
 			]
 		);
@@ -218,9 +209,7 @@ class Event_Description extends Abstract_Widget {
 					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
 					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
 				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}' ],
 				'separator' => 'none',
 			]
 		);

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Export.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Export.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 use Tribe\Events\Views\V2\iCalendar\Links\Google_Calendar;
 use Tribe\Events\Views\V2\iCalendar\Links\iCal;
@@ -29,6 +24,7 @@ use Tribe\Events\Views\V2\iCalendar\Links\Outlook_Live;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Export extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -149,7 +145,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_class', $class, $this );
 	}
 
 	/**
@@ -172,7 +168,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_button_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_button_class', $class, $this );
 	}
 
 	/**
@@ -195,7 +191,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_list_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_list_class', $class, $this );
 	}
 
 	/**
@@ -218,7 +214,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_list_item_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_list_item_class', $class, $this );
 	}
 
 	/**
@@ -241,7 +237,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_link_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_link_class', $class, $this );
 	}
 
 	/**
@@ -264,7 +260,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_content_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_content_class', $class, $this );
 	}
 
 	/**
@@ -287,7 +283,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_icon_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_icon_class', $class, $this );
 	}
 
 	/**
@@ -310,7 +306,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_export_icon_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_export_icon_class', $class, $this );
 	}
 
 	/**
@@ -333,7 +329,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_gcal_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_gcal_class', $class, $this );
 	}
 
 	/**
@@ -356,7 +352,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_ical_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_ical_class', $class, $this );
 	}
 
 	/**
@@ -379,7 +375,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_365_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_365_class', $class, $this );
 	}
 
 	/**
@@ -402,7 +398,7 @@ class Event_Export extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_export_widget_dropdown_live_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_export_widget_dropdown_live_class', $class, $this );
 	}
 
 	/**
@@ -410,7 +406,7 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function register_controls() {
+	protected function register_controls(): void {
 		// Content tab.
 		$this->content_panel();
 		// Style tab.
@@ -422,7 +418,7 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_panel() {
+	protected function content_panel(): void {
 		$this->content_options();
 	}
 
@@ -431,59 +427,47 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_options() {
+	protected function content_options(): void {
 		$this->start_controls_section(
-			'section_title',
+			'content_section',
 			[
 				'label' => esc_html__( 'Add to Calendar Button', 'the-events-calendar' ),
 			]
 		);
 
 		// Toggle for including Google Calendar.
-		$this->add_control(
-			'show_gcal_link',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Include Google Calendar', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'    => 'show_gcal_link',
+				'label' => esc_html__( 'Include Google Calendar', 'the-events-calendar' ),
 			]
 		);
 
 		// Toggle for including iCalendar.
-		$this->add_control(
-			'show_ical_link',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Include iCalendar', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'    => 'show_ical_link',
+				'label' => esc_html__( 'Include iCalendar', 'the-events-calendar' ),
 			]
 		);
 
 		// Toggle for including Outlook 365.
-		$this->add_control(
-			'show_outlook_365_link',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Include Outlook 365', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'    => 'show_outlook_365_link',
+				'label' => esc_html__( 'Include Outlook 365', 'the-events-calendar' ),
 			]
 		);
 
 		// Toggle for including Outlook Live.
-		$this->add_control(
-			'show_outlook_live_link',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Include Outlook Live', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'    => 'show_outlook_live_link',
+				'label' => esc_html__( 'Include Outlook Live', 'the-events-calendar' ),
 			]
 		);
 
@@ -495,9 +479,9 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_panel() {
+	protected function style_panel(): void {
 		$this->style_export_button();
-
+		$this->style_export_button_hover();
 		$this->style_export_dropdown();
 	}
 
@@ -506,91 +490,20 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_export_button() {
+	protected function style_export_button(): void {
 		$this->start_controls_section(
-			'styling_section_title',
+			'button_styling_section',
 			[
-				'label' => esc_html__( 'Add to Calendar Button', 'the-events-calendar' ),
+				'label' => esc_html__( 'Button Styles', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'color_on_hover',
-			[
-				'label'     => esc_html__( 'Text Color on Hover', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class() . ':hover' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class(),
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'prefix'   => 'button',
+				'selector' => '{{WRAPPER}} .' . $this->get_button_class(),
 			]
 		);
 
@@ -599,12 +512,7 @@ class Event_Export extends Abstract_Widget {
 			[
 				'label'     => esc_html__( 'Border Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class() => 'border-color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_button_class() => 'border-color: {{VALUE}};' ],
 				'separator' => 'before',
 			]
 		);
@@ -614,20 +522,51 @@ class Event_Export extends Abstract_Widget {
 			[
 				'label'     => esc_html__( 'Background Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . '  .' . $this->get_button_class() => 'background-color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_dropdown_class() . '  .' . $this->get_button_class() => 'background-color: {{VALUE}};' ],
+			]
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Add controls for text styling of the Google & iCal export button.
+	 *
+	 * @since TBD
+	 */
+	protected function style_export_button_hover(): void {
+		$this->start_controls_section(
+			'button_hover_styling_section',
+			[
+				'label' => esc_html__( 'Button Styles on Hover', 'the-events-calendar' ),
+				'tab'   => Controls_Manager::TAB_STYLE,
+			]
+		);
+
+		$this->add_shared_control(
+			'typography',
+			[
+				'prefix'   => 'button_hover',
+				'selector' => '{{WRAPPER}} .' . $this->get_button_class() . ':hover',
 			]
 		);
 
 		$this->add_control(
-			'button_background_hover_color',
+			'button_hover_border_color',
 			[
-				'label'     => esc_html__( 'Hover Background Color', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Border Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . '  .' . $this->get_button_class() . ':hover' => 'background-color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_button_class() . ':hover' => 'border-color: {{VALUE}};' ],
+				'separator' => 'before',
+			]
+		);
+
+		$this->add_control(
+			'button_hover_background_color',
+			[
+				'label'     => esc_html__( 'Background Color', 'the-events-calendar' ),
+				'type'      => Controls_Manager::COLOR,
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_button_class() => 'background-color: {{VALUE}};' ],
 			]
 		);
 
@@ -639,80 +578,29 @@ class Event_Export extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_export_dropdown() {
+	protected function style_export_dropdown(): void {
 		$this->start_controls_section(
-			'dropdown_styling_section_title',
+			'dropdown_styling_section',
 			[
-				'label' => esc_html__( 'Export Options', 'the-events-calendar' ),
+				'label' => esc_html__( 'Dropdown Options', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'dropdown_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_link_class() => 'color: {{VALUE}}; border-color: {{VALUE}};',
-				],
+				'prefix'   => 'dropdown',
+				'selector' => '{{WRAPPER}} .' . $this->get_list_class(),
+				'label'    => esc_html__( 'Dropdown Typography', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'dropdown_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_link_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'dropdown_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_link_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'dropdown_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_link_class(),
-			]
-		);
-
-		$this->add_control(
-			'dropdown_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_link_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'dropdown_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_list_class() ],
 			]
 		);
 
@@ -721,12 +609,7 @@ class Event_Export extends Abstract_Widget {
 			[
 				'label'     => esc_html__( 'Border Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_list_class() => 'border-color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_list_class() => 'border-color: {{VALUE}};' ],
 				'separator' => 'before',
 			]
 		);
@@ -737,9 +620,7 @@ class Event_Export extends Abstract_Widget {
 				'label'     => esc_html__( 'Background Color', 'the-events-calendar' ),
 				'type'      => Controls_Manager::COLOR,
 				'default'   => '#ffffff',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_dropdown_class() . ' .' . $this->get_list_class() => 'background-color: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_list_class() => 'background-color: {{VALUE}};' ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Export.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Export.php
@@ -40,6 +40,15 @@ class Event_Export extends Abstract_Widget {
 	protected static string $slug = 'event_export';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Image.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Image.php
@@ -24,6 +24,8 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Image extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
+
 	/**
 	 * Widget slug.
 	 *
@@ -133,7 +135,7 @@ class Event_Image extends Abstract_Widget {
 	 */
 	protected function content_options() {
 		$this->start_controls_section(
-			'section_title',
+			'content_section',
 			[
 				'label' => $this->get_title(),
 			]
@@ -167,9 +169,7 @@ class Event_Image extends Abstract_Widget {
 						'icon'  => 'eicon-text-align-right',
 					],
 				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};' ],
 			]
 		);
 
@@ -183,7 +183,7 @@ class Event_Image extends Abstract_Widget {
 	 */
 	protected function styling_options() {
 		$this->start_controls_section(
-			'styling_section_title',
+			'styling_section',
 			[
 				'label' => $this->get_title(),
 				'tab'   => Controls_Manager::TAB_STYLE,
@@ -297,9 +297,7 @@ class Event_Image extends Abstract_Widget {
 					'contain' => esc_html__( 'Contain', 'the-events-calendar' ),
 				],
 				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'object-fit: {{VALUE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'object-fit: {{VALUE}};' ],
 			]
 		);
 
@@ -320,12 +318,8 @@ class Event_Image extends Abstract_Widget {
 					'bottom right'  => esc_html__( 'Bottom Right', 'the-events-calendar' ),
 				],
 				'default'   => 'center center',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'object-position: {{VALUE}};',
-				],
-				'condition' => [
-					'object-fit' => 'cover',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'object-position: {{VALUE}};' ],
+				'condition' => [ 'object-fit' => 'cover' ],
 			]
 		);
 
@@ -358,9 +352,7 @@ class Event_Image extends Abstract_Widget {
 						'step' => 0.01,
 					],
 				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'opacity: {{SIZE}};',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'opacity: {{SIZE}};' ],
 			]
 		);
 
@@ -393,9 +385,7 @@ class Event_Image extends Abstract_Widget {
 						'step' => 0.01,
 					],
 				],
-				'selectors' => [
-					'{{WRAPPER}}:hover .' . $this->get_widget_class() . ' img' => 'opacity: {{SIZE}};',
-				],
+				'selectors' => [ '{{WRAPPER}}:hover .' . $this->get_widget_class() . ' img' => 'opacity: {{SIZE}};' ],
 			]
 		);
 
@@ -418,9 +408,7 @@ class Event_Image extends Abstract_Widget {
 						'step' => 0.1,
 					],
 				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'transition-duration: {{SIZE}}s',
-				],
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() . ' img' => 'transition-duration: {{SIZE}}s' ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Navigation.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Navigation.php
@@ -35,6 +35,15 @@ class Event_Navigation extends Abstract_Widget {
 	protected static string $slug = 'event_navigation';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Organizer.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Organizer.php
@@ -35,6 +35,15 @@ class Event_Organizer extends Abstract_Widget {
 	protected static string $slug = 'event_organizer';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Organizer.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Organizer.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -25,6 +20,8 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Organizer extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
+
 	/**
 	 * Widget slug.
 	 *
@@ -54,7 +51,6 @@ class Event_Organizer extends Abstract_Widget {
 		return esc_html__( 'Event Organizer', 'the-events-calendar' );
 	}
 
-
 	/**
 	 * Get the template args for the widget.
 	 *
@@ -77,26 +73,29 @@ class Event_Organizer extends Abstract_Widget {
 		}
 
 		return [
-			'organizer_ids'       => array_filter( tribe_get_organizer_ids( $event_id ) ),
-			'show_header'         => isset( $settings['show_organizer_header'] ) ? tribe_is_truthy( $settings['show_organizer_header'] ) : true,
-			'link_name'           => isset( $settings['link_organizer_name'] ) ? tribe_is_truthy( $settings['link_organizer_name'] ) : true,
-			'show_name'           => isset( $settings['show_organizer_name'] ) ? tribe_is_truthy( $settings['show_organizer_name'] ) : true,
-			'show_phone'          => isset( $settings['show_organizer_phone'] ) ? tribe_is_truthy( $settings['show_organizer_phone'] ) : true,
-			'show_email'          => isset( $settings['show_organizer_email'] ) ? tribe_is_truthy( $settings['show_organizer_email'] ) : true,
-			'show_website'        => isset( $settings['show_organizer_website'] ) ? tribe_is_truthy( $settings['show_organizer_website'] ) : true,
-			'show_phone_header'   => isset( $settings['show_organizer_phone_header'] ) ? tribe_is_truthy( $settings['show_organizer_phone_header'] ) : true,
-			'show_email_header'   => isset( $settings['show_organizer_email_header'] ) ? tribe_is_truthy( $settings['show_organizer_email_header'] ) : true,
-			'show_website_header' => isset( $settings['show_organizer_website_header'] ) ? tribe_is_truthy( $settings['show_organizer_website_header'] ) : true,
-			'header_tag'          => $settings['organizer_header_tag'] ?? 'h2',
-			'phone_header_tag'    => $settings['organizer_phone_header_tag'] ?? 'h3',
-			'email_header_tag'    => $settings['organizer_email_header_tag'] ?? 'h3',
-			'website_header_tag'  => $settings['organizer_website_header_tag'] ?? 'h3',
-			'email_header_text'   => $this->get_email_header_text(),
-			'phone_header_text'   => $this->get_phone_header_text(),
-			'website_header_text' => $this->get_website_header_text(),
-			'multiple'            => $multiple,
-			'settings'            => $settings,
-			'event_id'            => $event_id,
+			'organizer_ids'                 => array_filter( tribe_get_organizer_ids( $event_id ) ),
+			'show_organizer_header'         => tribe_is_truthy( $settings['show_organizer_header'] ?? true ),
+			'link_organizer_name'           => tribe_is_truthy( $settings['link_organizer_name'] ?? true ),
+			'show_organizer_name'           => tribe_is_truthy( $settings['show_organizer_name'] ?? true ),
+			'show_organizer_phone'          => tribe_is_truthy( $settings['show_organizer_phone'] ?? true ),
+			'link_organizer_phone'          => tribe_is_truthy( $settings['link_organizer_phone'] ?? true ),
+			'show_organizer_email'          => tribe_is_truthy( $settings['show_organizer_email'] ?? true ),
+			'link_organizer_email'          => tribe_is_truthy( $settings['link_organizer_email'] ?? true ),
+			'show_organizer_website'        => tribe_is_truthy( $settings['show_organizer_website'] ?? true ),
+			'show_organizer_phone_header'   => tribe_is_truthy( $settings['show_organizer_phone_header'] ?? true ),
+			'show_organizer_email_header'   => tribe_is_truthy( $settings['show_organizer_email_header'] ?? true ),
+			'show_organizer_website_header' => tribe_is_truthy( $settings['show_organizer_website_header'] ?? true ),
+			'organizer_header_tag'          => $settings['organizer_header_tag'] ?? 'h2',
+			'organizer_name_tag'            => $settings['organizer_name_tag'] ?? 'h3',
+			'organizer_phone_header_tag'    => $settings['organizer_phone_header_tag'] ?? 'h4',
+			'organizer_email_header_tag'    => $settings['organizer_email_header_tag'] ?? 'h4',
+			'organizer_website_header_tag'  => $settings['organizer_website_header_tag'] ?? 'h4',
+			'organizer_email_header_text'   => $this->get_email_header_text(),
+			'organizer_phone_header_text'   => $this->get_phone_header_text(),
+			'organizer_website_header_text' => $this->get_website_header_text(),
+			'multiple'                      => $multiple,
+			'settings'                      => $settings,
+			'event_id'                      => $event_id,
 		];
 	}
 
@@ -152,7 +151,7 @@ class Event_Organizer extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_widget_email_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_widget_email_header_text', $header_text, $this );
 	}
 
 	/**
@@ -179,7 +178,7 @@ class Event_Organizer extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_widget_phone_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_widget_phone_header_text', $header_text, $this );
 	}
 
 	/**
@@ -206,7 +205,7 @@ class Event_Organizer extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_widget_website_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_widget_website_header_text', $header_text, $this );
 	}
 
 	/**
@@ -214,23 +213,20 @@ class Event_Organizer extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 *
-	 * @return array<string> The classes for the event organizer widget.
+	 * @return string The classes for the event organizer widget.
 	 */
-	public function get_widget_header_classes(): array {
-		$classes = [
-			'tribe-events-single-section-title',
-			$this->get_widget_class() . '-header',
-		];
+	public function get_header_class(): string {
+		$class = $this->get_widget_class() . '-header';
 
 		/**
 		 * Filters the classes for the event organizer widget header.
 		 *
 		 * @since TBD
 		 *
-		 * @param array $classes The widget header classes.
-		 * @param Event_Organizer $this The event organizer widget instance.
+		 * @param string          $class The widget header class.
+		 * @param Event_Organizer $this  The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_header_class', $classes, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_header_class', $class, $this );
 	}
 
 	/**
@@ -251,7 +247,28 @@ class Event_Organizer extends Abstract_Widget {
 		 * @param string $class The name base class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_name_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_name_class', $class, $this );
+	}
+
+	/**
+	 * Get the wrapper class for the event organizer name.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name class.
+	 */
+	public function get_name_wrapper_class(): string {
+		$class = $this->get_widget_class() . '-name-wrapper';
+
+		/**
+		 * Filters the wrapper class for the event organizer name section header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $class The name wrapper class.
+		 * @param Event_Organizer $this The event organizer widget instance.
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_name_wrapper_class', $class, $this );
 	}
 
 	/**
@@ -272,28 +289,49 @@ class Event_Organizer extends Abstract_Widget {
 		 * @param string $class The phone base class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_phone_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_phone_class', $class, $this );
 	}
 
 	/**
-	 * Get the label class for the event organizer phone section.
+	 * Get the wrapper class for the event organizer phone.
 	 *
 	 * @since TBD
 	 *
 	 * @return string The phone class.
 	 */
-	public function get_phone_label_class(): string {
-		$class = $this->get_phone_base_class() . '-label';
+	public function get_phone_wrapper_class(): string {
+		$class = $this->get_phone_base_class() . '-wrapper';
 
 		/**
-		 * Filters the label class for the event organizer phone section header.
+		 * Filters the wrapper class for the event organizer phone section header.
 		 *
 		 * @since TBD
 		 *
-		 * @param string $class The phone label class.
+		 * @param string $class The phone wrapper class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_phone_label_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_phone_wrapper_class', $class, $this );
+	}
+
+	/**
+	 * Get the header class for the event organizer phone section.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The phone header class.
+	 */
+	public function get_phone_header_class(): string {
+		$class = $this->get_phone_base_class() . '-header';
+
+		/**
+		 * Filters the header class for the event organizer phone section header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $class The phone header class.
+		 * @param Event_Organizer $this The event organizer widget instance.
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_phone_header_class', $class, $this );
 	}
 
 	/**
@@ -314,28 +352,49 @@ class Event_Organizer extends Abstract_Widget {
 		 * @param string $class The email base class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_email_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_email_class', $class, $this );
 	}
 
 	/**
-	 * Get the label class for the event organizer email section.
+	 * Get the wrapper class for the event organizer email.
 	 *
 	 * @since TBD
 	 *
 	 * @return string The email class.
 	 */
-	public function get_email_label_class(): string {
-		$class = $this->get_email_base_class() . '-label';
+	public function get_email_wrapper_class(): string {
+		$class = $this->get_email_base_class() . '-wrapper';
 
 		/**
-		 * Filters the label class for the event organizer email section header.
+		 * Filters the wrapper class for the event organizer email section header.
 		 *
 		 * @since TBD
 		 *
-		 * @param string $class The email label class.
+		 * @param string $class The email wrapper class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_email_label_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_email_wrapper_class', $class, $this );
+	}
+
+	/**
+	 * Get the header class for the event organizer email section.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email class.
+	 */
+	public function get_email_header_class(): string {
+		$class = $this->get_email_base_class() . '-header';
+
+		/**
+		 * Filters the header class for the event organizer email section header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $class The email header class.
+		 * @param Event_Organizer $this The event organizer widget instance.
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_email_header_class', $class, $this );
 	}
 
 	/**
@@ -356,28 +415,49 @@ class Event_Organizer extends Abstract_Widget {
 		 * @param string $class The website base class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_website_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_website_class', $class, $this );
 	}
 
 	/**
-	 * Get the label class for the event organizer website section.
+	 * Get the wrapper class for the event organizer website.
 	 *
 	 * @since TBD
 	 *
 	 * @return string The website class.
 	 */
-	public function get_website_label_class(): string {
-		$class = $this->get_website_base_class() . '-label';
+	public function get_website_wrapper_class(): string {
+		$class = $this->get_website_base_class() . '-wrapper';
 
 		/**
-		 * Filters the label class for the event organizer website section header.
+		 * Filters the wrapper class for the event organizer website section header.
 		 *
 		 * @since TBD
 		 *
-		 * @param string $class The website label class.
+		 * @param string $class The website wrapper class.
 		 * @param Event_Organizer $this The event organizer widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_organizer_website_label_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_website_wrapper_class', $class, $this );
+	}
+
+	/**
+	 * Get the header class for the event organizer website section.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The website class.
+	 */
+	public function get_website_header_class(): string {
+		$class = $this->get_website_base_class() . '-header';
+
+		/**
+		 * Filters the header class for the event organizer website section header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $class The website header class.
+		 * @param Event_Organizer $this The event organizer widget instance.
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_organizer_website_header_class', $class, $this );
 	}
 
 	/**
@@ -465,122 +545,24 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		// Widget alignment control.
-		$this->add_responsive_control(
-			'align',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
+				'id'      => 'show_organizer_header',
+				'label'   => esc_html__( 'Show Widget Header', 'the-events-calendar' ),
+				'default' => 'no',
 			]
 		);
 
-		// Show Organizer Header control.
-		$this->add_control(
-			'show_organizer_header',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Widget Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		$this->add_control(
-			'organizer_header_tag',
-			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
+				'id'        => 'organizer_header_tag',
+				'label'     => esc_html__( 'Widget Header HTML Tag', 'the-events-calendar' ),
 				'default'   => 'h2',
-				'condition' => [
-					'show_organizer_header' => 'yes',
-				],
+				'condition' => [ 'show_organizer_header' => 'yes' ],
 			]
 		);
-
-		// Show Organizer Name control.
-		$this->add_control(
-			'show_organizer_name',
-			[
-				'label'     => esc_html__( 'Show Name', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		// Only show the following options if the event has a single organizer.
-		if ( ! $this->has_multiple_organizers() ) {
-			// Show Organizer Phone control.
-			$this->add_control(
-				'show_organizer_phone',
-				[
-					'label'     => esc_html__( 'Show Phone', 'the-events-calendar' ),
-					'type'      => Controls_Manager::SWITCHER,
-					'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-					'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-					'default'   => 'yes',
-				]
-			);
-
-			// Show Organizer Email control.
-			$this->add_control(
-				'show_organizer_email',
-				[
-					'label'     => esc_html__( 'Show Email', 'the-events-calendar' ),
-					'type'      => Controls_Manager::SWITCHER,
-					'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-					'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-					'default'   => 'yes',
-				]
-			);
-
-			// Show Organizer Website control.
-			$this->add_control(
-				'show_organizer_website',
-				[
-					'label'     => esc_html__( 'Show Website', 'the-events-calendar' ),
-					'type'      => Controls_Manager::SWITCHER,
-					'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-					'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-					'default'   => 'yes',
-				]
-			);
-		}
 
 		$this->end_controls_section();
 	}
@@ -591,8 +573,15 @@ class Event_Organizer extends Abstract_Widget {
 	 * @since TBD
 	 */
 	protected function style_panel() {
-		// Styling options.
-		$this->styling_options();
+		$this->style_organizer_header();
+
+		$this->style_organizer_name();
+
+		$this->style_organizer_phone();
+
+		$this->style_organizer_email();
+
+		$this->style_organizer_website();
 	}
 
 	/**
@@ -603,15 +592,28 @@ class Event_Organizer extends Abstract_Widget {
 	protected function organizer_name_content_options() {
 		$this->start_controls_section(
 			'organizer_name_content_options',
+			[ 'label' => esc_html__( 'Name', 'the-events-calendar' ) ]
+		);
+
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Event Organizer Name', 'the-events-calendar' ),
-				'condition' => [
-					'show_organizer_name' => 'yes',
-				],
+				'id'    => 'show_organizer_name',
+				'label' => esc_html__( 'Show Name', 'the-events-calendar' ),
 			]
 		);
 
-		// Show Organizer Header control.
+		$this->add_shared_control(
+			'tag',
+			[
+				'id'        => 'organizer_name_tag',
+				'label'     => esc_html__( 'Name HTML Tag', 'the-events-calendar' ),
+				'default'   => 'h2',
+				'condition' => [ 'show_organizer_name' => 'yes' ],
+			]
+		);
+
+		// Link Organizer Name control.
 		$this->add_control(
 			'link_organizer_name',
 			[
@@ -620,29 +622,7 @@ class Event_Organizer extends Abstract_Widget {
 				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
 				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
 				'default'   => 'yes',
-			]
-		);
-
-		$this->add_control(
-			'organizer_name_tag',
-			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h2',
-				'condition' => [
-					'show_organizer_header' => 'yes',
-				],
+				'condition' => [ 'show_organizer_name' => 'yes' ],
 			]
 		);
 
@@ -658,45 +638,49 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_phone_content_options',
 			[
-				'label'     => esc_html__( 'Event Organizer Phone', 'the-events-calendar' ),
-				'condition' => [
-					'show_organizer_phone' => 'yes',
-				],
+				'label' => esc_html__( 'Phone', 'the-events-calendar' ),
 			]
 		);
 
-		// Show Organizer Header control.
-		$this->add_control(
-			'show_organizer_phone_header',
+		$this->add_shared_control(
+			'show',
 			[
+				'id'    => 'show_organizer_phone',
+				'label' => esc_html__( 'Show Phone', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_organizer_phone_header',
 				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'default'   => 'no',
+				'condition' => [ 'show_organizer_phone' => 'yes' ],
 			]
 		);
 
-		$this->add_control(
-			'organizer_phone_header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
-				'condition' => [
-					'show_organizer_phone_header' => 'yes',
-				],
+				'id'        => 'organizer_phone_header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'default'   => 'h4',
+				'condition' => [ 'show_organizer_phone_header' => 'yes' ],
+			]
+		);
+
+		// Link Organizer Name control.
+		$this->add_control(
+			'link_organizer_phone',
+			[
+				'label'       => esc_html__( 'Link organizer phone.', 'the-events-calendar' ),
+				'description' => esc_html__( 'Make organizer phone number a callable link.', 'the-events-calendar' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'label_on'    => esc_html__( 'Yes', 'the-events-calendar' ),
+				'label_off'   => esc_html__( 'No', 'the-events-calendar' ),
+				'default'     => 'yes',
+				'condition'   => [ 'show_organizer_phone' => 'yes' ],
 			]
 		);
 
@@ -712,45 +696,49 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_email_content_options',
 			[
-				'label'     => esc_html__( 'Event Organizer Email', 'the-events-calendar' ),
-				'condition' => [
-					'show_organizer_email' => 'yes',
-				],
+				'label' => esc_html__( 'Email', 'the-events-calendar' ),
 			]
 		);
 
-		// Show Organizer Header control.
-		$this->add_control(
-			'show_organizer_email_header',
+		$this->add_shared_control(
+			'show',
 			[
+				'id'    => 'show_organizer_email',
+				'label' => esc_html__( 'Show Email', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_organizer_email_header',
 				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'condition' => [ 'show_organizer_email' => 'yes' ],
+				'default'   => 'no',
 			]
 		);
 
-		$this->add_control(
-			'organizer_email_header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
-				'condition' => [
-					'show_organizer_email_header' => 'yes',
-				],
+				'id'        => 'organizer_email_header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'default'   => 'h4',
+				'condition' => [ 'show_organizer_email_header' => 'yes' ],
+			]
+		);
+
+		// Link Organizer Name control.
+		$this->add_control(
+			'link_organizer_email',
+			[
+				'label'       => esc_html__( 'Link organizer email.', 'the-events-calendar' ),
+				'description' => esc_html__( 'Make organizer email a mailto link.', 'the-events-calendar' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'label_on'    => esc_html__( 'Yes', 'the-events-calendar' ),
+				'label_off'   => esc_html__( 'No', 'the-events-calendar' ),
+				'default'     => 'yes',
+				'condition'   => [ 'show_organizer_email' => 'yes' ],
 			]
 		);
 
@@ -766,80 +754,42 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_website_content_options',
 			[
-				'label'     => esc_html__( 'Event Organizer Website', 'the-events-calendar' ),
-				'condition' => [
-					'show_organizer_website' => 'yes',
-				],
+				'label' => esc_html__( 'Website', 'the-events-calendar' ),
 			]
 		);
 
 		// Show Organizer Header control.
-		$this->add_control(
-			'show_organizer_website_header',
+		$this->add_shared_control(
+			'show',
 			[
+				'id'    => 'show_organizer_website',
+				'label' => esc_html__( 'Show Website', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_organizer_website_header',
 				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'condition' => [ 'show_organizer_website' => 'yes' ],
+				'default'   => 'no',
 			]
 		);
 
-		$this->add_control(
-			'organizer_website_header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
-				'condition' => [
-					'show_organizer_website_header' => 'yes',
-				],
+				'id'        => 'organizer_website_header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'default'   => 'h4',
+				'condition' => [ 'show_organizer_website_header' => 'yes' ],
 			]
 		);
 
-		$this->add_control(
-			'organizer_website_link_target',
-			[
-				'label'       => esc_html__( 'Link Target', 'the-events-calendar' ),
-				'description' => esc_html__( 'Choose whether to open the organizer website link in the same window or a new window.', 'the-events-calendar' ),
-				'type'        => Controls_Manager::SELECT,
-				'default'     => '_self',
-				'options'     => [
-					'_self'  => 'same window',
-					'_blank' => 'new window',
-				],
-			]
-		);
+		$this->add_shared_control( 'link_target', [ 'prefix' => 'organizer_website_link_target' ] );
 
 		$this->end_controls_section();
-	}
-
-	/**
-	 * Add controls for text styling of the event organizer.
-	 *
-	 * @since TBD
-	 */
-	protected function styling_options() {
-		$this->style_organizer_label();
-
-		$this->style_organizer_name();
-
-		$this->style_organizer_phone();
-
-		$this->style_organizer_email();
-
-		$this->style_organizer_website();
 	}
 
 	/**
@@ -849,11 +799,11 @@ class Event_Organizer extends Abstract_Widget {
 	 *
 	 * @return void
 	 */
-	protected function style_organizer_label() {
+	protected function style_organizer_header() {
 		$this->start_controls_section(
-			'organizer_section_header_styling',
+			'organizer_header_styling_section',
 			[
-				'label'     => esc_html__( 'Organizer Header', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Header', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'show_organizer_header' => 'yes',
@@ -861,71 +811,19 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'header_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_header_classes()[0] => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'organizer_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'header_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_header_classes()[0],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'header_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_header_classes()[0],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'header_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_header_classes()[0],
-			]
-		);
-
-		$this->add_control(
-			'header_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_header_classes()[0] => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'organizer_header_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_header_class() ],
 			]
 		);
 
@@ -943,7 +841,7 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_name_styling',
 			[
-				'label'     => esc_html__( 'Organizer Name', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Name', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'show_organizer_name' => 'yes',
@@ -951,71 +849,19 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'name_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_name_base_class() . ' a' => 'color: {{VALUE}}; border-bottom-color: {{VALUE}};',
-				],
+				'prefix'   => 'organizer_name',
+				'selector' => '{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'name_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'name_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'name_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_control(
-			'name_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'organizer_name_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_name_base_class() ],
 			]
 		);
 
@@ -1033,7 +879,7 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_phone_styling',
 			[
-				'label'     => esc_html__( 'Organizer Phone', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Phone', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'show_organizer_phone' => 'yes',
@@ -1041,155 +887,52 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'phone_label_header',
+		$this->add_shared_control(
+			'subheader',
 			[
-				'label' => esc_html__( 'Phone Header', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
+				'prefix' => 'phone_header',
+				'label'  => esc_html__( 'Phone Header', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'phone_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_label_class() => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'phone_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_phone_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'phone_label_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_label_class(),
+				'id'        => 'phone_header_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_phone_header_class() ],
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'     => 'phone_label_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_label_class(),
+				'prefix'    => 'phone_text',
+				'label'     => esc_html__( 'Phone Text', 'the-events-calendar' ),
+				'separator' => 'before',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'     => 'phone_label_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_label_class(),
-			]
-		);
-
-		$this->add_control(
-			'phone_label_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_label_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-			]
-		);
-
-		$this->add_control(
-			'phone_header',
-			[
-				'label' => esc_html__( 'Phone Text', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'phone_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'phone_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'phone_text',
 				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'phone_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'phone_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class(),
-			]
-		);
-
-		$this->add_control(
-			'phone_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'phone_text_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_phone_base_class() ],
 			]
 		);
 
@@ -1207,7 +950,7 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_email_styling',
 			[
-				'label'     => esc_html__( 'Organizer Email', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Email', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'show_organizer_email' => 'yes',
@@ -1215,155 +958,52 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'email_label_header',
+		$this->add_shared_control(
+			'subheader',
 			[
-				'label' => esc_html__( 'Email Header', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
+				'prefix' => 'email_header',
+				'label'  => esc_html__( 'Email Header', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'email_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_email_label_class() => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'email_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_email_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'email_label_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_email_label_class(),
+				'id'        => 'email_header_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_email_header_class() ],
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'     => 'email_label_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_email_label_class(),
+				'prefix'    => 'email_text',
+				'label'     => esc_html__( 'Email Text', 'the-events-calendar' ),
+				'separator' => 'before',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'     => 'email_label_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_email_label_class(),
+				'prefix'   => 'email_text',
+				'selector' => '{{WRAPPER}}  .' . $this->get_email_base_class(),
 			]
 		);
 
-		$this->add_control(
-			'email_label_blend_mode',
+		$this->add_shared_control(
+			'alignment',
 			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_email_label_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-			]
-		);
-
-		$this->add_control(
-			'email_header',
-			[
-				'label' => esc_html__( 'Email Text', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'email_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_email_base_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'email_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_email_base_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'email_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_email_base_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'email_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_email_base_class(),
-			]
-		);
-
-		$this->add_control(
-			'email_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_email_base_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'email_text_alignment',
+				'selectors' => [ '{{WRAPPER}} .a' . $this->get_email_base_class() ],
 			]
 		);
 
@@ -1381,7 +1021,7 @@ class Event_Organizer extends Abstract_Widget {
 		$this->start_controls_section(
 			'organizer_website_styling',
 			[
-				'label'     => esc_html__( 'Organizer Website', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Website', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
 					'show_organizer_website' => 'yes',
@@ -1389,155 +1029,52 @@ class Event_Organizer extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'website_label_header',
+		$this->add_shared_control(
+			'subheader',
 			[
-				'label' => esc_html__( 'Website Header', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
+				'prefix' => 'website_header',
+				'label'  => esc_html__( 'Website Header', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'website_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_label_class() => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'website_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_website_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'website_label_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_website_label_class(),
+				'id'        => 'website_header_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_website_header_class() ],
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'     => 'website_label_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_label_class(),
+				'prefix'    => 'website_url',
+				'label'     => esc_html__( 'Website Url', 'the-events-calendar' ),
+				'separator' => 'before',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'     => 'website_label_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_label_class(),
-			]
-		);
-
-		$this->add_control(
-			'website_label_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_label_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-			]
-		);
-
-		$this->add_control(
-			'website_header',
-			[
-				'label' => esc_html__( 'Website Url', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'website_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . ' a' => 'color: {{VALUE}}; border-bottom-color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'website_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'website_url',
 				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . ' a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'website_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . ' a',
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'website_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . ' a',
-			]
-		);
-
-		$this->add_control(
-			'website_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . ' a' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'website_url_alignment',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_website_base_class() ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Tags.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Tags.php
@@ -36,6 +36,15 @@ class Event_Tags extends Abstract_Widget {
 	protected static string $slug = 'event_tags';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Title.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Title.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -25,6 +20,7 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Title extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -36,6 +32,15 @@ class Event_Title extends Abstract_Widget {
 	protected static string $slug = 'event_title';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD
@@ -44,19 +49,6 @@ class Event_Title extends Abstract_Widget {
 	 */
 	protected function title(): string {
 		return esc_html__( 'Event Title', 'the-events-calendar' );
-	}
-
-	/**
-	 * Determine the HTML tag to use for the event title based on settings.
-	 *
-	 * @since TBD
-	 *
-	 * @return string The HTML tag to use for the event title.
-	 */
-	protected function get_event_title_header_tag(): string {
-		$settings = $this->get_settings_for_display();
-
-		return $settings['header_tag'] ?? 'h1';
 	}
 
 	/**
@@ -76,6 +68,19 @@ class Event_Title extends Abstract_Widget {
 			'header_tag' => $header_tag,
 			'title'      => $title,
 		];
+	}
+
+	/**
+	 * Determine the HTML tag to use for the event title based on settings.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The HTML tag to use for the event title.
+	 */
+	protected function get_event_title_header_tag(): string {
+		$settings = $this->get_settings_for_display();
+
+		return $settings['header_tag'] ?? 'h1';
 	}
 
 	/**
@@ -116,59 +121,18 @@ class Event_Title extends Abstract_Widget {
 	 */
 	protected function content_options(): void {
 		$this->start_controls_section(
-			'section_title',
+			'content_section',
 			[
 				'label' => $this->get_title(),
 			]
 		);
 
-		$this->add_control(
-			'header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
+				'id'      => 'header_tag',
 				'label'   => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'    => Controls_Manager::SELECT,
-				'options' => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
 				'default' => 'h1',
-			]
-		);
-
-		$this->add_responsive_control(
-			'align',
-			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
 			]
 		);
 
@@ -182,78 +146,26 @@ class Event_Title extends Abstract_Widget {
 	 */
 	protected function styling_options(): void {
 		$this->start_controls_section(
-			'styling_section_title',
+			'event_title_styling_section',
 			[
 				'label' => $this->get_title(),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'event_title',
 				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'event_title_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_widget_class() ],
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Venue.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Venue.php
@@ -37,6 +37,15 @@ class Event_Venue extends Abstract_Widget {
 	protected static string $slug = 'event_venue';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Venue.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Venue.php
@@ -10,13 +10,8 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -27,6 +22,8 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Venue extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
+
 	/**
 	 * Widget slug.
 	 *
@@ -70,9 +67,9 @@ class Event_Venue extends Abstract_Widget {
 
 		if ( isset( $settings['venue_website_link_target'] ) ) {
 			$this->set_template_filter(
-				'tec_get_event_venue_website_link_target',
+				'tribe_get_event_venue_website_link_target',
 				function () use ( $settings ) {
-					return $settings['organizer_website_link_target'];
+					return $settings['venue_website_link_target'];
 				}
 			);
 		}
@@ -91,6 +88,7 @@ class Event_Venue extends Abstract_Widget {
 			// Boolean conversion of yes/no strings. Default false.
 			'show_address_header'   => tribe_is_truthy( $settings['show_venue_address_header'] ?? false ),
 			'show_phone_header'     => tribe_is_truthy( $settings['show_venue_phone_header'] ?? false ),
+			'link_venue_phone'      => tribe_is_truthy( $settings['link_venue_phone'] ?? false ),
 			'show_website_header'   => tribe_is_truthy( $settings['show_venue_website_header'] ?? false ),
 			// HTML tags.
 			'header_tag'            => $settings['venue_header_tag'] ?? 'h2',
@@ -180,7 +178,7 @@ class Event_Venue extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_widget_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_widget_header_text', $header_text, $this );
 	}
 
 	/**
@@ -207,7 +205,7 @@ class Event_Venue extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_widget_website_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_widget_website_header_text', $header_text, $this );
 	}
 
 	/**
@@ -234,7 +232,7 @@ class Event_Venue extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_widget_phone_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_widget_phone_header_text', $header_text, $this );
 	}
 
 	/**
@@ -261,7 +259,7 @@ class Event_Venue extends Abstract_Widget {
 		 *
 		 * @return string The filtered header text.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_widget_address_header_text', $header_text, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_widget_address_header_text', $header_text, $this );
 	}
 
 	/**
@@ -284,17 +282,14 @@ class Event_Venue extends Abstract_Widget {
 	}
 
 	/**
-	 * Get the classes for the widget header.
+	 * Get the class for the widget header.
 	 *
 	 * @since TBD
 	 *
-	 * @return array The header classes.
+	 * @return array The header class.
 	 */
-	public function get_header_classes() {
-		$classes = [
-			'tribe-events-single-section-title',
-			$this->get_widget_class() . '-header',
-		];
+	public function get_header_class() {
+		$class = $this->get_widget_class() . '-header';
 
 		/**
 		 * Filters the classes for the event venue widget header.
@@ -304,7 +299,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param array $classes The widget header classes.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_header_class', $classes, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_header_class', $class, $this );
 	}
 
 	/**
@@ -325,7 +320,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param string $class The name base class.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_name_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_name_class', $class, $this );
 	}
 
 	/**
@@ -346,7 +341,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param string $class The address base class.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_address_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_address_class', $class, $this );
 	}
 
 	/**
@@ -367,7 +362,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param string $class The phone base class.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_phone_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_phone_class', $class, $this );
 	}
 
 	/**
@@ -388,7 +383,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param string $class The website base class.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_website_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_website_class', $class, $this );
 	}
 
 	/**
@@ -409,7 +404,7 @@ class Event_Venue extends Abstract_Widget {
 		 * @param string $class The map base class.
 		 * @param Event_Venue $this The event venue widget instance.
 		 */
-		return apply_filters( 'tec_events_elementor_event_venue_map_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_venue_map_class', $class, $this );
 	}
 
 	/**
@@ -418,9 +413,7 @@ class Event_Venue extends Abstract_Widget {
 	 * @since TBD
 	 */
 	protected function register_controls() {
-		// Content tab.
 		$this->content_panel();
-		// Style tab.
 		$this->style_panel();
 	}
 
@@ -439,6 +432,8 @@ class Event_Venue extends Abstract_Widget {
 		$this->venue_phone_content_options();
 
 		$this->venue_website_content_options();
+
+		$this->venue_map_content_options();
 	}
 
 	/**
@@ -447,8 +442,17 @@ class Event_Venue extends Abstract_Widget {
 	 * @since TBD
 	 */
 	protected function style_panel() {
-		// Styling options.
-		$this->styling_options();
+		$this->style_venue_header();
+
+		$this->style_venue_name();
+
+		$this->style_venue_address();
+
+		$this->style_venue_phone();
+
+		$this->style_venue_website();
+
+		$this->style_venue_map();
 	}
 
 	/**
@@ -459,134 +463,27 @@ class Event_Venue extends Abstract_Widget {
 	protected function content_options() {
 		$this->start_controls_section(
 			'section_title',
-			[
-				'label' => esc_html__( 'Event Venue', 'the-events-calendar' ),
-			]
-		);
-
-		// Widget alignment control.
-		$this->add_responsive_control(
-			'align',
-			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . implode( ' ', (array) $this->get_container_classes() ) => 'text-align: {{VALUE}};',
-				],
-			]
+			[ 'label' => esc_html__( 'Event Venue', 'the-events-calendar' ) ]
 		);
 
 		// Show Venue Header control.
-		$this->add_control(
-			'show_venue_header',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Show Widget Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'      => 'show_venue_header',
+				'label'   => esc_html__( 'Show Widget Header', 'the-events-calendar' ),
+				'default' => 'no',
 			]
 		);
 
-		$this->add_control(
-			'venue_header_tag',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
+				'id'        => 'venue_header_tag',
 				'default'   => 'h2',
 				'condition' => [
 					'show_venue_header' => 'yes',
 				],
-			]
-		);
-
-		// Show Venue Name control.
-		$this->add_control(
-			'show_venue_name',
-			[
-				'label'     => esc_html__( 'Show Name', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		// Show Venue Address control.
-		$this->add_control(
-			'show_venue_address',
-			[
-				'label'     => esc_html__( 'Show Address', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		// Show Venue Phone control.
-		$this->add_control(
-			'show_venue_phone',
-			[
-				'label'     => esc_html__( 'Show Phone', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		// Show Venue Website control.
-		$this->add_control(
-			'show_venue_website',
-			[
-				'label'     => esc_html__( 'Show Website', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		// Show Venue Map control.
-		$this->add_control(
-			'show_venue_map',
-			[
-				'label'     => esc_html__( 'Show Map', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
 			]
 		);
 
@@ -601,33 +498,24 @@ class Event_Venue extends Abstract_Widget {
 	protected function venue_name_content_options() {
 		$this->start_controls_section(
 			'venue_name_content_options',
+			[ 'label' => esc_html__( 'Name', 'the-events-calendar' ) ]
+		);
+
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Event Venue Name', 'the-events-calendar' ),
-				'condition' => [
-					'show_venue_name' => 'yes',
-				],
+				'id'    => 'show_venue_name',
+				'label' => esc_html__( 'Show Name', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_control(
-			'venue_name_html_tag',
+		$this->add_shared_control(
+			'tag',
 			[
+				'id'        => 'venue_name_html_tag',
 				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
 				'condition' => [
-					'show_venue_address_header' => 'yes',
+					'show_venue_name' => 'yes',
 				],
 			]
 		);
@@ -641,6 +529,9 @@ class Event_Venue extends Abstract_Widget {
 				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
 				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
 				'default'   => 'yes',
+				'condition' => [
+					'show_venue_name' => 'yes',
+				],
 			]
 		);
 
@@ -655,46 +546,50 @@ class Event_Venue extends Abstract_Widget {
 	protected function venue_phone_content_options() {
 		$this->start_controls_section(
 			'venue_phone_content_options',
+			[ 'label' => esc_html__( 'Phone', 'the-events-calendar' ) ]
+		);
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Event Venue Phone', 'the-events-calendar' ),
+				'id'    => 'show_venue_phone',
+				'label' => esc_html__( 'Show Phone', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_venue_phone_header',
+				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
+				'default'   => 'no',
 				'condition' => [
 					'show_venue_phone' => 'yes',
 				],
 			]
 		);
 
-		// Show Venue Header control.
-		$this->add_control(
-			'show_venue_phone_header',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'no',
-			]
-		);
-
-		$this->add_control(
-			'venue_phone_header_tag',
-			[
+				'id'        => 'venue_phone_header_tag',
 				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
 				'condition' => [
 					'show_venue_phone_header' => 'yes',
 				],
+			]
+		);
+
+		// Link Organizer Name control.
+		$this->add_control(
+			'link_venue_phone',
+			[
+				'label'       => esc_html__( 'Link venue phone.', 'the-events-calendar' ),
+				'description' => esc_html__( 'Make venue phone number a callable link.', 'the-events-calendar' ),
+				'type'        => Controls_Manager::SWITCHER,
+				'label_on'    => esc_html__( 'Yes', 'the-events-calendar' ),
+				'label_off'   => esc_html__( 'No', 'the-events-calendar' ),
+				'default'     => 'yes',
+				'condition'   => [ 'show_venue_phone' => 'yes' ],
 			]
 		);
 
@@ -709,57 +604,46 @@ class Event_Venue extends Abstract_Widget {
 	protected function venue_address_content_options() {
 		$this->start_controls_section(
 			'venue_address_content_options',
+			[ 'label' => esc_html__( 'Address', 'the-events-calendar' ) ]
+		);
+
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Event Venue Address', 'the-events-calendar' ),
+				'id'    => 'show_venue_address',
+				'label' => esc_html__( 'Show Address', 'the-events-calendar' ),
+			]
+		);
+
+		// Show Venue Header control.
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_venue_address_header',
+				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
+				'default'   => 'no',
 				'condition' => [
 					'show_venue_address' => 'yes',
 				],
 			]
 		);
 
-		// Show Venue Header control.
-		$this->add_control(
-			'show_venue_address_header',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'no',
-			]
-		);
-
-		$this->add_control(
-			'venue_address_header_tag',
-			[
+				'id'        => 'venue_address_header_tag',
 				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
 				'condition' => [
 					'show_venue_address_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'show_venue_address_map_link',
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Show Map Link', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'yes',
+				'id'    => 'show_venue_address_map_link',
+				'label' => esc_html__( 'Show Map Link', 'the-events-calendar' ),
 			]
 		);
 
@@ -774,82 +658,66 @@ class Event_Venue extends Abstract_Widget {
 	protected function venue_website_content_options() {
 		$this->start_controls_section(
 			'venue_website_content_options',
+			[ 'label' => esc_html__( 'Website', 'the-events-calendar' ) ]
+		);
+
+		$this->add_shared_control(
+			'show',
 			[
-				'label'     => esc_html__( 'Event Venue Website', 'the-events-calendar' ),
+				'id'    => 'show_venue_website',
+				'label' => esc_html__( 'Show Website', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'        => 'show_venue_website_header',
+				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
+				'default'   => 'no',
 				'condition' => [
 					'show_venue_website' => 'yes',
 				],
 			]
 		);
 
-		// Show Venue Header control.
-		$this->add_control(
-			'show_venue_website_header',
+		$this->add_shared_control(
+			'tag',
 			[
-				'label'     => esc_html__( 'Show Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Yes', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'No', 'the-events-calendar' ),
-				'default'   => 'no',
-			]
-		);
-
-		$this->add_control(
-			'venue_website_header_tag',
-			[
+				'id'        => 'venue_website_header_tag',
 				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
 				'condition' => [
 					'show_venue_website_header' => 'yes',
 				],
 			]
 		);
-		$this->add_control(
-			'venue_website_link_target',
-			[
-				'label'       => esc_html__( 'Link Target', 'the-events-calendar' ),
-				'description' => esc_html__( 'Choose whether to open the venue website link in the same window or a new window.', 'the-events-calendar' ),
-				'type'        => Controls_Manager::SELECT,
-				'default'     => '_self',
-				'options'     => [
-					'_self'  => 'same window',
-					'_blank' => 'new window',
-				],
-			]
-		);
+
+		$this->add_shared_control( 'link_target', [ 'prefix' => 'venue_website_link_target' ] );
 
 		$this->end_controls_section();
 	}
 
 	/**
-	 * Add controls for text styling of the event venue.
+	 * Add controls for text content of the event venue website.
 	 *
 	 * @since TBD
 	 */
-	protected function styling_options() {
-		$this->style_venue_label();
+	protected function venue_map_content_options() {
+		$this->start_controls_section(
+			'venue_map_content_options',
+			[ 'label' => esc_html__( 'Map', 'the-events-calendar' ) ]
+		);
 
-		$this->style_venue_name();
+		// Show Venue Map control.
+		$this->add_shared_control(
+			'show',
+			[
+				'id'    => 'show_venue_map',
+				'label' => esc_html__( 'Show Map', 'the-events-calendar' ),
+			]
+		);
 
-		$this->style_venue_address();
-
-		$this->style_venue_phone();
-
-		$this->style_venue_website();
-
-		$this->style_venue_map();
+		$this->end_controls_section();
 	}
 
 	/**
@@ -859,7 +727,7 @@ class Event_Venue extends Abstract_Widget {
 	 *
 	 * @return void
 	 */
-	protected function style_venue_label() {
+	protected function style_venue_header() {
 		$this->start_controls_section(
 			'venue_section_header_styling',
 			[
@@ -871,71 +739,19 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'header_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_header_classes()[0] => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'venue_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'header_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_header_classes()[0],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'header_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_header_classes()[0],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'header_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_header_classes()[0],
-			]
-		);
-
-		$this->add_control(
-			'header_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} ' . $this->get_header_classes()[0] => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'venue_header_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_header_class(),
 			]
 		);
 
@@ -961,73 +777,22 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'name_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'name_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'venue_name',
 				'selector' => '{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'name_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a',
+				'id'        => 'venue_name_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_name_base_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'name_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a',
-			]
-		);
-
-		$this->add_control(
-			'name_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_name_base_class() . ', {{WRAPPER}} .' . $this->get_name_base_class() . ' a' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
-			]
-		);
 
 		$this->end_controls_section();
 	}
@@ -1051,173 +816,54 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'phone_label_header',
+		$this->add_shared_control(
+			'subheader',
 			[
+				'prefix'    => 'phone_header',
 				'label'     => esc_html__( 'Phone Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::HEADING,
 				'condition' => [
 					'show_venue_phone_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'phone_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() . '-header' => 'color: {{VALUE}};',
-				],
-				'condition' => [
-					'show_venue_phone_header' => 'yes',
-				],
+				'prefix'   => 'phone_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'      => 'phone_label_typography',
-				'global'    => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector'  => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-header',
-				'condition' => [
-					'show_venue_phone_header' => 'yes',
-				],
+				'id'        => 'phone_header_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'      => 'phone_label_text_stroke',
-				'selector'  => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-header',
-				'condition' => [
-					'show_venue_phone_header' => 'yes',
-				],
+				'prefix' => 'phone_number',
+				'label'  => esc_html__( 'Phone Number', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'      => 'phone_label_text_shadow',
-				'selector'  => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-header',
-				'condition' => [
-					'show_venue_phone_header' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'phone_label_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() . '-header' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-				'condition' => [
-					'show_venue_phone_header' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'phone_header',
-			[
-				'label' => esc_html__( 'Phone Text', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'phone_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() . '-number' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'phone_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'phone_number',
 				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-number',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'phone_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-number',
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'phone_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-number',
-			]
-		);
-
-		$this->add_control(
-			'phone_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_phone_base_class() . '-number' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'phone_number_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_phone_base_class() . '-number',
 			]
 		);
 
@@ -1243,181 +889,56 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'address_label_header',
+
+
+		$this->add_shared_control(
+			'subheader',
 			[
-				'label'     => esc_html__( 'Address Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::HEADING,
+				'prefix'    => 'address_header',
+				'label'     => esc_html__( 'Phone Number', 'the-events-calendar' ),
 				'condition' => [
 					'show_venue_address_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'address_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class() . '-header' => 'color: {{VALUE}};',
-				],
-				'condition' => [
-					'show_venue_address_header' => 'yes',
-				],
+				'prefix'   => 'address_header',
+				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'      => 'address_label_typography',
-				'global'    => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-header',
-				'condition' => [
-					'show_venue_address_header' => 'yes',
-				],
+				'id'        => 'address_header_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_address_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'      => 'address_label_text_stroke',
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-header',
-				'condition' => [
-					'show_venue_address_header' => 'yes',
-				],
+				'prefix' => 'address_text',
+				'label'  => esc_html__( 'Address Text', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'      => 'address_label_text_shadow',
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-header',
-				'condition' => [
-					'show_venue_address_header' => 'yes',
-				],
+				'prefix'   => 'address_text',
+				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class(),
 			]
 		);
 
-		$this->add_control(
-			'address_label_blend_mode',
+		$this->add_shared_control(
+			'subheader',
 			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class() . '-header' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-				'condition' => [
-					'show_venue_address_header' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'address_header',
-			[
-				'label' => esc_html__( 'Address Text', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'address_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class()  => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'address_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class() ,
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'address_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class() ,
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'address_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class() ,
-			]
-		);
-
-		$this->add_control(
-			'address_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class()  => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
-			]
-		);
-
-		$this->add_control(
-			'address_venue_map_link_header',
-			[
+				'prefix'    => 'address_map_link',
 				'label'     => esc_html__( 'Map Link', 'the-events-calendar' ),
-				'type'      => Controls_Manager::HEADING,
 				'separator' => 'before',
 				'condition' => [
 					'show_venue_address_map_link' => 'yes',
@@ -1425,86 +946,19 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'address_venue_map_link_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap' => 'color: {{VALUE}};',
-				],
-				'condition' => [
-					'show_venue_address_map_link' => 'yes',
-				],
+				'prefix'   => 'address_map_link_typography',
+				'selector' => '{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'      => 'address_venue_map_link_typography',
-				'global'    => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap',
-				'condition' => [
-					'show_venue_address_map_link' => 'yes',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'      => 'address_venue_map_link_text_stroke',
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap',
-				'condition' => [
-					'show_venue_address_map_link' => 'yes',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'      => 'address_venue_map_link_text_shadow',
-				'selector'  => '{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap',
-				'condition' => [
-					'show_venue_address_map_link' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'address_venue_map_link_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link .tribe-events-gmap' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
-				'condition' => [
-					'show_venue_address_map_link' => 'yes',
-				],
+				'id'        => 'address_venue_map_link_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_address_base_class() . '-map-link',
 			]
 		);
 
@@ -1530,173 +984,54 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		$this->add_control(
-			'website_label_header',
+		$this->add_shared_control(
+			'subheader',
 			[
+				'prefix'    => 'website_header',
 				'label'     => esc_html__( 'Website Header', 'the-events-calendar' ),
-				'type'      => Controls_Manager::HEADING,
 				'condition' => [
 					'show_venue_website_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'website_label_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . '-header' => 'color: {{VALUE}};',
-				],
-				'condition' => [
-					'show_venue_website_header' => 'yes',
-				],
+				'prefix'   => 'website_label_typography',
+				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'      => 'website_label_typography',
-				'global'    => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector'  => '{{WRAPPER}} .' . $this->get_website_base_class() . '-header',
-				'condition' => [
-					'show_venue_website_header' => 'yes',
-				],
+				'id'        => 'website_label_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-header',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'subheader',
 			[
-				'name'      => 'website_label_text_stroke',
-				'selector'  => '{{WRAPPER}} .' . $this->get_website_base_class() . '-header',
-				'condition' => [
-					'show_venue_website_header' => 'yes',
-				],
+				'prefix' => 'website_url',
+				'label'  => esc_html__( 'Website Url', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'      => 'website_label_text_shadow',
-				'selector'  => '{{WRAPPER}} .' . $this->get_website_base_class() . '-header',
-				'condition' => [
-					'show_venue_website_header' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'website_label_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . '-header' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'after',
-				'condition' => [
-					'show_venue_website_header' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'venue_website_header',
-			[
-				'label' => esc_html__( 'Website Url', 'the-events-calendar' ),
-				'type'  => Controls_Manager::HEADING,
-			]
-		);
-
-		$this->add_control(
-			'website_color',
-			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . '-url a' => 'color: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
-			[
-				'name'     => 'website_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
+				'prefix'   => 'website_url',
 				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-url a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'website_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-url a',
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'website_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-url a',
-			]
-		);
-
-		$this->add_control(
-			'website_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_website_base_class() . '-url a' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'website_url_align',
+				'selectors' => '{{WRAPPER}} .' . $this->get_website_base_class() . '-url',
 			]
 		);
 
@@ -1714,9 +1049,9 @@ class Event_Venue extends Abstract_Widget {
 		$this->start_controls_section(
 			'styling_section_title',
 			[
-				'label'     => esc_html__( 'Venue Map', 'the-events-calendar' ),
-				'tab'       => Controls_Manager::TAB_STYLE,
-				'condition' => [
+				'label'       => esc_html__( 'Venue Map', 'the-events-calendar' ),
+				'tab'         => Controls_Manager::TAB_STYLE,
+				'conditional' => [
 					'show_venue_map' => 'yes',
 				],
 			]
@@ -1839,18 +1174,17 @@ class Event_Venue extends Abstract_Widget {
 			]
 		);
 
-		// phpcs:disable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		$this->add_group_control(
 			Group_Control_Box_Shadow::get_type(),
 			[
 				'name'     => 'venue_map_box_shadow',
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- This is not a query.
 				'exclude'  => [
 					'box_shadow_position',
 				],
 				'selector' => '{{WRAPPER}} .' . $this->get_map_base_class(),
 			]
 		);
-		// phpcs:enable WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 
 		$this->end_controls_section();
 	}

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Website.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Website.php
@@ -36,6 +36,15 @@ class Event_Website extends Abstract_Widget {
 	protected static string $slug = 'event_website';
 
 	/**
+	 * Whether the widget has styles to register/enqueue.
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	protected static bool $has_styles = true;
+
+	/**
 	 * Create the widget title.
 	 *
 	 * @since TBD

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Website.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Event_Website.php
@@ -10,11 +10,6 @@
 namespace TEC\Events\Integrations\Plugins\Elementor\Widgets;
 
 use Elementor\Controls_Manager;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
-use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
-use Elementor\Group_Control_Text_Shadow;
-use Elementor\Group_Control_Text_Stroke;
-use Elementor\Group_Control_Typography;
 use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
 
 /**
@@ -25,6 +20,7 @@ use TEC\Events\Integrations\Plugins\Elementor\Widgets\Contracts\Abstract_Widget;
  * @package TEC\Events\Integrations\Plugins\Elementor\Widgets
  */
 class Event_Website extends Abstract_Widget {
+	use Traits\With_Shared_Controls;
 
 	/**
 	 * Widget slug.
@@ -67,7 +63,7 @@ class Event_Website extends Abstract_Widget {
 		$event_id = $this->get_event_id();
 
 		// Only add filters if they are needed.
-		if ( $settings['link_target'] ) {
+		if ( $settings['website_link_target'] ) {
 			$this->set_template_filter(
 				'tribe_get_event_website_link_target',
 				[ $this, 'modify_link_target' ],
@@ -88,13 +84,13 @@ class Event_Website extends Abstract_Widget {
 		$website = tribe_get_event_website_link( $event_id );
 
 		return [
-			'align'        => $settings['align'] ?? '',
-			'show_heading' => $settings['show_heading'] ?? 'yes',
-			'header_tag'   => $settings['header_tag'] ?? 'h3',
-			'event_id'     => $event_id,
-			'label_class'  => $this->get_label_class(),
-			'link_class'   => $this->get_link_class(),
-			'website'      => $website,
+			'align'               => $settings['align'] ?? '',
+			'show_website_header' => $settings['show_website_header'] ?? 'yes',
+			'header_tag'          => $settings['header_tag'] ?? 'h3',
+			'event_id'            => $event_id,
+			'header_class'        => $this->get_header_class(),
+			'link_class'          => $this->get_link_class(),
+			'website'             => $website,
 		];
 	}
 
@@ -117,7 +113,7 @@ class Event_Website extends Abstract_Widget {
 		}
 
 		$settings        = $this->get_settings_for_display();
-		$target_override = $settings['link_target'];
+		$target_override = $settings['website_link_target'];
 
 		if ( ! $target_override ) {
 			return $link_target;
@@ -134,7 +130,7 @@ class Event_Website extends Abstract_Widget {
 	 * @param string $label   The link label.
 	 * @param int    $post_id The event ID.
 	 */
-	public function modify_link_label( $label, $post_id ) {
+	public function modify_link_label( $label, $post_id ): string {
 		$event_id = $this->get_event_id();
 		// Not the same event, bail.
 		if ( $event_id !== $post_id ) {
@@ -152,13 +148,36 @@ class Event_Website extends Abstract_Widget {
 	}
 
 	/**
+	 * Get the class used for the website link header.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_header_class(): string {
+		$class = $this->get_widget_class() . '-header';
+
+		/**
+		 * Filters the class used for the website header.
+		 *
+		 * @since TBD
+		 *
+		 * @param string          $class The class used for the website header .
+		 * @param Abstract_Widget $this  The widget instance.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'tec_events_pro_elementor_event_website_widget_header_class', $class, $this );
+	}
+
+	/**
 	 * Get the class used for the website link wrapper.
 	 *
 	 * @since TBD
 	 *
 	 * @return string
 	 */
-	public function get_link_class() {
+	public function get_link_class(): string {
 		$class = $this->get_widget_class() . '-link';
 
 		/**
@@ -171,30 +190,7 @@ class Event_Website extends Abstract_Widget {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'tec_events_elementor_event_website_widget_link_class', $class, $this );
-	}
-
-	/**
-	 * Get the class used for the website link label.
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function get_label_class() {
-		$class = $this->get_widget_class() . '-label';
-
-		/**
-		 * Filters the class used for the website link label.
-		 *
-		 * @since TBD
-		 *
-		 * @param string          $class The class used for the website link label.
-		 * @param Abstract_Widget $this  The widget instance.
-		 *
-		 * @return string
-		 */
-		return apply_filters( 'tec_events_elementor_event_website_widget_label_class', $class, $this );
+		return apply_filters( 'tec_events_pro_elementor_event_website_widget_link_class', $class, $this );
 	}
 
 	/**
@@ -202,7 +198,7 @@ class Event_Website extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function register_controls() {
+	protected function register_controls(): void {
 		// Content tab.
 		$this->content_panel();
 		// Style tab.
@@ -214,8 +210,9 @@ class Event_Website extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_panel() {
-		$this->content_options();
+	protected function content_panel(): void {
+		$this->header_options();
+		$this->link_options();
 	}
 
 	/**
@@ -223,10 +220,44 @@ class Event_Website extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function style_panel() {
+	protected function style_panel(): void {
+		$this->header_styling();
 		$this->link_styling();
+	}
 
-		$this->heading_styling();
+	/**
+	 * Add controls for the header content of the event website.
+	 *
+	 * @since TBD
+	 */
+	protected function header_options(): void {
+		$this->start_controls_section(
+			'header_section',
+			[
+				'label' => esc_html__( 'Header Content', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'show',
+			[
+				'id'    => 'show_website_header',
+				'label' => esc_html__( 'Show Header', 'the-events-calendar' ),
+			]
+		);
+
+		$this->add_shared_control(
+			'tag',
+			[
+				'id'        => 'header_tag',
+				'label'     => esc_html__( 'Header HTML Tag', 'the-events-calendar' ),
+				'condition' => [
+					'show_website_header' => 'yes',
+				],
+			]
+		);
+
+		$this->end_controls_section();
 	}
 
 	/**
@@ -234,91 +265,15 @@ class Event_Website extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function content_options() {
+	protected function link_options(): void {
 		$this->start_controls_section(
-			'section_title',
+			'link_section',
 			[
-				'label' => $this->get_title(),
+				'label' => esc_html__( 'Link Controls', 'the-events-calendar' ),
 			]
 		);
 
-		$this->add_responsive_control(
-			'align',
-			[
-				'label'     => esc_html__( 'Alignment', 'the-events-calendar' ),
-				'type'      => Controls_Manager::CHOOSE,
-				'options'   => [
-					'left'    => [
-						'title' => esc_html__( 'Left', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center'  => [
-						'title' => esc_html__( 'Center', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'   => [
-						'title' => esc_html__( 'Right', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-					'justify' => [
-						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
-						'icon'  => 'eicon-text-align-justify',
-					],
-				],
-				'default'   => '',
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'text-align: {{VALUE}};',
-				],
-			]
-		);
-
-		$this->add_control(
-			'show_heading',
-			[
-				'label'     => esc_html__( 'Show Heading', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SWITCHER,
-				'label_on'  => esc_html__( 'Show', 'the-events-calendar' ),
-				'label_off' => esc_html__( 'Hide', 'the-events-calendar' ),
-				'default'   => 'yes',
-			]
-		);
-
-		$this->add_control(
-			'header_tag',
-			[
-				'label'     => esc_html__( 'HTML Tag', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					'h1'   => 'H1',
-					'h2'   => 'H2',
-					'h3'   => 'H3',
-					'h4'   => 'H4',
-					'h5'   => 'H5',
-					'h6'   => 'H6',
-					'div'  => 'div',
-					'span' => 'span',
-					'p'    => 'p',
-				],
-				'default'   => 'h3',
-				'condition' => [
-					'show_heading' => 'yes',
-				],
-			]
-		);
-
-		$this->add_control(
-			'link_target',
-			[
-				'label'       => esc_html__( 'Link Target', 'the-events-calendar' ),
-				'description' => esc_html__( 'Choose whether to open the event website link in the same window or a new window.', 'the-events-calendar' ),
-				'type'        => Controls_Manager::SELECT,
-				'default'     => '_self',
-				'options'     => [
-					'_self'  => 'same window',
-					'_blank' => 'new window',
-				],
-			]
-		);
+		$this->add_shared_control( 'link_target', [ 'prefix' => 'website' ] );
 
 		$this->add_control(
 			'link_label',
@@ -334,87 +289,35 @@ class Event_Website extends Abstract_Widget {
 	}
 
 	/**
-	 * Add controls for text styling of the section heading.
+	 * Add controls for text styling of the section header.
 	 *
 	 * @since TBD
 	 */
-	protected function heading_styling() {
+	protected function header_styling(): void {
 		$this->start_controls_section(
-			'heading_section_title',
+			'header_styles_section',
 			[
-				'label'     => esc_html__( 'Section Heading', 'the-events-calendar' ),
+				'label'     => esc_html__( 'Header Styles', 'the-events-calendar' ),
 				'tab'       => Controls_Manager::TAB_STYLE,
 				'condition' => [
-					'show_heading' => 'yes',
+					'show_website_header' => 'yes',
 				],
 			]
 		);
 
-		$this->add_control(
-			'heading_color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_PRIMARY,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'header',
+				'selector' => '{{WRAPPER}} .' . $this->get_header_class(),
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'heading_typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
-			[
-				'name'     => 'heading_text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class() . '-link a',
-			]
-		);
-
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
-			[
-				'name'     => 'heading_text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class(),
-			]
-		);
-
-		$this->add_control(
-			'heading_blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'id'        => 'header_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_header_class() ],
 			]
 		);
 
@@ -426,80 +329,53 @@ class Event_Website extends Abstract_Widget {
 	 *
 	 * @since TBD
 	 */
-	protected function link_styling() {
+	protected function link_styling(): void {
 		$this->start_controls_section(
-			'website_section_title',
+			'link_styles_section',
 			[
-				'label' => $this->get_title(),
+				'label' => esc_html__( 'Link Styles', 'the-events-calendar' ),
 				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_control(
-			'color',
+		$this->add_shared_control(
+			'typography',
 			[
-				'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
-				'type'      => Controls_Manager::COLOR,
-				'global'    => [
-					'default' => Global_Colors::COLOR_TEXT,
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . '-link a' => 'color: {{VALUE}};',
-				],
+				'prefix'   => 'link',
+				'selector' => '{{WRAPPER}} .' . $this->get_link_class() . ' a',
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Typography::get_type(),
+		$this->add_shared_control(
+			'alignment',
 			[
-				'name'     => 'typography',
-				'global'   => [
-					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
-				],
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class() . '-link a',
+				'id'        => 'link_align',
+				'selectors' => [ '{{WRAPPER}} .' . $this->get_link_class() ],
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Stroke::get_type(),
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Add controls for text styling of the event website.
+	 *
+	 * @since TBD
+	 */
+	protected function link_hover_styling(): void {
+		$this->start_controls_section(
+			'link_hover_styles_section',
 			[
-				'name'     => 'text_stroke',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class() . '-link a',
+				'label' => esc_html__( 'Link Hover Styles', 'the-events-calendar' ),
+				'tab'   => Controls_Manager::TAB_STYLE,
 			]
 		);
 
-		$this->add_group_control(
-			Group_Control_Text_Shadow::get_type(),
+		$this->add_shared_control(
+			'typography',
 			[
-				'name'     => 'text_shadow',
-				'selector' => '{{WRAPPER}} .' . $this->get_widget_class() . '-link a',
-			]
-		);
-
-		$this->add_control(
-			'blend_mode',
-			[
-				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
-				'type'      => Controls_Manager::SELECT,
-				'options'   => [
-					''            => esc_html__( 'Normal', 'the-events-calendar' ),
-					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
-					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
-					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
-					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
-					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
-					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
-					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
-					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
-					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
-					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
-					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
-					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
-				],
-				'selectors' => [
-					'{{WRAPPER}} .' . $this->get_widget_class() . '-link a' => 'mix-blend-mode: {{VALUE}}',
-				],
-				'separator' => 'none',
+				'prefix'   => 'link_hover',
+				'selector' => '{{WRAPPER}} .' . $this->get_link_class() . ' a:hover',
 			]
 		);
 

--- a/src/Events/Integrations/Plugins/Elementor/Widgets/Traits/With_Shared_Controls.php
+++ b/src/Events/Integrations/Plugins/Elementor/Widgets/Traits/With_Shared_Controls.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Provides shared control methods for Elementor widgets using the TEC templating engine.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events\Integrations\Plugins\Elementor\Widgets\Traits;
+ */
+
+namespace TEC\Events\Integrations\Plugins\Elementor\Widgets\Traits;
+
+use Elementor\Controls_Manager;
+use Elementor\Group_Control_Text_Shadow;
+use Elementor\Group_Control_Text_Stroke;
+use Elementor\Group_Control_Typography;
+use WP_Error;
+
+/**
+ * Trait With_Shared_Controls
+ *
+ * @since   TBD
+ *
+ * @package TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Traits;
+ */
+trait With_Shared_Controls {
+	/**
+	 * Add a shared control.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $control The control to add.
+	 * @param array  $args    Additional arguments for the control.
+	 */
+	protected function add_shared_control( $control, $args = [] ): void {
+		call_user_func(
+			[ $this, $control ],
+			$args
+		);
+	}
+
+	/**
+	 * Add control for HTML tag.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Additional arguments for the control.
+	 *                    Requires:
+	 *                        - string id: The control ID.
+	 *                    Accepts:
+	 *                        - string label:    The label for the control.
+	 *                        - array options:   The alignment options.
+	 *                        - array condition: The conditions for showing the control.
+	 */
+	protected function tag( $args = [] ): void {
+		$check = $this->check_required_args( $args, 'id' );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+		$this->add_control(
+			$args['id'],
+			[
+				'label'     => $args['label'] ?? esc_html__( 'HTML Tag', 'the-events-calendar' ),
+				'type'      => Controls_Manager::SELECT,
+				'options'   => $args['options'] ?? [
+					'h1'   => 'H1',
+					'h2'   => 'H2',
+					'h3'   => 'H3',
+					'h4'   => 'H4',
+					'h5'   => 'H5',
+					'h6'   => 'H6',
+					'div'  => 'div',
+					'span' => 'span',
+					'p'    => 'p',
+				],
+				'default'   => $args['default'] ?? 'h3',
+				'condition' => $args['condition'] ?? [],
+			]
+		);
+	}
+
+	/**
+	 * Add a control for text alignment.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args      Additional arguments for the control.
+	 *                         Requires:
+	 *                             - string id: The control ID.
+	 *                             - array  selectors: The selectors to apply the alignment to.
+	 *                         Accepts:
+	 *                             - string label:    The label for the control.
+	 *                             - array  options:   The alignment options.
+	 *                             - string default:  The default alignment.
+	 *                             - array  condition: The conditions for showing the control.
+	 */
+	protected function alignment( $args = [] ): void {
+		$check = $this->check_required_args( $args, [ 'id', 'selectors' ] );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+		$updated = [];
+
+		foreach ( (array) $args['selectors'] as $selector ) {
+			$updated[ $selector ] = 'text-align: {{VALUE}};';
+		}
+		$this->add_responsive_control(
+			$args['id'],
+			[
+				'label'     => $args['label'] ?? esc_html__( 'Alignment', 'the-events-calendar' ),
+				'type'      => Controls_Manager::CHOOSE,
+				'options'   => $args['options'] ?? [
+					'left'    => [
+						'title' => esc_html__( 'Left', 'the-events-calendar' ),
+						'icon'  => 'eicon-text-align-left',
+					],
+					'center'  => [
+						'title' => esc_html__( 'Center', 'the-events-calendar' ),
+						'icon'  => 'eicon-text-align-center',
+					],
+					'right'   => [
+						'title' => esc_html__( 'Right', 'the-events-calendar' ),
+						'icon'  => 'eicon-text-align-right',
+					],
+					'justify' => [
+						'title' => esc_html__( 'Justified', 'the-events-calendar' ),
+						'icon'  => 'eicon-text-align-justify',
+					],
+				],
+				'default'   => $args['default'] ?? '',
+				'selectors' => (array) $updated,
+				'condition' => $args['condition'] ?? [],
+			]
+		);
+	}
+
+	/**
+	 * Add control for showing an element.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Additional arguments for the control.
+	 *                        Requires:
+	 *                            - string id: The control ID.
+	 *                        Accepts:
+	 *                            - string label:     The label for the control.
+	 *                            - string label_on:  The label for the "on" state. Defaults to "Show".
+	 *                            - string label_off: The label for the "off" state. Defaults to "Hide".
+	 *                            - string default:   The default state ("yes" or "no", defaults to "yes").
+	 */
+	protected function show( $args = [] ): void {
+		$check = $this->check_required_args( $args, 'id' );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+
+		$this->add_control(
+			$args['id'],
+			[
+				'label'     => $args['label'] ?? esc_html__( 'Show Element', 'the-events-calendar' ),
+				'type'      => Controls_Manager::SWITCHER,
+				'label_on'  => $args['label_on'] ?? esc_html__( 'Show', 'the-events-calendar' ),
+				'label_off' => $args['label_off'] ?? esc_html__( 'Hide', 'the-events-calendar' ),
+				'default'   => $args['default'] ?? 'yes',
+			]
+		);
+	}
+
+	/**
+	 * Add controls for text styling.
+	 * Includes text color, typography, text stroke, text shadow, and blend mode controls.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Additional arguments for the control.
+	 *                        Requires:
+	 *                            - string prefix: The control ID prefix.
+	 *                        Accepts:
+	 *                            - string selector  The CSS selector used for the controls. Defaults to "{{WRAPPER}}"
+	 *                            - string separator The separator for the controls.
+	 *                            - array global     The global typography settings.
+	 *                                                  Accepted values: 'primary', 'secondary', 'text', or 'accent'. Defaults to "primary'.
+	 */
+	protected function typography( $args = [] ) {
+		$check = $this->check_required_args( $args, 'prefix' );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+		$selector          = strval( $args['selector'] ?? '{{WRAPPER}}' );
+		$global_color      = empty( $args['global'] ) ? false : 'COLOR_' . strtoupper( $args['global'] ?? 'PRIMARY' );
+		$global_typography = empty( $args['global'] ) ? false : 'TYPOGRAPHY_' . strtoupper( $args['global'] ?? 'PRIMARY' );
+
+		$color_opts = [
+			'label'     => esc_html__( 'Text Color', 'the-events-calendar' ),
+			'type'      => Controls_Manager::COLOR,
+			'separator' => $args['separator'] ?? 'none',
+			'selectors' => [ $selector => 'color: {{VALUE}};' ],
+		];
+
+		if ( $global_color ) {
+			$color_opts['global'] = [
+				'default' => constant( 'Elementor\Core\Kits\Documents\Tabs\Global_Colors::' . $global_color ),
+			];
+		}
+
+
+		$this->add_control(
+			$args['prefix'] . '_color',
+			$color_opts
+		);
+
+		$typography_opts = [
+			'name'      => $args['prefix'] . '_typography',
+			'selector'  => $selector,
+			'separator' => $args['separator'] ?? 'none',
+		];
+
+		if ( $global_typography ) {
+			$typography_opts['global'] = [
+				'default' => constant( 'Elementor\Core\Kits\Documents\Tabs\Global_Typography::' . $global_typography ),
+			];
+		}
+
+		$this->add_group_control(
+			Group_Control_Typography::get_type(),
+			$typography_opts
+		);
+
+		$this->add_group_control(
+			Group_Control_Text_Stroke::get_type(),
+			[
+				'name'      => $args['prefix'] . '_text_stroke',
+				'selector'  => $selector,
+				'separator' => $args['separator'] ?? 'none',
+			]
+		);
+
+		$this->add_group_control(
+			Group_Control_Text_Shadow::get_type(),
+			[
+				'name'      => $args['prefix'] . 'text_shadow',
+				'selector'  => $selector,
+				'separator' => $args['separator'] ?? 'none',
+			]
+		);
+
+		$this->add_control(
+			$args['prefix'] . '_blend_mode',
+			[
+				'label'     => esc_html__( 'Blend Mode', 'the-events-calendar' ),
+				'type'      => Controls_Manager::SELECT,
+				'separator' => $args['separator'] ?? 'none',
+				'options'   => [
+					''            => esc_html__( 'Normal', 'the-events-calendar' ),
+					'multiply'    => esc_html__( 'Multiply', 'the-events-calendar' ),
+					'screen'      => esc_html__( 'Screen', 'the-events-calendar' ),
+					'overlay'     => esc_html__( 'Overlay', 'the-events-calendar' ),
+					'darken'      => esc_html__( 'Darken', 'the-events-calendar' ),
+					'lighten'     => esc_html__( 'Lighten', 'the-events-calendar' ),
+					'color-dodge' => esc_html__( 'Color Dodge', 'the-events-calendar' ),
+					'saturation'  => esc_html__( 'Saturation', 'the-events-calendar' ),
+					'color'       => esc_html__( 'Color', 'the-events-calendar' ),
+					'difference'  => esc_html__( 'Difference', 'the-events-calendar' ),
+					'exclusion'   => esc_html__( 'Exclusion', 'the-events-calendar' ),
+					'hue'         => esc_html__( 'Hue', 'the-events-calendar' ),
+					'luminosity'  => esc_html__( 'Luminosity', 'the-events-calendar' ),
+				],
+				'selectors' => [ '{{WRAPPER}} .' . $selector => 'mix-blend-mode: {{VALUE}};' ],
+				'condition' => $args['condition'] ?? '',
+			]
+		);
+	}
+
+	/**
+	 * Add control for link target.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Additional arguments for the control.
+	 *                        Requires:
+	 *                            - string prefix: The control ID prefix.
+	 *                        Accepts:
+	 *                            - string label       The label for the control.
+	 *                            - string description The description for the control.
+	 */
+	protected function link_target( $args = [] ): void {
+		$check = $this->check_required_args( $args, 'prefix' );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+		$this->add_control(
+			$args['prefix'] . '_link_target',
+			[
+				'label'       => $args['label'] ?? esc_html__( 'Link Target', 'the-events-calendar' ),
+				'description' => $args['description'] ?? esc_html__( 'Choose whether to open the link in the same window or a new window.', 'the-events-calendar' ),
+				'type'        => Controls_Manager::SELECT,
+				'default'     => '_self',
+				'options'     => [
+					'_self'  => 'same window',
+					'_blank' => 'new window',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Add control for phone number.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Additional arguments for the control.
+	 *                        Requires:
+	 *                            - string prefix: The control ID prefix.
+	 *                        Accepts:
+	 *                            - string label The label for the control.
+	 *                            - string separator The separator for the controls.
+	 *                            - array condition The conditions for showing the control.
+	 */
+	protected function subheader( $args = [] ) {
+		$check = $this->check_required_args( $args, 'prefix' );
+
+		if ( is_wp_error( $check ) ) {
+			echo esc_html( $check->get_error_message() );
+			return;
+		}
+
+		$this->add_control(
+			$args['prefix'] . '_title',
+			[
+				'label'     => $args['label'],
+				'type'      => Controls_Manager::HEADING,
+				'separator' => $args['separator'] ?? 'none',
+				'condition' => $args['condition'] ?? '',
+			]
+		);
+	}
+
+	/**
+	 * Allows above functions to check their required args and throw an error if they are missing.
+	 *
+	 * @since TBD
+	 *
+	 * @param array        $args     The arguments to check.
+	 * @param string|array $required The required arguments. Converted to an array.
+	 *
+	 * @return ?WP_Error         True if all required args are present, WP_Error if not.
+	 */
+	private function check_required_args( $args, $required ): ?WP_Error {
+		$required = (array) $required;
+		foreach ( $required as $req ) {
+			if ( ! isset( $args[ $req ] ) ) {
+				return new WP_Error(
+					'broke',
+					sprintf(
+						/* translators: %s: The missing argument */
+						__( 'Missing required argument: %s', 'the-events-calendar' ),
+						$req
+					)
+				);
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-categories.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-categories.pcss
@@ -5,13 +5,13 @@
  */
 
 .tec-events-elementor-event-widget__categories {
-	padding-bottom: var(--tec-spacer-5);
-
-	.tec-events-elementor-event-widget__categories-label {
-		padding-bottom: var(--tec-spacer-1);
-	}
 
 	.tec-events-elementor-event-widget__categories-link-wrapper a {
 		border-bottom-color: currentColor;
+		color: var(--tec-color-accent-primary);
+
+		&:hover {
+			color: var(--tec-color-accent-primary-hover);
+		}
 	}
 }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-export.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-export.pcss
@@ -64,7 +64,7 @@
 		font-family: var(--tec-font-family-sans-serif);
 		font-size: var(--tec-font-size-2);
 		font-weight: var(--tec-font-weight-regular);
-		line-height: var(----tec-line-height-2);
+		line-height: var--tec-line-height-2);
 		margin-bottom: var(--tec-spacer-0);
 		padding: var(--tec-spacer-0) var(--tec-spacer-4);
 		text-wrap: nowrap;
@@ -74,7 +74,7 @@
 		}
 
 		#tribe-events-pg-template & {
-			line-height: var(----tec-line-height-2);
+			line-height: var--tec-line-height-2);
 			margin-bottom: var(--tec-spacer-0);
 		}
 	}

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-image.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-image.pcss
@@ -1,0 +1,9 @@
+/**
+ * Elementor Event Datetime Widget styles.
+ *
+ * @since TBD
+ */
+
+ .tec-events-elementor-event-widget__image {
+
+ }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-organizer.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-organizer.pcss
@@ -7,17 +7,30 @@
 .tec-events-elementor-event-widget__organizer {
 	padding-bottom: var(--tec-spacer-2);
 
-	.tec-events-elementor-event-widget__organizer-phone-label,
-	.tec-events-elementor-event-widget__organizer-email-label,
-	.tec-events-elementor-event-widget__organizer-website-label {
-		padding-bottom: var(--tec-spacer-1);
+	.tec-events-elementor-event-widget__organizer-phone,
+	.tec-events-elementor-event-widget__organizer-email,
+	.tec-events-elementor-event-widget__organizer-website {
+
+		&-header {
+			margin: var(--tec-spacer-3) 0 var(--tec-spacer-0) 0;
+			padding: 0;
+		}
 	}
 
-	.tec-events-elementor-event-widget__organizer-website > a {
-		border-color: currentColor;
+	.tec-events-elementor-event-widget__organizer-website {
+		> a {
+			border-color: currentColor;
+			color: var(--tec-color-accent-primary);
+
+			&:hover {
+				color: var(--tec-color-accent-primary-hover);
+			}
+		}
 	}
 
-	.tec-events-elementor-event-widget__organizer-name-link {
+	.tec-events-elementor-event-widget__organizer-name-link,
+	.tec-events-elementor-event-widget__organizer-email-link,
+	.tec-events-elementor-event-widget__organizer-phone-link {
 		border-color: currentColor;
 	}
 }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-tags.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-tags.pcss
@@ -5,13 +5,13 @@
  */
 
 .tec-events-elementor-event-widget__tags {
-	padding-bottom: var(--tec-spacer-5);
-
-	.tec-events-elementor-event-widget__tags-label {
-		padding-bottom: var(--tec-spacer-1);
-	}
 
 	.tec-events-elementor-event-widget__tags-link {
 		border-bottom-color: currentColor;
+		color: var(--tec-color-accent-primary);
+
+		&:hover {
+			color: var(--tec-color-accent-primary-hover);
+		}
 	}
 }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-title.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-title.pcss
@@ -1,0 +1,14 @@
+/**
+ * Elementor Event Datetime Widget styles.
+ *
+ * @since TBD
+ */
+
+.tec-events-elementor-event-widget__title {
+	color: var(--tec-color-text-event-title);
+	font-size: 1.7em;
+	font-weight: var(--tec-font-weight-bold);
+	line-height: 1;
+	margin: 0;
+	padding: 0;
+}

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-venue.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-venue.pcss
@@ -11,19 +11,25 @@
 
 .tec-events-elementor-event-widget__venue-container,
 .tribe-events-content .tec-events-elementor-event-widget__venue-container {
+	border: 1px solid var(--tec-color-border-secondary);
+	border-radius: var(--tec-border-radius-default);
 	display: flex;
+	flex-direction: column;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin-bottom: var(--tec-spacer-6);
+	max-width: 580px;
+	padding: var(--tec-spacer-5);
 
-	@media only screen and (max-width: 767px) {
-		flex-direction: column;
+	@media only screen and (min-width: 767px) {
+		flex-direction: row;
 	}
 
 	.tec-events-elementor-event-widget__venue-details {
 		box-sizing: border-box;
 		flex: 1;
-		min-width: 50%;
+		flex-basis: 50%;
+		font-size: var(--tec-font-size-2);
 		padding: 10px;
 
 		p {
@@ -47,23 +53,49 @@
 		margin: var(--tec-spacer-1) 0;
 	}
 
+	,
+	.tec-events-elementor-event-widget__venue-email-link,
+	.tec-events-elementor-event-widget__venue-phone-link {
+		border-color: currentColor;
+	}
+
 	.tec-events-elementor-event-widget__venue-address-map-link > a {
 		border-color: currentColor;
+		color: var(--tec-color-accent-primary);
+
+		&:hover {
+			color: var(--tec-color-accent-primary-hover);
+		}
 	}
 
 	.tec-events-elementor-event-widget__venue-website-url > a {
 		border-color: currentColor;
+		color: var(--tec-color-accent-primary);
+
+		&:hover {
+			color: var(--tec-color-accent-primary-hover);
+		}
 	}
 
 	.tec-events-elementor-event-widget__venue-name-header {
 		padding-bottom: var(--tec-spacer-2);
 	}
 
+	.tec-events-elementor-event-widget__venue-name {
+		font-size: var(--tec-font-size-4);
+	}
+
 	.tec-events-elementor-event-widget__venue-name-link {
 		border-color: currentColor;
+		font-size: inherit;
 	}
 
 	.tec-events-elementor-event-widget__venue-phone-header .tec-events-elementor-event-widget__venue-phone {
 		padding: 0;
+	}
+
+	.tec-events-elementor-event-widget__venue-map {
+		flex: 1;
+		flex-basis: 50%;
 	}
 }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/event-website.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/event-website.pcss
@@ -7,11 +7,11 @@
 .tec-events-elementor-event-widget__website {
 	.tec-events-elementor-event-widget__website-link > a {
 		border-color: currentColor;
-		color: var(--tec-color-text-primary);
+		color: var(--tec-color-accent-primary);
 		font-weight: var(--tec-font-weight-regular);
 
 		&:hover {
-			color: var(--tec-color-accent-primary);
+			color: var(--tec-color-accent-primary-hover);
 		}
 	}
 }

--- a/src/resources/postcss/integrations/plugins/elementor/widgets/widget-base.pcss
+++ b/src/resources/postcss/integrations/plugins/elementor/widgets/widget-base.pcss
@@ -1,0 +1,28 @@
+/**
+ * Elementor Event Widget base styles.
+ *
+ * @since TBD
+ */
+
+[class*="tec-events-elementor-event-widget"] {
+	color: var(--tec-color-text-primary);
+	font-family: var(--tec-font-family-sans-serif);
+	font-size: 1rem;
+	font-weight: var(--tec-font-weight-regular);
+	line-height: var(--tec-line-height-3);
+	margin: 0 0 var(--tec-spacer-0) 0;
+	padding: 0;
+}
+
+a[class*="tec-events-elementor-event-widget"],
+[class*="tec-events-elementor-event-widget"] a {
+	border-bottom-color: currentColor;
+	text-decoration: underline;
+}
+
+.e-con-inner,
+.elementor-section:not(.elementor-top-section) {
+	[class*="elementor-widget-tec_elementor_widget"]:not(:last-child) {
+		margin-block-end: var(--tec-spacer-3);
+	}
+}

--- a/src/views/integrations/elementor/widgets/event-categories.php
+++ b/src/views/integrations/elementor/widgets/event-categories.php
@@ -7,15 +7,16 @@
  *
  * @since TBD
  *
- * @var bool             $show_heading Whether to show the heading.
+ * @var bool             $show_header Whether to show the header.
  * @var array            $categories   The event categories.
- * @var string           $heading_tag  The HTML tag to use for the heading.
+ * @var string           $header_tag   The HTML tag to use for the header.
+ * @var string           $header_text  The header text.
  * @var array            $settings     The widget settings.
  * @var int              $event_id     The event ID.
  * @var Event_Categories $widget       The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Categories;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Categories;
 
 if ( empty( $categories ) ) {
 	return;
@@ -27,13 +28,7 @@ if ( empty( $categories ) ) {
 	<?php
 	$this->template(
 		'views/integrations/elementor/widgets/event-categories/header',
-		[
-			'show'        => $show_heading,
-			'heading_tag' => $heading_tag,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
+		[ 'show' => $show_header ]
 	);
 	?>
 	<div <?php tribe_classes( $widget->get_wrapper_class() ); ?>>

--- a/src/views/integrations/elementor/widgets/event-categories/header.php
+++ b/src/views/integrations/elementor/widgets/event-categories/header.php
@@ -7,11 +7,12 @@
  *
  * @since TBD
  *
- * @var bool   $show         Whether to show the heading.
- * @var string $heading_tag  The HTML tag to use for the heading.
+ * @var bool   $show         Whether to show the header.
+ * @var string $header_tag   The HTML tag to use for the header.
+ * @var string $header_text  The header text.
  * @var array  $settings     The widget settings.
  * @var int    $event_id     The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Categories $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Categories $widget The widget instance.
  */
 
 if ( ! $show ) {
@@ -19,4 +20,4 @@ if ( ! $show ) {
 }
 ?>
 
-<<?php echo tag_escape( $heading_tag ); ?> <?php tribe_classes( $widget->get_label_class() ); ?>><?php echo esc_html( $widget->get_label_text() ); ?></<?php echo tag_escape( $heading_tag ); ?>>
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>><?php echo esc_html( $header_text ); ?></<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-cost.php
+++ b/src/views/integrations/elementor/widgets/event-cost.php
@@ -7,18 +7,24 @@
  *
  * @since TBD
  *
- * @var string     $header_tag The HTML tag for the event cost.
+ * @var string     $html_tag The HTML tag for the event cost.
  * @var int        $event_id   The event ID.
  * @var string     $cost       The event cost.
  * @var Event_Cost $widget     The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Cost;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Cost;
 
 if ( empty( $cost ) ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $header_tag ); ?><?php tribe_classes( $widget->get_element_classes() ); ?>>
+<?php
+$this->template(
+	'views/integrations/elementor/widgets/event-cost/header',
+	[ 'show' => $show_header ]
+);
+?>
+<<?php echo tag_escape( $html_tag ); ?><?php tribe_classes( $widget->get_element_classes() ); ?>>
 <?php echo esc_html( $cost ); ?>
-</<?php echo tag_escape( $header_tag ); ?>>
+</<?php echo tag_escape( $html_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-cost/header.php
+++ b/src/views/integrations/elementor/widgets/event-cost/header.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * View: Elementor Event Cost widget header.
+ *
+ * You can override this template in your own theme by creating a file at
+ * [your-theme]/tribe/events/integrations/elementor/widgets/event-cost/header.php
+ *
+ * @since TBD
+ *
+ * @var bool   $show         Whether to show the header.
+ * @var array  $settings     The widget settings.
+ * @var int    $event_id     The event ID.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Cost $widget The widget instance.
+ */
+
+if ( ! $show ) {
+	return;
+}
+?>
+<<?php echo tag_escape( $widget->get_header_tag() ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>>
+	<?php echo esc_html( $widget->get_header_text() ); ?>
+</<?php echo tag_escape( $widget->get_header_tag() ); ?>>

--- a/src/views/integrations/elementor/widgets/event-datetime.php
+++ b/src/views/integrations/elementor/widgets/event-datetime.php
@@ -3,12 +3,13 @@
  * View: Elementor Event Datetime widget.
  *
  * You can override this template in your own theme by creating a file at
- * [your-theme]/tribe/events/integrations/elementor/widgets/event-datetime.php
+ * [your-theme]/tribe/events-pro/integrations/elementor/widgets/event-datetime.php
  *
  * @since TBD
  *
  * @var Template_Engine $this              The template engine.
- * @var string          $html_tag          The HTML tag for the widget.
+ * @var bool            $show_header       Whether to show the header.
+ * @var string          $html_tag          The HTML tag for the date content.
  * @var bool            $show_date         Whether to show the date.
  * @var bool            $show_time         Whether to show the time.
  * @var bool            $show_year         Whether to show the year.
@@ -20,16 +21,23 @@
  * @var bool            $is_all_day        Whether the event is all day on a single day.
  * @var bool            $is_same_start_end Whether the start and end date and time are the same.
  *
- * @var Event_Datetime  $widget            The widget instance.
+ * @var Event_Datetime  $this-            The widget instance.
  */
 
 use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Datetime;
 use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Template_Engine;
 
-if ( ! $this->has_event() ) {
+if ( ! $this->has_event() || ! $show ) {
 	return;
 }
 
+$widget = $this->get_widget();
+?>
+<?php
+$this->template(
+	'views/integrations/elementor/widgets/event-datetime/header',
+	[ 'show' => $show_header ]
+);
 ?>
 <<?php echo tag_escape( $html_tag ); ?> <?php tribe_classes( $widget->get_widget_class() ); ?>>
 <?php if ( $show_date && $start_date ) : ?>
@@ -42,7 +50,7 @@ if ( ! $this->has_event() ) {
 	<span <?php tribe_classes( $widget->get_time_class(), $widget->get_start_time_class() ); ?>><?php echo esc_html( $start_time ); ?></span>
 <?php endif; ?>
 <?php if ( $is_all_day ) : ?>
-	<span <?php tribe_classes( $widget->get_all_day_class() ); ?>><?php esc_html_e( 'All day', 'tribe-events-calendar-pro' ); ?></span>
+	<span <?php tribe_classes( $widget->get_all_day_class() ); ?>><?php esc_html_e( 'All day', 'the-events-calendar' ); ?></span>
 <?php endif; ?>
 <?php if ( ! $is_same_start_end && ( $show_date || $show_time ) ) : ?>
 	<?php if ( $show_date && $show_time ) : ?>

--- a/src/views/integrations/elementor/widgets/event-datetime/header.php
+++ b/src/views/integrations/elementor/widgets/event-datetime/header.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * View: Elementor Event Datetime widget header.
+ *
+ * You can override this template in your own theme by creating a file at
+ * [your-theme]/tribe/events/integrations/elementor/widgets/event-datetime/header.php
+ *
+ * @since TBD
+ *
+ * @var bool   $show         Whether to show the header.
+ * @var array  $settings     The widget settings.
+ * @var int    $event_id     The event ID.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Datetime $widget The widget instance.
+ */
+
+if ( ! $show ) {
+	return;
+}
+
+$widget = $this->get_widget();
+?>
+<<?php echo tag_escape( $widget->get_header_tag() ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>>
+	<?php echo esc_html( $widget->get_header_text() ); ?>
+</<?php echo tag_escape( $widget->get_header_tag() ); ?>>

--- a/src/views/integrations/elementor/widgets/event-description.php
+++ b/src/views/integrations/elementor/widgets/event-description.php
@@ -13,7 +13,7 @@
  * @var Event_Description $widget   The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Description;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Description;
 
 // No content, no render.
 if ( empty( $content ) ) {

--- a/src/views/integrations/elementor/widgets/event-export.php
+++ b/src/views/integrations/elementor/widgets/event-export.php
@@ -39,7 +39,7 @@ $ical         ??= null;
 $outlook_365  ??= null;
 $outlook_live ??= null;
 
-// Ensure we dont get notices.
+// Ensure we don't get notices.
 $show_gcal_link         ??= false;
 $show_ical_link         ??= false;
 $show_outlook_365_link  ??= false;

--- a/src/views/integrations/elementor/widgets/event-export/button.php
+++ b/src/views/integrations/elementor/widgets/event-export/button.php
@@ -22,7 +22,7 @@ use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Export;
 	<?php tribe_classes( $widget->get_button_class(), 'tribe-common-c-btn-border', 'tribe-events-c-subscribe-dropdown__button' ); ?>
 	aria-expanded="false"
 	aria-controls="<?php $widget->get_content_class(); ?>"
-	aria-label="<?php esc_attr_e( 'View links to add events to your calendar', 'tribe-events-calendar-pro' ); ?>"
+	aria-label="<?php esc_attr_e( 'View links to add events to your calendar', 'the-events-calendar' ); ?>"
 >
 	<i
 		<?php
@@ -37,7 +37,7 @@ use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Export;
 		?>
 		aria-hidden="true"
 	></i>
-	<?php esc_html_e( 'Add to calendar', 'tribe-events-calendar-pro' ); ?>
+	<?php esc_html_e( 'Add to calendar', 'the-events-calendar' ); ?>
 	<svg
 		<?php tribe_classes( $widget->get_dropdown_icon_class() ); ?>
 		width="12"

--- a/src/views/integrations/elementor/widgets/event-image.php
+++ b/src/views/integrations/elementor/widgets/event-image.php
@@ -12,7 +12,7 @@
  * @var Event_Image $widget   The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Image;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Image;
 
 if ( ! $image ) {
 

--- a/src/views/integrations/elementor/widgets/event-navigation.php
+++ b/src/views/integrations/elementor/widgets/event-navigation.php
@@ -19,55 +19,32 @@
  * @var Event_Navigation $widget     The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Navigation;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Navigation;
 
 // Bail if both links empty.
 if ( empty( $prev_link ) && empty( $next_link ) ) {
 	return;
 }
-// Bail if both events empty.
 
+// Bail if both events empty.
 if ( empty( $prev_event ) && empty( $next_event ) ) {
 	return;
 }
 
 ?>
-<nav <?php tribe_classes( $widget->get_widget_class() ); ?>>
-	<?php if ( ! empty( $label ) ) : ?>
+<nav <?php tribe_classes( $widget->get_widget_class() ); ?> aria-label="<?php echo esc_attr( tribe_get_event_label_plural() ); ?>">
+	<?php if ( ! empty( $header_text ) ) : ?>
 		<?php
-		$this->template(
-			'integrations/elementor/widgets/event-navigation/header',
-			[
-				'label'      => $label,
-				'header_tag' => $header_tag,
-				'widget'     => $widget,
-			]
-		);
+		$this->template( 'integrations/elementor/widgets/event-navigation/header' );
 		?>
 	<?php endif; ?>
 	<ul <?php tribe_classes( $widget->get_list_class() ); ?>>
 		<?php
-		$this->template(
-			'integrations/elementor/widgets/event-navigation/previous',
-			[
-				'prev_link'  => $prev_link,
-				'prev_event' => $prev_event,
-				'event_id'   => $event_id,
-				'widget'     => $widget,
-			]
-		);
+		$this->template( 'integrations/elementor/widgets/event-navigation/previous' );
 		?>
 
 		<?php
-		$this->template(
-			'integrations/elementor/widgets/event-navigation/next',
-			[
-				'next_link'  => $next_link,
-				'next_event' => $next_event,
-				'event_id'   => $event_id,
-				'widget'     => $widget,
-			]
-		);
+		$this->template( 'integrations/elementor/widgets/event-navigation/next' );
 		?>
 	</ul>
 </nav>

--- a/src/views/integrations/elementor/widgets/event-navigation/header.php
+++ b/src/views/integrations/elementor/widgets/event-navigation/header.php
@@ -7,13 +7,18 @@
  *
  * @since TBD
  *
- * @var string $header_tag The HTML tag for the event title.
- * @var string $label      The label for the event navigation.
- * @var int    $event_id   The event ID.
+ * @var bool   $show_nav_header Whether to visually show/hide the event navigation header.
+ * @var string $header_tag      The HTML tag for the event title.
+ * @var string $header_text     The header_text for the event navigation.
+ * @var int    $event_id        The event ID.
  * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Navigation $widget The widget instance.
  */
 
+if ( ! $show_nav_header ) {
+	return;
+}
+
 ?>
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_classes() ); ?>>
-	<?php echo esc_html( $label ); ?>
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_class(), $class ); ?>>
+	<?php echo esc_html( $header_text ); ?>
 </<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-organizer.php
+++ b/src/views/integrations/elementor/widgets/event-organizer.php
@@ -7,7 +7,7 @@
  *
  * @since TBD
  *
- * @var bool            $show_header         Whether to show the organizer heading.
+ * @var bool            $show_header         Whether to show the organizer header.
  * @var bool            $link_name           Whether to link the organizer name.
  * @var bool            $show_name           Whether to show the organizer name.
  * @var bool            $show_phone          Whether to show the organizer phone.
@@ -18,6 +18,7 @@
  * @var bool            $show_website_header Whether to show the organizer website header.
  * @var bool            $multiple            If there are multiple organizers.
  * @var string          $header_tag          The widget header tag.
+ * @var string          $organizer_name_tag  The widget header text.
  * @var string          $phone_header_tag    The phone header tag.
  * @var string          $email_header_tag    The email header tag.
  * @var string          $email_header_text   The text for the email header.
@@ -30,7 +31,7 @@
  * @var Event_Organizer $widget              The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Organizer;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Organizer;
 
 // No organizers, no render.
 if ( empty( $organizer_ids ) ) {
@@ -39,51 +40,18 @@ if ( empty( $organizer_ids ) ) {
 ?>
 <div <?php tribe_classes( $widget->get_container_classes() ); ?>>
 	<?php
-	$this->template(
-		'views/integrations/elementor/widgets/event-organizer/header',
-		[
-			'show'       => $show_header,
-			'header_tag' => $header_tag,
-			'multiple'   => $multiple,
-			'settings'   => $settings,
-			'event_id'   => $event_id,
-			'widget'     => $widget,
-		]
-	);
+	$this->template( 'views/integrations/elementor/widgets/event-organizer/header' );
 
 	foreach ( $organizer_ids as $organizer ) {
 		$this->template(
 			'views/integrations/elementor/widgets/event-organizer/names',
-			[
-				'link'      => $link_name,
-				'show'      => $show_name,
-				'organizer' => $organizer,
-				'multiple'  => $multiple,
-				'settings'  => $settings,
-				'event_id'  => $event_id,
-				'widget'    => $widget,
-			]
+			[ 'organizer' => $organizer ]
 		);
 	}
 
 	$this->template(
 		'views/integrations/elementor/widgets/event-organizer/details',
-		[
-			'organizer'           => $organizer,
-			'show_phone'          => $show_phone,
-			'show_email'          => $show_email,
-			'show_website'        => $show_website,
-			'show_phone_header'   => $show_phone_header,
-			'show_email_header'   => $show_email_header,
-			'show_website_header' => $show_website_header,
-			'phone_header_tag'    => $phone_header_tag,
-			'email_header_tag'    => $email_header_tag,
-			'website_header_tag'  => $website_header_tag,
-			'multiple'            => $multiple,
-			'settings'            => $settings,
-			'event_id'            => $event_id,
-			'widget'              => $widget,
-		]
+		[ 'organizer' => $organizer ]
 	);
 	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-organizer/details.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details.php
@@ -26,12 +26,8 @@
  * @var array  $organizer_ids The organizer IDs.
  * @var int    $event_id The event ID.
  * @var array  $settings The widget settings.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
-
-if ( ! $show ) {
-	return;
-}
 
 // Only show organizer details if there's just one.
 if ( $multiple ) {
@@ -40,46 +36,10 @@ if ( $multiple ) {
 ?>
 <div <?php tribe_classes( $widget->get_widget_class() . '-details' ); ?>>
 	<?php
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/phone',
-		[
-			'show'        => $show_phone,
-			'show_header' => $show_phone_header,
-			'header_tag'  => $phone_header_tag,
-			'header_text' => $phone_header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/phone' );
 
-	$this->template(
-		'views/integrations/elementor/widgets/event-organizer/details/email',
-		[
-			'show'        => $show_email,
-			'show_header' => $show_email_header,
-			'header_tag'  => $email_header_tag,
-			'header_text' => $email_header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'views/integrations/elementor/widgets/event-organizer/details/website' );
 
-	$this->template(
-		'views/integrations/elementor/widgets/event-organizer/details/website',
-		[
-			'show'        => $show_website,
-			'show_header' => $show_website_header,
-			'header_tag'  => $website_header_tag,
-			'header_text' => $website_header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'views/integrations/elementor/widgets/event-organizer/details/email' );
 	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/email.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/email.php
@@ -8,41 +8,22 @@
  * @since TBD
  *
  * @var bool   $show        Whether to show the organizer email.
- * @var bool   $show_header Whether to show the organizer email heading.
+ * @var bool   $show_header Whether to show the organizer email header.
  * @var string $header_tag  The organizer email header tag.
  * @var int    $organizer   The organizer ID.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_email ) {
 	return;
 }
 ?>
-<div <?php tribe_classes( $widget->get_email_base_class() ); ?>>
+<div <?php tribe_classes( $widget->get_email_wrapper_class() ); ?>>
 	<?php
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/email/header',
-		[
-			'show'        => $show_header,
-			'header_tag'  => $header_tag,
-			'header_text' => $header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/email/header' );
 
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/email/content',
-		[
-			'organizer' => $organizer,
-			'settings'  => $settings,
-			'event_id'  => $event_id,
-			'widget'    => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/email/content' );
 	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/email/content.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/email/content.php
@@ -13,5 +13,15 @@
  * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
+$email = tribe_get_organizer_email( $organizer );
 ?>
-<p <?php tribe_classes( $widget->get_email_base_class() ); ?>><?php echo esc_html( tribe_get_organizer_email( $organizer, false ) ); ?></p>
+<p <?php tribe_classes( $widget->get_email_base_class() ); ?>>
+	<?php if ( $link_organizer_email ) : ?>
+		<?php // For a dial link we remove spaces, and replace 'ext' or 'x' with 'p' to pause before dialing the extension. ?>
+		<a <?php tribe_classes( $widget->get_email_base_class() . '-link' ); ?> href="<?php echo esc_url( 'mailto:' . $email ); ?>">
+	<?php endif; ?>
+		<?php echo esc_html( $email ); ?>
+	<?php if ( $link_organizer_email ) : ?>
+		</a>
+	<?php endif; ?>
+</p>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/email/header.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/email/header.php
@@ -7,18 +7,18 @@
  *
  * @since TBD
  *
- * @var bool   $show        Whether to show the organizer email heading.
- * @var string $header_tag  The HTML tag to use for the heading.
+ * @var bool   $show        Whether to show the organizer email header.
+ * @var string $header_tag  The HTML tag to use for the header.
  * @var string $header_text The header text.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_email_header ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_email_label_class() ); ?>>
-	<?php echo wp_kses_post( $header_text ); ?>
-</<?php echo tag_escape( $header_tag ); ?>>
+<<?php echo tag_escape( $organizer_email_header_tag ); ?> <?php tribe_classes( $widget->get_email_header_class() ); ?>>
+	<?php echo wp_kses_post( $organizer_email_header_text ); ?>
+</<?php echo tag_escape( $organizer_email_header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/phone.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/phone.php
@@ -8,41 +8,22 @@
  * @since TBD
  *
  * @var bool   $show        Whether to show the organizer phone.
- * @var bool   $show_header Whether to show the organizer phone heading.
+ * @var bool   $show_header Whether to show the organizer phone header.
  * @var string $header_tag  The organizer phone header tag.
  * @var int    $organizer   The organizer ID.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_phone ) {
 	return;
 }
 ?>
-<div <?php tribe_classes( $widget->get_phone_base_class() ); ?>>
+<div <?php tribe_classes( $widget->get_phone_wrapper_class() ); ?>>
 	<?php
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/phone/header',
-		[
-			'show'        => $show_header,
-			'header_tag'  => $header_tag,
-			'header_text' => $header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/phone/header' );
 
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/phone/content',
-		[
-			'organizer' => $organizer,
-			'settings'  => $settings,
-			'event_id'  => $event_id,
-			'widget'    => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/phone/content' );
 	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/phone/content.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/phone/content.php
@@ -13,5 +13,15 @@
  * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
+$phone = tribe_get_organizer_phone( $organizer );
 ?>
-<p <?php tribe_classes( $widget->get_phone_base_class() ); ?>><?php echo esc_html( tribe_get_organizer_phone( $organizer ) ); ?></p>
+<p <?php tribe_classes( $widget->get_phone_base_class() ); ?>>
+	<?php if ( $link_organizer_phone ) : ?>
+		<?php // For a dial link we remove spaces, and replace 'ext' or 'x' with 'p' to pause before dialing the extension. ?>
+		<a <?php tribe_classes( $widget->get_phone_base_class() . '-link' ); ?> href="<?php echo esc_url( 'tel:' . str_ireplace( [ 'ext', 'x', ' ' ], [ 'p', 'p', '' ], $phone ) ); ?>">
+	<?php endif; ?>
+		<?php echo esc_html( $phone ); ?>
+	<?php if ( $link_organizer_phone ) : ?>
+		</a>
+	<?php endif; ?>
+</p>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/phone/header.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/phone/header.php
@@ -7,20 +7,20 @@
  *
  * @since TBD
  *
- * @var bool   $show        Whether to show the organizer phone heading.
- * @var string $header_tag  The HTML tag to use for the heading.
+ * @var bool   $show        Whether to show the organizer phone header.
+ * @var string $header_tag  The HTML tag to use for the header.
  * @var string $header_text The header text.
  * @var array  $organizer   The organizer ID.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_phone_header ) {
 	return;
 }
 ?>
 
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_phone_label_class() ); ?>>
-	<?php echo wp_kses_post( $header_text ); ?>
-</<?php echo tag_escape( $header_tag ); ?>>
+<<?php echo tag_escape( $organizer_phone_header_tag ); ?> <?php tribe_classes( $widget->get_phone_header_class() ); ?>>
+	<?php echo wp_kses_post( $organizer_phone_header_text ); ?>
+</<?php echo tag_escape( $organizer_phone_header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/website.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/website.php
@@ -8,44 +8,25 @@
  * @since TBD
  *
  * @var bool   $show        Whether to show the organizer website.
- * @var bool   $show_header Whether to show the organizer website heading.
+ * @var bool   $show_header Whether to show the organizer website header.
  * @var string $header_tag  The organizer website header tag.
  * @var string $header_text The organizer website header text.
  * @var string $website     The organizer website.
  * @var int    $organizer   The organizer ID.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_website ) {
 	return;
 }
 
 ?>
-<div <?php tribe_classes( $widget->get_website_base_class() ); ?>>
+<div <?php tribe_classes( $widget->get_website_wrapper_class() ); ?>>
 	<?php
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/website/header',
-		[
-			'show'        => $show_header,
-			'header_tag'  => $header_tag,
-			'header_text' => $header_text,
-			'organizer'   => $organizer,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/website/header' );
 
-	$this->template(
-		'integrations/elementor/widgets/event-organizer/details/website/content',
-		[
-			'organizer' => $organizer,
-			'settings'  => $settings,
-			'event_id'  => $event_id,
-			'widget'    => $widget,
-		]
-	);
+	$this->template( 'integrations/elementor/widgets/event-organizer/details/website/content' );
 	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-organizer/details/website/header.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/details/website/header.php
@@ -7,20 +7,20 @@
  *
  * @since TBD
  *
- * @var bool   $show        Whether to show the organizer website heading.
- * @var string $header_tag  The HTML tag to use for the heading.
+ * @var bool   $show        Whether to show the organizer website header.
+ * @var string $header_tag  The HTML tag to use for the header.
  * @var string $header_text The header text.
  * @var array  $organizer   The organizer ID.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_website_header ) {
 	return;
 }
 ?>
 
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_website_label_class() ); ?>>
-	<?php echo wp_kses_post( $header_text ); ?>
-</<?php echo tag_escape( $header_tag ); ?>>
+<<?php echo tag_escape( $organizer_website_header_tag ); ?> <?php tribe_classes( $widget->get_website_header_class() ); ?>>
+	<?php echo wp_kses_post( $organizer_website_header_text ); ?>
+</<?php echo tag_escape( $organizer_website_header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-organizer/header.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/header.php
@@ -7,17 +7,17 @@
  *
  * @since TBD
  *
- * @var bool  $show          Whether to show the organizer heading.
+ * @var bool  $show          Whether to show the organizer header.
  * @var bool  $multiple      Whether there are multiple organizers.
  * @var array $settings      The widget settings.
  * @var int   $event_id      The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_header ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_widget_header_classes() ); ?>>
+<<?php echo tag_escape( $organizer_header_tag ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>>
 	<?php echo esc_html( tribe_get_organizer_label( ! $multiple ) ); ?>
-</<?php echo tag_escape( $header_tag ); ?>>
+</<?php echo tag_escape( $organizer_header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-organizer/names.php
+++ b/src/views/integrations/elementor/widgets/event-organizer/names.php
@@ -8,15 +8,15 @@
  * @since TBD
  *
  * @var bool   $show          Whether to show the organizer names.
- * @var bool   $link          Whether to link the organizer name.
+ * @var bool   $link_name     Whether to link the organizer name.
  * @var bool   $multiple      Whether there are multiple organizers.
  * @var string $organizer     The organizer ID.
  * @var array  $settings      The widget settings.
  * @var int    $event_id      The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Organizer $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_organizer_name ) {
 	return;
 }
 
@@ -24,12 +24,12 @@ if ( empty( $organizer ) ) {
 	return;
 }
 ?>
-<h4 <?php tribe_classes( $widget->get_name_base_class() ); ?>>
-	<?php if ( $link ) : ?>
+<<?php echo tag_escape( $organizer_name_tag ); ?> <?php tribe_classes( $widget->get_name_base_class() ); ?>>
+	<?php if ( $link_organizer_name ) : ?>
 		<a <?php tribe_classes( $widget->get_name_base_class() . '-link' ); ?> href="<?php echo esc_url( tribe_get_organizer_link( $organizer, false ) ); ?>">
 	<?php endif; ?>
 		<?php echo esc_html( tribe_get_organizer( $organizer ) ); ?>
-	<?php if ( $link ) : ?>
+	<?php if ( $link_organizer_name ) : ?>
 		</a>
 	<?php endif; ?>
-</h4>
+</<?php echo tag_escape( $organizer_name_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-tags.php
+++ b/src/views/integrations/elementor/widgets/event-tags.php
@@ -7,16 +7,16 @@
  *
  * @since TBD
  *
- * @var bool       $show_heading Whether to show the heading.
- * @var string     $heading_tag  The HTML tag for the heading.
- * @var string     $label_text   The label text.
- * @var array      $tags         The event tags.
- * @var array      $settings     The widget settings.
- * @var int        $event_id     The event ID.
- * @var Event_Tags $widget       The widget instance.
+ * @var bool       $show_tags_header Whether to show the header.
+ * @var string     $header_tag       The HTML tag for the header.
+ * @var string     $label_text       The label text.
+ * @var array      $tags             The event tags.
+ * @var array      $settings         The widget settings.
+ * @var int        $event_id         The event ID.
+ * @var Event_Tags $widget           The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Tags;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Tags;
 
 // No tags, no render.
 if ( empty( $tags ) ) {
@@ -25,29 +25,20 @@ if ( empty( $tags ) ) {
 ?>
 <div <?php tribe_classes( $widget->get_element_classes() ); ?>>
 	<?php
-	$this->template(
-		'views/integrations/elementor/widgets/event-tags/header',
-		[
-			'show'        => $show_heading,
-			'heading_tag' => $heading_tag,
-			'label_text'  => $label_text,
-			'event_id'    => $event_id,
-			'settings'    => $settings,
-			'widget'      => $widget,
-		]
-	);
+	$this->template( 'views/integrations/elementor/widgets/event-tags/header' );
 	?>
 	<div <?php tribe_classes( $widget->get_links_class() ); ?>>
 		<?php
+		$tag_count = count( $tags );
+		$count     = 0;
 		foreach ( $tags as $tag_name => $tag_link ) {
+			++$count;
 			$this->template(
 				'views/integrations/elementor/widgets/event-tags/content',
 				[
 					'tag_name' => $tag_name,
 					'tag_link' => $tag_link,
-					'event_id' => $event_id,
-					'settings' => $settings,
-					'widget'   => $widget,
+					'last'     => $count === $tag_count,
 				]
 			);
 		}

--- a/src/views/integrations/elementor/widgets/event-tags/content.php
+++ b/src/views/integrations/elementor/widgets/event-tags/content.php
@@ -11,8 +11,16 @@
  * @var string $tag_link The tag url.
  * @var array  $settings The widget settings.
  * @var int    $event_id The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Tags $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Tags $widget The widget instance.
  */
 
+// Note: inserting a line break after the closing anchor tag will add a visual "space" between the anchor text and the separator.
 ?>
-<a <?php tribe_classes( $widget->get_link_class() ); ?> href="<?php echo esc_url( $tag_link ); ?>"><?php echo esc_html( $tag_name ); ?></a>
+<a <?php tribe_classes( $widget->get_link_class() ); ?> href="<?php echo esc_url( $tag_link ); ?>">
+	<?php echo esc_html( $tag_name ); ?>
+</a><span class="<?php tribe_classes( $widget->get_link_class() . '-separator' ); ?>"><?php // phpcs:ignore Squiz.PHP.EmbeddedPhp.ContentBeforeOpen,Squiz.PHP.EmbeddedPhp.ContentAfterOpen
+if ( ! $last ) {
+	$widget->print_tags_separator();
+}
+?>
+</span>

--- a/src/views/integrations/elementor/widgets/event-tags/header.php
+++ b/src/views/integrations/elementor/widgets/event-tags/header.php
@@ -7,19 +7,19 @@
  *
  * @since TBD
  *
- * @var string $alignment   The text alignment.
- * @var bool   $show        Whether to show the heading.
- * @var string $heading_tag The HTML tag for the heading.
- * @var string $label_text  The label text.
- * @var array  $settings    The widget settings.
- * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Tags $widget The widget instance.
+ * @var string $alignment         The text alignment.
+ * @var bool   $show_tags_header  Whether to show the header.
+ * @var string $header_tag        The HTML tag for the header.
+ * @var string $label_text        The label text.
+ * @var array  $settings          The widget settings.
+ * @var int    $event_id          The event ID.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Tags $widget The widget instance.
  */
 
-if ( ! $show ) {
+if ( ! $show_tags_header ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $heading_tag ); ?> <?php tribe_classes( $widget->get_label_class() ); ?>class="tec-events-pro-event-tags-label">
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>class="tec-events-event-tags-label">
 	<?php echo esc_html( $label_text ); ?>
-</<?php echo tag_escape( $heading_tag ); ?>>
+</<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-title.php
+++ b/src/views/integrations/elementor/widgets/event-title.php
@@ -13,13 +13,13 @@
  * @var Event_Title $widget     The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Title;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Title;
 
 // No title, no render.
 if ( empty( $title ) ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_element_classes() ); ?>>
-<?php echo wp_kses_post( $title ); ?>
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_widget_class() ); ?>>
+	<?php echo wp_kses_post( $title ); ?>
 </<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-venue.php
+++ b/src/views/integrations/elementor/widgets/event-venue.php
@@ -42,7 +42,7 @@
  * @var Event_Venue $widget                The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Venue;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Venue;
 
 // No title, no render.
 if ( empty( $venue_ids ) ) {
@@ -53,48 +53,13 @@ if ( empty( $venue_ids ) ) {
 	<?php
 	$this->template(
 		'views/integrations/elementor/widgets/event-venue/header',
-		[
-			'show'        => $show_widget_header,
-			'header_tag'  => $header_tag,
-			'header_text' => $header_text,
-			'settings'    => $settings,
-			'event_id'    => $event_id,
-			'widget'      => $widget,
-		]
+		[ 'show' => $show_widget_header ]
 	);
 	?>
 	<div <?php tribe_classes( $widget->get_container_classes() ); ?>>
 		<?php foreach ( $venue_ids as $venue_id ) : ?>
 			<?php
-			$this->template(
-				'views/integrations/elementor/widgets/event-venue/single-venue',
-				[
-					'link_name'             => $link_name,
-					'show_name'             => $show_name,
-					'tag'                   => $name_tag,
-					'show_widget_header'    => $show_widget_header,
-					'show_address'          => $show_address,
-					'show_address_map_link' => $show_address_map_link,
-					'show_map'              => $show_map,
-					'show_phone'            => $show_phone,
-					'show_website'          => $show_website,
-					'show_address_header'   => $show_address_header,
-					'show_phone_header'     => $show_phone_header,
-					'show_website_header'   => $show_website_header,
-					'header_tag'            => $header_tag,
-					'address_header_tag'    => $address_header_tag,
-					'phone_header_tag'      => $phone_header_tag,
-					'website_header_tag'    => $website_header_tag,
-					'header_text'           => $header_text,
-					'address_header_text'   => $address_header_text,
-					'phone_header_text'     => $phone_header_text,
-					'website_header_text'   => $website_header_text,
-					'event_id'              => $event_id,
-					'settings'              => $settings,
-					'venue_ids'             => $venue_ids,
-					'widget'                => $widget,
-				]
-			);
+			$this->template( 'views/integrations/elementor/widgets/event-venue/single-venue' );
 			?>
 		<?php endforeach; ?>
 	</div>

--- a/src/views/integrations/elementor/widgets/event-venue/address/address.php
+++ b/src/views/integrations/elementor/widgets/event-venue/address/address.php
@@ -17,10 +17,10 @@ if ( empty( $venue_id ) ) {
 	return;
 }
 ?>
-<p <?php tribe_classes( $widget->get_address_base_class() . '-address' ); ?>>
+<address <?php tribe_classes( $widget->get_address_base_class() . '-address' ); ?>>
 	<?php
 	echo wp_kses_post(
 		tribe_get_full_address( $venue_id )
 	);
 	?>
-</p>
+</address>

--- a/src/views/integrations/elementor/widgets/event-venue/header.php
+++ b/src/views/integrations/elementor/widgets/event-venue/header.php
@@ -12,13 +12,13 @@
  * @var string $header_tag  The HTML tag for the section header.
  * @var array  $settings    The widget settings.
  * @var int    $event_id    The event ID.
- * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Venue $widget The widget instance.
+ * @var Tribe\Events\Integrations\Elementor\Widgets\Event_Venue $widget The widget instance.
  */
 
 if ( empty( $show ) ) {
 	return;
 }
 ?>
-<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_classes() ); ?>>
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $widget->get_header_class() ); ?>>
 	<?php echo esc_html( $header_text ); ?>
 </<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-venue/name.php
+++ b/src/views/integrations/elementor/widgets/event-venue/name.php
@@ -21,7 +21,7 @@ if ( empty( $show ) ) {
 
 $url = $link ? tribe_get_venue_link( $venue_id, false ) : false;
 ?>
-<<?php echo tag_escape( $tag ); ?> <?php tribe_classes( $widget->get_name_base_class() ); ?>>
+<<?php echo tag_escape( $name_tag ); ?> <?php tribe_classes( $widget->get_name_base_class() ); ?>>
 	<?php if ( $url ) : ?>
 		<a <?php tribe_classes( $widget->get_name_base_class() . '-link' ); ?> href="<?php echo esc_url( $url ); ?>">
 	<?php endif; ?>
@@ -29,4 +29,4 @@ $url = $link ? tribe_get_venue_link( $venue_id, false ) : false;
 	<?php if ( $url ) : ?>
 		</a>
 	<?php endif; ?>
-</<?php echo tag_escape( $tag ); ?>>
+</<?php echo tag_escape( $name_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-venue/phone/phone.php
+++ b/src/views/integrations/elementor/widgets/event-venue/phone/phone.php
@@ -13,7 +13,15 @@
  * @var Tribe\Events\Pro\Integrations\Elementor\Widgets\Event_Venue $widget The widget instance.
  */
 
+$phone = tribe_get_phone( $venue_id );
 ?>
 <p <?php tribe_classes( $widget->get_phone_base_class() . '-number' ); ?> >
-	<?php echo wp_kses_post( tribe_get_phone( $venue_id ) ); ?>
+	<?php if ( $link_venue_phone ) : ?>
+		<?php // For a dial link we remove spaces, and replace 'ext' or 'x' with 'p' to pause before dialing the extension. ?>
+		<a <?php tribe_classes( $widget->get_phone_base_class() . '-link' ); ?> href="<?php echo esc_url( 'tel:' . str_ireplace( [ 'ext', 'x', ' ' ], [ 'p', 'p', '' ], $phone ) ); ?>">
+	<?php endif; ?>
+		<?php echo wp_kses_post( $phone ); ?>
+	<?php if ( $link_venue_phone ) : ?>
+		</a>
+	<?php endif; ?>
 </p>

--- a/src/views/integrations/elementor/widgets/event-website.php
+++ b/src/views/integrations/elementor/widgets/event-website.php
@@ -7,17 +7,17 @@
  *
  * @since TBD
  *
- * @var string        $align        The text alignment.
- * @var string        $show_heading Whether to show the heading.
- * @var string        $header_tag   The HTML tag for the heading.
- * @var int           $event_id     The event ID.
- * @var string        $label_class  The class for the link label.
- * @var string        $link_class   The class for the link.
- * @var string        $website      The event website link.
- * @var Event_Website $widget       The widget instance.
+ * @var string        $align                The text alignment.
+ * @var string        $show_website_header  Whether to show the header.
+ * @var string        $header_tag           The HTML tag for the header.
+ * @var string        $header_class         The class for the link header.
+ * @var int           $event_id             The event ID.
+ * @var string        $link_class           The class for the link.
+ * @var string        $website              The event website link.
+ * @var Event_Website $widget               The widget instance.
  */
 
-use TEC\Events_Pro\Integrations\Plugins\Elementor\Widgets\Event_Website;
+use TEC\Events\Integrations\Plugins\Elementor\Widgets\Event_Website;
 
 if ( empty( $website ) ) {
 	return;
@@ -25,20 +25,10 @@ if ( empty( $website ) ) {
 
 ?>
 <div <?php tribe_classes( $widget->get_element_classes() ); ?>>
-	<?php if ( $show_heading === 'yes' ) : ?>
-		<<?php echo tag_escape( $header_tag ); ?>
-			<?php tribe_classes( $label_class ); ?>
-		>
-		<?php
-			printf(
-				/* translators: %s: Event (singular) */
-				esc_html__( '%s Website:', 'tribe-events-calendar-pro' ),
-				esc_html( tribe_get_event_label_singular() )
-			);
-		?>
-		</<?php echo tag_escape( $header_tag ); ?>>
-	<?php endif; ?>
-	<div <?php tribe_classes( $link_class ); ?>>
-		<?php echo wp_kses_post( $website ); ?>
-	</div>
+	<?php
+	$this->template( 'views/integrations/elementor/widgets/event-website/header' );
+	?>
+	<?php
+	$this->template( 'views/integrations/elementor/widgets/event-website/link' );
+	?>
 </div>

--- a/src/views/integrations/elementor/widgets/event-website/header.php
+++ b/src/views/integrations/elementor/widgets/event-website/header.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * View: Elementor Event Website widget header.
+ *
+ * You can override this template in your own theme by creating a file at
+ * [your-theme]/tribe/events/integrations/elementor/widgets/event-website/header.php
+ *
+ * @since TBD
+ *
+ * @var bool   $show_website_header  Whether to show the header.
+ * @var string $header_tag           The HTML tag for the header.
+ * @var string $header_class         The class for the link header.
+ */
+
+if ( ! $show_website_header ) {
+	return;
+}
+?>
+<<?php echo tag_escape( $header_tag ); ?> <?php tribe_classes( $header_class ); ?>>
+	<?php printf( esc_html__( 'Website:', 'the-events-calendar' ) ); ?>
+</<?php echo tag_escape( $header_tag ); ?>>

--- a/src/views/integrations/elementor/widgets/event-website/link.php
+++ b/src/views/integrations/elementor/widgets/event-website/link.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * View: Elementor Event Website widget header.
+ *
+ * You can override this template in your own theme by creating a file at
+ * [your-theme]/tribe/events/integrations/elementor/widgets/event-website/header.php
+ *
+ * @since TBD
+ *
+ * @var string $link_class The class for the link.
+ * @var string $website    The event website link.
+ */
+
+if ( ! $website ) {
+	return;
+}
+?>
+<div <?php tribe_classes( $link_class ); ?>>
+	<?php echo wp_kses_post( $website ); ?>
+</div>


### PR DESCRIPTION
Working for all that have existing styles in the template:
<img width="1800" alt="Screenshot 2024-03-26 at 9 11 33 PM" src="https://github.com/the-events-calendar/the-events-calendar/assets/929375/6ba1af09-cf8f-4ea3-b1b3-b0b46fcb8068">

Now, as we add styles, we just have to add the param to the widget and the rest happens automatically.

**Now contains the consolidation changes and all the new styling.**
