### PR TITLE
docBlock: `month_day_classes` and `tec_events_month_day_classes_comparison_date`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ Remember to always make a backup of your database and files before updating!
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Updated docblock for `month_day_classes` and `tec_events_month_day_classes_comparison_date`.
+
 = [6.5.1.4] 2024-06-18 =
 
 * Fix - In installations where the plugins or wp-content directories were symbolic linked, assets would fail to be located.[TECTRIA-91]

--- a/src/Tribe/Views/V2/functions/classes.php
+++ b/src/Tribe/Views/V2/functions/classes.php
@@ -98,16 +98,16 @@ function month_multiday_classes( $event, $day_date, $is_start_of_week, $today_da
 }
 
 /**
+ * A list of CSS classes that will be added to the day "cell" in month view.
  * Used in the Month View days loop.
- * Outputs classes for each day "cell".
  *
  * @since 6.0.2
  * @since 6.2.9 Updated logic to always default to comparing days with today's date.
  *
  * @param array<mixed> $day          The current day data.
- * @param string       $day_date     The current day date, in the `Y-m-d` format.
+ * @param string       $day_date     The current day date in `Y-m-d` format.
  * @param \DateTime    $request_date The request date for the view.
- * @param string       $today_date   Today's date in the `Y-m-d` format.
+ * @param string       $today_date   Today's date in `Y-m-d` format.
  *
  * @return array<string,bool> $day_classes The classes to add to the day "cell".
  */
@@ -119,11 +119,11 @@ function month_day_classes( array $day, string $day_date, \DateTime $request_dat
 	 * @since 6.2.9 Added `$today_date` parameter to the filter.
 	 * @since 6.2.9 Comparison date now defaults to today's date instead of the request date.
 	 *
-	 * @param string       $comparison_date The date used for comparisons. Defaults to today's date ($today_date).
+	 * @param string       $comparison_date The date used for comparisons. Defaults to today's date (`$today_date`).
 	 * @param \DateTime    $request_date    The request date for the view.
-	 * @param string       $day_date        The current day date, in the `Y-m-d` format.
+	 * @param string       $day_date        The current day date in `Y-m-d` format.
 	 * @param array<mixed> $day             The current day data.
-	 * @param string       $today_date      Today's date in the `Y-m-d` format.
+	 * @param string       $today_date      Today's date in `Y-m-d` format.
 	 */
 	$comparison_date = apply_filters( 'tec_events_month_day_classes_comparison_date', $today_date, $request_date, $day_date, $day, $today_date );
 


### PR DESCRIPTION
Updated docblock for `month_day_classes` and `tec_events_month_day_classes_comparison_date`