### PR TITLE
Add missing single quote to line 255 for `events-meta-box.php`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -238,7 +238,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Remove automatic capitalization for 'View Calendar' text on Calendar List Widget. [TECTRIA-40]
 * Tweak - Add note to `tribe_create_venue()`, `tribe_create_organizer()`, `tribe_create_event()`, `tribe_update_event()`, `tribe_update_venue()`, `tribe_update_organizer()`, `tribe_delete_organizer()`, and `tribe_delete_venue()` docblocks to indicate future deprecation.
 * Tweak - Add docblocks to `src/Tribe/Featured_Events/Permalinks_Helper.php` and `src/Tribe/Featured_Events/Query_Helper.php`.
-* Tweak - Add missing single quote to `src/admin-views/events-meta-box.php` on line 255.
+* Tweak - Add missing single quote to `src/admin-views/events-meta-box.php` on line 255 - props for the fix @gugaalves! [TECTRIA-63]
 
 = [6.5.0] 2024-05-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -238,7 +238,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Remove automatic capitalization for 'View Calendar' text on Calendar List Widget. [TECTRIA-40]
 * Tweak - Add note to `tribe_create_venue()`, `tribe_create_organizer()`, `tribe_create_event()`, `tribe_update_event()`, `tribe_update_venue()`, `tribe_update_organizer()`, `tribe_delete_organizer()`, and `tribe_delete_venue()` docblocks to indicate future deprecation.
 * Tweak - Add docblocks to `src/Tribe/Featured_Events/Permalinks_Helper.php` and `src/Tribe/Featured_Events/Query_Helper.php`.
-
+* Tweak - Add missing single quote to `src/admin-views/events-meta-box.php` on line 255.
 
 = [6.5.0] 2024-05-14 =
 

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -252,7 +252,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 							id='EventCurrencyCode'
 							name='EventCurrencyCode'
 							size='3'
-							value='<?php echo esc_attr( $currency_code ); ?>
+							value='<?php echo esc_attr( $currency_code ); ?>'
 							class='alignleft'
 						/>
 					</td>


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-63]

### 🗒️ Description
The `EventCurrency` code input was missing one `'` at the end of line 255, causing an issue on some sites (using Apache Server + PHP 7.4.33) where the Currency Code field was being populated with "USD class=". Credit for the fix goes to @gugaalves for the submission of PR #4609 

### 🎥 Artifacts 
![image](https://github.com/the-events-calendar/the-events-calendar/assets/95599199/af059e9a-2e80-4bdb-91c0-c458c8302434)

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[TECTRIA-63]: https://stellarwp.atlassian.net/browse/TECTRIA-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ