### PR TITLE
TEC-4667 Show Notice when REST API is blocked

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add a warning notice in admin area when the REST API endpoints are not accessible. [TEC-4667]
+
 = [6.3.6] 2024-04-09 =
 
 * Fix - Adds timezone offset to the dates in the Outlook subscribe links on event pages. [TEC-4831]

--- a/src/Events/Admin/Notice/Provider.php
+++ b/src/Events/Admin/Notice/Provider.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Service Provider for interfacing with TEC\Common\Admin\Notice.
+ *
+ * @since
+ *
+ * @package TEC\Events\Admin\Notice
+ */
+
+namespace TEC\Events\Admin\Notice;
+
+use TEC\Common\Contracts\Service_Provider;
+
+/**
+ * Class Provider
+ *
+ * @since
+ *
+ * @package TEC\Events\Admin\Notice
+ */
+class Provider extends Service_Provider {
+
+	/**
+	 * Register implementations.
+	 *
+	 * @since
+	 */
+	public function register() {
+		$this->container->singleton( Rest_Api::class, Rest_Api::class );
+
+		$this->add_actions();
+		$this->add_filters();
+	}
+
+	/**
+	 * Add the action hooks.
+	 *
+	 * @since
+	 */
+	public function add_actions() {
+		add_action( 'admin_init', $this->container->callback( Rest_Api::class, 'hook' ) );
+	}
+
+
+	/**
+	 * Add the filter hooks.
+	 *
+	 * @since
+	 */
+	public function add_filters() {
+	}
+}

--- a/src/Events/Admin/Notice/Rest_Api.php
+++ b/src/Events/Admin/Notice/Rest_Api.php
@@ -4,10 +4,10 @@
  *
  * @since
  *
- * @package Tribe\Events\Admin\Notice
+ * @package TEC\Events\Admin\Notice
  */
 
-namespace Tribe\Events\Admin\Notice;
+namespace TEC\Events\Admin\Notice;
 
 use Tribe\Events\Views\V2\Rest_Endpoint as V2;
 
@@ -61,7 +61,7 @@ class Rest_Api {
 	}
 
 	/**
-	 * Checks if we are in an TEC page or in main admin Dashboard.
+	 * Checks if we are in a TEC page or in the main Dashboard.
 	 *
 	 * @since
 	 *

--- a/src/Events/Admin/Notice/Rest_Api.php
+++ b/src/Events/Admin/Notice/Rest_Api.php
@@ -52,9 +52,11 @@ class Rest_Api {
 			$slug,
 			[ $this, 'notice' ],
 			[
-				'type'    => 'error',
-				'dismiss' => 1,
-				'wrap'    => 'p',
+				'type'               => 'error',
+				'dismiss'            => 1,
+				'wrap'               => 'p',
+				'recurring'          => true,
+				'recurring_interval' => 'P7D',
 			],
 			[ $this, 'should_display' ]
 		);
@@ -116,12 +118,17 @@ class Rest_Api {
 			return false;
 		}
 
-		$text = [];
-		// Translators: %s is the "Warning" word in bold.
-		$text[] = sprintf( __( '%s : The Events Calendar REST API endpoints are not accessible! This may be due to a server configuration or another plugin blocking access to the REST API.', 'the-events-calendar' ), '<strong>' . __( 'Warning', 'the-events-calendar' ) . '</strong>' );
-		$text[] = __( 'Please check with your hosting provider or system administrator to ensure that the below is accessible:', 'the-events-calendar' );
-		$text[] = '<p><a href="' . $this->blocked_endpoint . '" target="_blank">' . $this->blocked_endpoint . '</a></p>';
+		$output = sprintf(
+			/* Translators: %1$s and %2$s - opening and closing strong tags, respectively. */
+			__( '%1$sWarning%2$s: The Events Calendar REST API endpoints are not accessible! This may be due to a server configuration or another plugin blocking access to the REST API.', 'the-events-calendar' ),
+			'<strong>',
+			'</strong>'
+		);
+		$output .= '<br />';
+		$output .= __( 'Please check with your hosting provider or system administrator to ensure that the below is accessible:', 'the-events-calendar' );
+		$output .= '<br />';
+		$output .= '<a href="' . $this->blocked_endpoint . '" target="_blank">' . $this->blocked_endpoint . '</a>';
 
-		return implode( '<br />', $text );
+		return $output;
 	}
 }

--- a/src/Events/Admin/Notice/Rest_Api.php
+++ b/src/Events/Admin/Notice/Rest_Api.php
@@ -87,7 +87,7 @@ class Rest_Api {
 	public function is_rest_api_blocked(): bool {
 
 		$v1_api    = new \Tribe__Events__REST__V1__Main();
-		$event_api = get_rest_url( null, $v1_api->get_namespace() . '/events/' . $v1_api->get_version() );
+		$event_api = get_rest_url( null, $v1_api->get_events_route_namespace() );
 		$response  = wp_remote_get( $event_api );
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$this->blocked_endpoint = $event_api;

--- a/src/Tribe/Admin/Notice/Rest_Api.php
+++ b/src/Tribe/Admin/Notice/Rest_Api.php
@@ -40,8 +40,10 @@ class Rest_Api {
 	 * Constructor.
 	 *
 	 * @since
+	 *
+	 * @return void
 	 */
-	public function hook() {
+	public function hook() : void {
 		$slug = $this->slug;
 
 		tribe_notice(
@@ -63,7 +65,7 @@ class Rest_Api {
 	 *
 	 * @return boolean
 	 */
-	public function should_display() {
+	public function should_display() : bool {
 		global $pagenow;
 
 		if ( tribe( 'admin.helpers' )->is_screen() || 'index.php' === $pagenow ) {
@@ -80,7 +82,7 @@ class Rest_Api {
 	 *
 	 * @return boolean
 	 */
-	public function is_rest_api_blocked() {
+	public function is_rest_api_blocked() : bool {
 
 		$event_api = get_rest_url( null, '/tribe/events/v1/' );
 		$response  = wp_remote_get( $event_api );
@@ -104,7 +106,7 @@ class Rest_Api {
 	 *
 	 * @since
 	 *
-	 * @return string
+	 * @return false|string
 	 */
 	public function notice() {
 		if ( ! current_user_can( 'activate_plugins' ) ) {

--- a/src/Tribe/Admin/Notice/Rest_Api.php
+++ b/src/Tribe/Admin/Notice/Rest_Api.php
@@ -9,6 +9,8 @@
 
 namespace Tribe\Events\Admin\Notice;
 
+use Tribe\Events\Views\V2\Rest_Endpoint as V2;
+
 /**
  * Class Rest_Api
  *
@@ -43,7 +45,7 @@ class Rest_Api {
 	 *
 	 * @return void
 	 */
-	public function hook() : void {
+	public function hook(): void {
 		$slug = $this->slug;
 
 		tribe_notice(
@@ -65,7 +67,7 @@ class Rest_Api {
 	 *
 	 * @return boolean
 	 */
-	public function should_display() : bool {
+	public function should_display(): bool {
 		global $pagenow;
 
 		if ( tribe( 'admin.helpers' )->is_screen() || 'index.php' === $pagenow ) {
@@ -82,16 +84,17 @@ class Rest_Api {
 	 *
 	 * @return boolean
 	 */
-	public function is_rest_api_blocked() : bool {
+	public function is_rest_api_blocked(): bool {
 
-		$event_api = get_rest_url( null, '/tribe/events/v1/' );
+		$v1_api    = new \Tribe__Events__REST__V1__Main();
+		$event_api = get_rest_url( null, $v1_api->get_namespace() . '/events/' . $v1_api->get_version() );
 		$response  = wp_remote_get( $event_api );
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$this->blocked_endpoint = $event_api;
 			return true;
 		}
 
-		$views_api = get_rest_url( null, 'tribe/views/v2/' );
+		$views_api = get_rest_url( null, V2::ROOT_NAMESPACE );
 		$response  = wp_remote_get( $views_api );
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$this->blocked_endpoint = $views_api;

--- a/src/Tribe/Admin/Notice/Rest_Api.php
+++ b/src/Tribe/Admin/Notice/Rest_Api.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Shows an admin notice when our REST API endpoints are not available.
+ *
+ * @since
+ *
+ * @package Tribe\Events\Admin\Notice
+ */
+
+namespace Tribe\Events\Admin\Notice;
+
+/**
+ * Class Rest_Api
+ *
+ * Shows an admin notice when our REST API endpoints are not available.
+ *
+ * @since
+ */
+class Rest_Api {
+
+	/**
+	 * Notice Slug on the user options
+	 *
+	 * @since
+	 *
+	 * @var string
+	 */
+	private $slug = 'events-rest-api-notice';
+
+	/**
+	 * Blocked endpoint.
+	 *
+	 * @since
+	 *
+	 * @var string
+	 */
+	private $blocked_endpoint = '';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since
+	 */
+	public function hook() {
+		$slug = $this->slug;
+
+		tribe_notice(
+			$slug,
+			[ $this, 'notice' ],
+			[
+				'type'    => 'error',
+				'dismiss' => 1,
+				'wrap'    => 'p',
+			],
+			[ $this, 'should_display' ]
+		);
+	}
+
+	/**
+	 * Checks if we are in an TEC page or in main admin Dashboard.
+	 *
+	 * @since
+	 *
+	 * @return boolean
+	 */
+	public function should_display() {
+		global $pagenow;
+
+		if ( tribe( 'admin.helpers' )->is_screen() || 'index.php' === $pagenow ) {
+			return $this->is_rest_api_blocked() ? true : false;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if our endpoints are accessible.
+	 *
+	 * @since
+	 *
+	 * @return boolean
+	 */
+	public function is_rest_api_blocked() {
+
+		$event_api = get_rest_url( null, '/tribe/events/v1/' );
+		$response  = wp_remote_get( $event_api );
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$this->blocked_endpoint = $event_api;
+			return true;
+		}
+
+		$views_api = get_rest_url( null, 'tribe/views/v2/' );
+		$response  = wp_remote_get( $views_api );
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$this->blocked_endpoint = $views_api;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * HTML for the notice when we have blocked REST API endpoints.
+	 *
+	 * @since
+	 *
+	 * @return string
+	 */
+	public function notice() {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return false;
+		}
+
+		$text = [];
+		// Translators: %s is the "Warning" word in bold.
+		$text[] = sprintf( __( '%s : The Events Calendar REST API endpoints are not accessible! This may be due to a server configuration or another plugin blocking access to the REST API.', 'the-events-calendar' ), '<strong>' . __( 'Warning', 'the-events-calendar' ) . '</strong>' );
+		$text[] = __( 'Please check with your hosting provider or system administrator to ensure that the below is accessible:', 'the-events-calendar' );
+		$text[] = '<p><a href="' . $this->blocked_endpoint . '" target="_blank">' . $this->blocked_endpoint . '</a></p>';
+
+		return implode( '<br />', $text );
+	}
+}

--- a/src/Tribe/Admin/Provider.php
+++ b/src/Tribe/Admin/Provider.php
@@ -20,6 +20,7 @@ class Provider extends Service_Provider {
 		$this->container->singleton( 'tec.admin.notice.marketing', Notice\Marketing::class );
 		$this->container->singleton( 'tec.admin.notice.update', Notice\Update::class );
 		$this->container->singleton( Notice\Install_Event_Tickets::class, Notice\Install_Event_Tickets::class );
+		$this->container->singleton( Notice\Rest_Api::class, Notice\Rest_Api::class );
 
 		$this->add_hooks();
 	}
@@ -32,9 +33,9 @@ class Provider extends Service_Provider {
 	public function add_hooks() {
 		add_action( 'tribe_settings_do_tabs', $this->container->callback( Settings::class, 'settings_ui' ) );
 		add_action( 'admin_menu', $this->container->callback( Settings::class, 'add_admin_pages' ), 11 );
-		add_action( 'tribe_settings_do_tabs', $this->container->callback(  Settings::class, 'do_addons_api_settings_tab' ) );
-		add_action( 'tribe_settings_do_tabs', $this->container->callback(  Settings::class, 'do_upgrade_tab' ) );
-		add_filter( 'tribe_settings_url', $this->container->callback(  Settings::class, 'filter_url' ) );
+		add_action( 'tribe_settings_do_tabs', $this->container->callback( Settings::class, 'do_addons_api_settings_tab' ) );
+		add_action( 'tribe_settings_do_tabs', $this->container->callback( Settings::class, 'do_upgrade_tab' ) );
+		add_filter( 'tribe_settings_url', $this->container->callback( Settings::class, 'filter_url' ) );
 		add_action( 'network_admin_menu', $this->container->callback( Settings::class, 'maybe_add_network_settings_page' ) );
 		add_action( 'tribe_settings_do_tabs', $this->container->callback( Settings::class, 'do_network_settings_tab' ), 400 );
 		add_filter( 'tribe_settings_page_title', $this->container->callback( Settings::class, 'settings_page_title' ) );
@@ -52,5 +53,6 @@ class Provider extends Service_Provider {
 		add_action( 'admin_init', $this->container->callback( 'tec.admin.notice.fse', 'hook' ) );
 		add_action( 'admin_init', $this->container->callback( Notice\Legacy_Views_Updated::class, 'hook' ) );
 		add_action( 'admin_init', $this->container->callback( Notice\Install_Event_Tickets::class, 'hook' ) );
+		add_action( 'admin_init', $this->container->callback( Notice\Rest_Api::class, 'hook' ) );
 	}
 }

--- a/src/Tribe/Admin/Provider.php
+++ b/src/Tribe/Admin/Provider.php
@@ -20,7 +20,6 @@ class Provider extends Service_Provider {
 		$this->container->singleton( 'tec.admin.notice.marketing', Notice\Marketing::class );
 		$this->container->singleton( 'tec.admin.notice.update', Notice\Update::class );
 		$this->container->singleton( Notice\Install_Event_Tickets::class, Notice\Install_Event_Tickets::class );
-		$this->container->singleton( Notice\Rest_Api::class, Notice\Rest_Api::class );
 
 		$this->add_hooks();
 	}
@@ -53,6 +52,5 @@ class Provider extends Service_Provider {
 		add_action( 'admin_init', $this->container->callback( 'tec.admin.notice.fse', 'hook' ) );
 		add_action( 'admin_init', $this->container->callback( Notice\Legacy_Views_Updated::class, 'hook' ) );
 		add_action( 'admin_init', $this->container->callback( Notice\Install_Event_Tickets::class, 'hook' ) );
-		add_action( 'admin_init', $this->container->callback( Notice\Rest_Api::class, 'hook' ) );
 	}
 }

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -700,6 +700,9 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			// SEO support.
 			tribe_register_provider( TEC\Events\SEO\Controller::class );
 
+			// Register new Admin Notice system.
+			tribe_register_provider( TEC\Events\Admin\Notice\Provider::class );
+
 			/**
 			 * Allows other plugins and services to override/change the bound implementations.
 			 *

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -171,7 +171,7 @@ class Tribe__Events__REST__V1__Main extends Tribe__REST__Main {
 	 *
 	 * @return string
 	 */
-	protected function get_events_route_namespace() {
+	public function get_events_route_namespace() {
 		return $this->get_namespace() . '/events/' . $this->get_version();
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4667]

### 🗒️ Description

Added a class names `Rest_Api.php` under `src/Tribe/Admin/Notice` to register an admin notice that would warn the user when our Rest Api endpoints are not accessible.

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[TEC-4667]: https://stellarwp.atlassian.net/browse/TEC-4667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ