### PR TITLE
Don't use an empty string for the label.

### DIFF
--- a/src/functions/template-tags/link.php
+++ b/src/functions/template-tags/link.php
@@ -411,7 +411,7 @@ function tribe_get_event_website_link( $event = null, $label = null, $target = '
 	$rel    = ( '_blank' === $target ) ? 'noopener noreferrer' : 'external';
 
 	if ( ! empty( $url ) ) {
-		$label = is_null( $label ) ? $url : $label;
+		$label = empty( $label ) ? $url : $label;
 		/**
 		 * Filter the website link label
 		 *


### PR DESCRIPTION
[ECP-1746]

[ECP-1746]: https://stellarwp.atlassian.net/browse/ECP-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ