### PR TITLE
Remove text-transform:capitalize;

### DIFF
--- a/src/resources/postcss/widgets/full/_events-list.pcss
+++ b/src/resources/postcss/widgets/full/_events-list.pcss
@@ -38,7 +38,6 @@
 
 	.tribe-events-widget-events-list__view-more-link {
 		color: var(--tec-color-link-accent);
-		text-transform: capitalize;
 
 		&:visited {
 			color: var(--tec-color-link-accent);


### PR DESCRIPTION
This CSS rule is bad for localization, because it leads to grammatically incorrect constructs, like "Vis Kalender" in Norwegian (we never capitalize words unless they are proper nouns, and "Kalender" is not a proper noun).

### 🗒️ Description

Bug fix (non-breaking change which fixes an issue)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.