### PR TITLE
Wrong dates in Page Titles

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ Remember to always make a backup of your database and files before updating!
 
 * Feature - Moved the Remove End Time settings from our Tweaks extension into the TEC > Settings > Display section. Fixes some compatibility issues with recent updates to the views. Also adds a compatibility layer in case of using an older Tweaks extension. [TEC-4371]
 * Fix - When creating a new event the Currency symbol, code and position fields are populated from the general settings options. [TEC-5072]
+* Fix - Wrong page titles in List page when using a Classic Theme. [TEC-5074]
 * Tweak - Add a warning notice in admin area when the REST API endpoints are not accessible. [TEC-4667]
 * Tweak - Add aria-hidden="true" to the event image link so that screen readers ignore it. [TEC-5023]
 

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -82,9 +82,7 @@ class Title {
 		 * @param string      $title     The original title.
 		 * @param null|string $sep       The separator sequence to separate the title components.
 		 */
-		$the_title = apply_filters( 'tribe_events_title_tag', $new_title, $title, $sep, $depth );
-
-		return $the_title;
+		return apply_filters( 'tribe_events_title_tag', $new_title, $title, $sep, $depth );
 	}
 
 	/**
@@ -141,18 +139,18 @@ class Title {
 		 */
 		$this->events_label_plural = apply_filters( 'tribe_events_filter_views_v2_wp_title_plural_events_label', $this->events_label_plural, $context );
 
-		// If there's a date selected in the tribe bar, show the date range of the currently showing events
+		// If there's a date selected in the tribe bar, show the date range of the currently showing events.
 		$event_date         = $context->get( 'event_date', false );
 		$event_display_mode = $context->get( 'event_display_mode' );
 
 		if ( Month_View::get_view_slug() === $event_display_mode ) {
 			$title = $this->build_month_title( $event_date );
-		} else if ( Day_View::get_view_slug() === $event_display_mode ) {
+		} elseif ( Day_View::get_view_slug() === $event_display_mode ) {
 			$title = $this->build_day_title( $event_date );
 		} elseif ( $context->is( 'single' ) && $context->is( 'event_post_type' ) ) {
-			// For single events, the event title itself is required
+			// For single events, the event title itself is required.
 			$title = get_the_title( $context->get( 'post_id' ) );
-		} else if ( count( $posts ) ) {
+		} elseif ( count( $posts ) ) {
 			$range = static::build_post_range_title( $context, $event_date, $posts );
 			if ( 'past' === $event_display_mode ) {
 				/* translators: %1$s: Events plural %2$s: Event date range */
@@ -165,7 +163,7 @@ class Title {
 			/* translators: %s: Events plural */
 			$title = sprintf( esc_html__( 'Past %s', 'the-events-calendar' ), $this->events_label_plural );
 		} else {
-			// For all other cases, start with 'upcoming events'
+			// For all other cases, start with 'upcoming events'.
 			/* translators: %s: Events plural */
 			$title = sprintf( esc_html__( 'Upcoming %s', 'the-events-calendar' ), $this->events_label_plural );
 		}
@@ -377,6 +375,7 @@ class Title {
 		$event_date = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
 
 		$title = sprintf(
+			/* translators: %1$s: Events plural %2$s: Month and year */
 			esc_html_x( '%1$s for %2$s', 'month view', 'the-events-calendar' ),
 			$this->events_label_plural,
 			date_i18n( tribe_get_date_option( 'monthAndYearFormat', 'F Y' ), strtotime( $event_date ) )
@@ -404,6 +403,7 @@ class Title {
 	 */
 	protected function build_day_title( $event_date ) {
 		$title = sprintf(
+			/* translators: %1$s: Events plural %2$s: Day */
 			esc_html_x( '%1$s for %2$s', 'day_view', 'the-events-calendar' ),
 			$this->events_label_plural,
 			date_i18n( tribe_get_date_format( true ), strtotime( $event_date ) )
@@ -418,7 +418,7 @@ class Title {
 		 * @param string The date to use to build the title, in the `Y-m-d` format.
 		 */
 		return apply_filters( 'tribe_events_views_v2_day_title', $title, $event_date );
-}
+	}
 
 	/**
 	 * Builds, wrapping the current title, the Event Category archive title.
@@ -427,7 +427,7 @@ class Title {
 	 * @since 5.12.3 Added params, refined logic around category archive titles.
 	 *
 	 * @param string      $title     The input title.
-	 * @param  \WP_Term   $cat       The category term to use to build the title.
+	 * @param  \WP_Term    $cat       The category term to use to build the title.
 	 * @param boolean     $depth     Whether to display the taxonomy hierarchy as part of the title.
 	 * @param null|string $separator The separator sequence to separate the title components.
 	 *
@@ -441,7 +441,7 @@ class Title {
 		 *
 		 * @since 5.12.3
 		 *
-	 	 * @param boolean     $depth Whether to display the taxonomy hierarchy as part of the title.
+		 * @param boolean     $depth Whether to display the taxonomy hierarchy as part of the title.
 		 * @param string      $title The input title.
 		 * @param  \WP_Term   $cat   The category term to use to build the title.
 		 */
@@ -454,7 +454,7 @@ class Title {
 				$cat->taxonomy,
 				[
 					'link'      => false,
-					'separator' => $separator
+					'separator' => $separator,
 				]
 			);
 		}
@@ -463,13 +463,12 @@ class Title {
 			$term_parents = $cat->name;
 		}
 
-		$new_title =  $title . $separator . $term_parents;
+		$new_title = $title . $separator . $term_parents;
 
 		/**
 		 * Filters the Event Category Archive title.
 		 *
 		 * @since 4.9.10
-		 *
 		 *
 		 * @param string    $new_title The Event Category archive title.
 		 * @param string    $title     The original title.

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -346,6 +346,19 @@ class Title {
 		if ( null === $this->posts ) {
 			global $wp_query;
 			$posts = null !== $wp_query->posts ? $wp_query->posts : $wp_query->get_posts();
+
+			if ( is_post_type_archive( 'tribe_events' ) ) {
+				$post_ids = wp_list_pluck( $posts, 'ID' );
+				$posts    = tribe_get_events(
+					[
+						'posts_per_page' => -1,
+						'orderby'        => 'meta_value',
+						'meta_key'       => '_EventStartDate',
+						'order'          => 'ASC',
+						'post__in'       => $post_ids,
+					]
+				);
+			}
 		}
 
 		return $posts;


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5074]

### 🗒️ Description

When we are using a classic theme (not a Block Theme) the filters that adjust the Page Title were fired before the current View of the List page was setup. So the query results were null and the global query fallback had a different events list, of what was eventually displayed. Thus the page titles daterange was wrong.

In this case, we setup the View earlier, with the repository and query arguments and get the proper events list to display the right page title.

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[TEC-5074]: https://stellarwp.atlassian.net/browse/TEC-5074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ