### PR TITLE
fix nonce verification issue

### DIFF
--- a/src/Tribe/Views/V2/Rest_Endpoint.php
+++ b/src/Tribe/Views/V2/Rest_Endpoint.php
@@ -166,8 +166,13 @@ class Rest_Endpoint {
 		}
 
 		// Did either our unauth or authed nonce pass? If neither, something is fishy.
-		$nonce_check = wp_verify_nonce( $request->get_param( static::PRIMARY_NONCE_KEY ), static::NONCE_ACTION )
-		               || wp_verify_nonce( $request->get_param( static::SECONDARY_NONCE_KEY ), static::NONCE_ACTION );
+		$nonce_check = tribe_without_filters(
+			[ 'nonce_user_logged_out' ],
+			function () use ( $request ) {
+				return wp_verify_nonce( $request->get_param( static::PRIMARY_NONCE_KEY ), static::NONCE_ACTION )
+					|| wp_verify_nonce( $request->get_param( static::SECONDARY_NONCE_KEY ), static::NONCE_ACTION );
+			}
+		);
 
 		return ( $auth || is_null( $auth ) )
 		       && ! is_wp_error( $auth )

--- a/tests/views_integration/Tribe/Events/Views/V2/Rest_EndpointTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Rest_EndpointTest.php
@@ -185,6 +185,25 @@ class Rest_EndpointTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * Validates we exclude other filters when validating nonces.
+	 *
+	 * @test
+	 */
+	public function it_can_validate_generated_nonces() {
+		add_filter( 'nonce_user_logged_out', function () {
+			return '127.0.0.1';
+		} );
+
+		// Get our nonces
+		$nonces = Rest_Endpoint::get_rest_nonces();
+
+		$rest_endpoint = new Rest_Endpoint();
+		$request       = new WP_REST_Request( 'POST' );
+		$request->set_body_params( $nonces );
+		$this->assertTrue( $rest_endpoint->is_valid_request( $request ) );
+	}
+
+	/**
 	 * We should still auth the request with the wp rest server.
 	 *
 	 * @test


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Bug fix: when used on a site with SAM Pro Free, logged-out users’ ajax requests to `/wp-json/tribe/views/v2/html` fail with a `401 Unauthorized` response and this response body:

```json
{
    "code": "rest_forbidden",
    "message": "Sorry, you are not allowed to do that.",
    "data": {
        "status": 401
    }
}
```

Logged-in user’s ajax requests work fine.

Cause:

- The Events Calendar [generates nonces](https://github.com/the-events-calendar/the-events-calendar/blob/a88c3daa04357c5807211a7a347cdf0dd678500a/src/Tribe/Views/V2/Rest_Endpoint.php#L192-L217) while ignoring the `nonce_user_logged_out` filter
- SAM Pro Free uses that filter to return the logged-out user’s IP address rather than the default `0`
- The Events Calendar does not ignore that filter when [verifying the nonce](https://github.com/the-events-calendar/the-events-calendar/blob/a88c3daa04357c5807211a7a347cdf0dd678500a/src/Tribe/Views/V2/Rest_Endpoint.php#L169-L170), so nonce verification fails

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.