### PR TITLE
[ET-2019] Tickets Emails: Fix missing venue website URL

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Corrected the missing Venue Website URL within the Event Tickets Email feature. [ET-2019]
+
 = [6.3.5] 2024-03-20 =
 
 * Tweak - Updated version of tribe-common with fixes for ECP.

--- a/src/views/integrations/event-tickets/emails/template-parts/body/event/venue/website.php
+++ b/src/views/integrations/event-tickets/emails/template-parts/body/event/venue/website.php
@@ -23,7 +23,7 @@ if ( empty( $venue ) ) {
 	return;
 }
 
-if ( empty( $venue->website_url ) ) {
+if ( empty( $venue->website ) ) {
 	return;
 }
 ?>
@@ -39,12 +39,12 @@ if ( empty( $venue->website_url ) ) {
 		</td>
 		<td class="tec-tickets__email-table-content-event-venue-website-container">
 			<a
-				href="<?php echo esc_url( $venue->website_url ); ?>"
+				href="<?php echo esc_url( $venue->website ); ?>"
 				target="_blank"
 				rel="noopener noreferrer"
 				style="overflow-wrap: anywhere;"
 			>
-				<?php echo esc_url( $venue->website_url ); ?>
+				<?php echo esc_url( $venue->website ); ?>
 			</a>
 		</td>
 	</tr>


### PR DESCRIPTION
### 🎫 Ticket
[ET-2019]

### 🗒️ Description
The Venue Website URL was not showing within the tickets emails because we were using the wrong property (`website_url` rather than `website`).

### 🎥 Artifacts <!-- if applicable-->
![image](https://github.com/the-events-calendar/the-events-calendar/assets/7432506/5ef83445-954f-43b0-8f99-fa49f5ff6023)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2019]: https://stellarwp.atlassian.net/browse/ET-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ