### PR TITLE
Fix logic for applying Hide_End_Time_Modifier. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
   "_glotPressUrl": "https://translate.wordpress.org",
   "_glotPressSlug": "wp-plugins/the-events-calendar/stable",
   "_glotPressFileFormat": "%textdomain%-%wp_locale%.%format%",
-  "_glotPressFormats": [
-    "po",
-    "mo"
-  ],
+  "_glotPressFormats": ["po", "mo"],
   "_glotPressFilter": {
     "translation_sets": false,
     "minimum_percentage": 30,
@@ -71,10 +68,7 @@
     "zip": "node node_modules/@the-events-calendar/product-taskmaster/util/zip.js",
     "glotpress": "gulp glotpress"
   },
-  "engines": {
-    "node": "18.13.0",
-    "npm": "8.19.3"
-  },
+  "engines": { "node": "18.13.0", "npm": "8.19.3" },
   "devDependencies": {
     "@the-events-calendar/product-taskmaster": "^3.0.0",
     "@wordpress/hooks": "^1.3.2",
@@ -134,11 +128,7 @@
     "whatwg-fetch": "^2.0.4",
     "zero-fill": "^2.2.3"
   },
-  "overrides": {
-    "babel-plugin-lodash": {
-      "@babel/types": "~7.20.0"
-    }
-  },
+  "overrides": { "babel-plugin-lodash": { "@babel/types": "~7.20.0" } },
   "browserslist": [
     "last 2 Chrome versions",
     "last 2 Firefox versions",

--- a/src/Events/Views/Modifiers/Hide_End_Time_Modifier.php
+++ b/src/Events/Views/Modifiers/Hide_End_Time_Modifier.php
@@ -3,6 +3,7 @@
 namespace TEC\Events\Views\Modifiers;
 
 use TEC\Events\Views\Modifiers\Visibility_Modifier_Abstract;
+use Tribe\Events\Views\V2\Manager as Views_Manager;
 use Tribe__Context;
 use WP_Post;
 
@@ -83,6 +84,11 @@ class Hide_End_Time_Modifier extends Visibility_Modifier_Abstract {
 	final public function check_visibility( string $area, $post = null ): bool {
 		$views        = $this->get_options();
 		$display_mode = $this->get_context()->get( 'event_display_mode' );
+
+		// If the area is the default view, we need to replace 'default' with the actual view slug.
+		if ( $area === 'default' ) {
+			$area = tribe( Views_Manager::class )->get_default_view_slug();
+		}
 
 		if ( $area === 'list' && $display_mode === 'past' ) {
 			// Recent past events list view should not show the end time.

--- a/src/Events/Views/Modifiers/Hide_End_Time_Modifier.php
+++ b/src/Events/Views/Modifiers/Hide_End_Time_Modifier.php
@@ -82,18 +82,14 @@ class Hide_End_Time_Modifier extends Visibility_Modifier_Abstract {
 	 * @return bool Whether the end time should be hidden or visible.
 	 */
 	final public function check_visibility( string $area, $post = null ): bool {
-		$views        = $this->get_options();
-		$display_mode = $this->get_context()->get( 'event_display_mode' );
+		$views = $this->get_options();
 
 		// If the area is the default view, we need to replace 'default' with the actual view slug.
 		if ( $area === 'default' ) {
 			$area = tribe( Views_Manager::class )->get_default_view_slug();
 		}
 
-		if ( $area === 'list' && $display_mode === 'past' ) {
-			// Recent past events list view should not show the end time.
-			return isset( $views['recent'] ) ?? true;
-		} elseif ( isset( $views[ $area ] ) ) {
+		if ( isset( $views[ $area ] ) ) {
 			// Is this view flagged to hide the end time?
 			return $views[ $area ];
 		}

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -250,7 +250,6 @@ $tec_events_display_fields += $tec_events_display_template;
 $sample_date = strtotime( 'January 15 ' . gmdate( 'Y' ) );
 
 $end_time_options = [
-	'recent'       => esc_html__( 'Recent past events list', 'the-events-calendar' ),
 	'single-event' => esc_html__( 'Single event page', 'the-events-calendar' ),
 	'day'          => esc_html__( 'Day view', 'the-events-calendar' ),
 	'list'         => esc_html__( 'List view', 'the-events-calendar' ),


### PR DESCRIPTION
Specifically around the default view.
Remove past control and logic

[TEC-4371]

See: https://github.com/the-events-calendar/the-events-calendar/pull/4536

[TEC-4371]: https://stellarwp.atlassian.net/browse/TEC-4371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ