### PR TITLE
Update events-meta-box.php

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -252,9 +252,9 @@ Remember to always make a backup of your database and files before updating!
 = [6.4.0.1] 2024-05-06 =
 
 * Fix - Prevent the Status widget from potentially running undefined methods. [ECP-1797]
-* Fix - Ensure JSON response of Reflector View class is sanitized, to avoid potential security issues. [SVUL-2]
 * Tweak - Add action to signal activation of TEC Elementor compatibility. [ECP-1789]
 * Tweak - Added actions: `tec_events_elementor_loaded`
+* Security - Ensure JSON response of Reflector View class is sanitized, to avoid potential security issues. [SVUL-2]
 * Security - Correct a user permissions check.
 * Language - 0 new strings added, 27 updated, 0 fuzzied, and 0 obsoleted
 

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -252,7 +252,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 							id='EventCurrencyCode'
 							name='EventCurrencyCode'
 							size='3'
-							value='<?php echo esc_attr( $currency_code ); ?>
+							value='<?php echo esc_attr( $currency_code ); ?>'
 							class='alignleft'
 						/>
 					</td>


### PR DESCRIPTION
The EventCurrency Code input was missing one ' at the end of the line 255, causing an issue on some sites (using Apache Server + PHP 7.4.33) where the Currency Code field was being populated with "USD							class="

### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.