### PR TITLE
DocBlock: `tribe_delete_venue()`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -234,10 +234,10 @@ Remember to always make a backup of your database and files before updating!
 
 = [6.5.1] TBD =
 
+* Tweak - Add note to `tribe_delete_venue()` docblock to indicate future deprecation.
 * Tweak - Add note to `tribe_create_organizer()` docblock to indicate future deprecation.
 * Tweak - Add note to `tribe_create_event()` docblock to indicate future deprecation.
 * Tweak - Add note to `tribe_event_update()` docblock to indicate future deprecation.
-
 
 = [6.5.0] 2024-05-14 =
 

--- a/src/functions/advanced-functions/venue.php
+++ b/src/functions/advanced-functions/venue.php
@@ -60,15 +60,19 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 	}
 
 	/**
-	 * Delete a Venue
+	 * Delete a Venue using the legacy method.
+	 *
+	 * Note: This function is outdated and should be replaced with the [TEC ORM `tribe_venue()->delete()` method](https://docs.theeventscalendar.com/apis/orm/delete)
+	 *
+	 * @since 3.0.0
+	 *
+	 * @link     http://codex.wordpress.org/Function_Reference/wp_delete_post
+	 * @see      wp_delete_post()
 	 *
 	 * @param int  $postId       ID of the Venue to be deleted.
 	 * @param bool $force_delete Whether to bypass trash and force deletion. Defaults to false.
 	 *
 	 * @return bool false if delete failed.
-	 * @link     http://codex.wordpress.org/Function_Reference/wp_delete_post
-	 * @see      wp_delete_post()
-	 * @category Venues
 	 */
 	function tribe_delete_venue( $postId, $force_delete = false ) {
 		$success = Tribe__Events__API::deleteVenue( $postId, $args );


### PR DESCRIPTION
Added note to docblock for `tribe_delete_venue()` to indication future deprecation and to use the ORM instead. 