### PR TITLE
Force the classic editor for events edited in Elementor

### DIFF
--- a/src/Events/Integrations/Plugins/Elementor/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Controller.php
@@ -17,7 +17,6 @@ use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use Elementor\Core\Base\Document;
 use Tribe__Template as Template;
 use Tribe__Events__Main as TEC;
-use Tribe__Main;
 
 /**
  * Class Controller

--- a/src/Events/Integrations/Plugins/Elementor/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Controller.php
@@ -14,7 +14,7 @@ use TEC\Common\Integrations\Traits\Plugin_Integration;
 use TEC\Events\Integrations\Integration_Abstract;
 use TEC\Events\Integrations\Plugins\Elementor\Template\Controller as Template_Controller;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
-
+use Elementor\Core\Base\Document;
 use Tribe__Template as Template;
 use Tribe__Events__Main as TEC;
 use Tribe__Main;
@@ -266,35 +266,36 @@ class Controller extends Integration_Abstract {
 	 * @return bool
 	 */
 	public function disable_blocks( $blocks_enabled ) {
-		$post_id = get_the_ID();
+		return $this->built_with_elementor() ? false : $blocks_enabled;
+	}
 
-		if ( ! $post_id ) {
-			$post_id = Tribe__Main::post_id_helper();
-		}
-
+	/**
+	 * Checks if the post was edited with Elementor.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return bool
+	 */
+	public function built_with_elementor( $post_id = null ): bool {
 		if ( ! $post_id ) {
 			$post_id = tribe_get_request_var( 'post' );
 		}
 
 		// We can't get the post ID, bail out.
 		if ( ! $post_id ) {
-			return $blocks_enabled;
+			return false;
 		}
 
 		// Not an event, bail out.
 		if ( ! tribe_is_event( $post_id ) ) {
-			return $blocks_enabled;
+			return false;
 		}
 
-		$elementor_edit = get_post_meta( $post_id, '_elementor_edit_mode', true );
+		$elementor_edit = get_post_meta( $post_id, Document::BUILT_WITH_ELEMENTOR_META_KEY, true );
 
-		// Missing the expected meta - bail out.
-		if ( empty( $elementor_edit ) ) {
-			return $blocks_enabled;
-		}
-
-		// Disable the blocks editor.
-		return false;
+		return apply_filters( 'tec_events_elementor_built_with_elementor', $elementor_edit, $post_id );
 	}
 
 	/**

--- a/src/Events/Integrations/Plugins/Elementor/Manager_Abstract.php
+++ b/src/Events/Integrations/Plugins/Elementor/Manager_Abstract.php
@@ -45,7 +45,7 @@ abstract class Manager_Abstract {
 		 *
 		 * @param array $widgets An associative array of objects in the shape `[ <slug> => <class> ]`.
 		 */
-		return (array) apply_filters( "tribe_events_pro_elementor_registered_{$this->type}", $this->objects );
+		return (array) apply_filters( "tec_events_elementor_registered_{$this->type}", $this->objects );
 	}
 
 	/**


### PR DESCRIPTION
Add a filter to prevent going from editing an event in Elementor to the blocks editor.

[ECP-1749]

:movie_camera: https://www.loom.com/share/b0569ac552214df1b7e6ad40deac86aa?sid=46732eff-6c85-4d8a-a1a2-0190bfb2a754


[ECP-1749]: https://stellarwp.atlassian.net/browse/ECP-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ