### PR TITLE
Update Custom_Tables_Query_Filters.php

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -238,6 +238,7 @@ Remember to always make a backup of your database and files before updating!
 * Fix - Correct docblocks in the file `Tribe\Events\Views\V2\Views\Traits\Breakpoint_Behavior.php` - credit goes to @IanDelMar
 * Fix - Add missing closing tags on some admin pages to ensure valid HTML markup. [TEC-4807]
 * Fix - Fix an issue where the import screen broke when the import limit type was set to "date range". [TECTRIA-103]
+* Fix - Changed `else if` to `if` in `filter_posts_join()` function to avoid database error. Credit goes to @datadiver0x0. [ECP-1562]
 * Tweak - Add details to the `tec_views_v2_subscribe_link_visibility()` and `tec_views_v2_subscribe_link_' . self::get_slug() . '_visibility()` docblocks for clarity.
 * Tweak - Added filters `tec_events_general_settings_toc`, `tec_events_display_settings_toc`.
 * Tweak - Updated docblock for `get_before_events_html` and `get_after_events_html` to provide more clarity.

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -226,7 +226,19 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			if ( ! in_array( $join_clause, $this->query_vars['join'], true ) ) {
 				$this->query_vars['join'][] = $join_clause;
 			}
-		} else if ( ! empty( $this->query_vars['join'] ) ) {
+		//} else if ( ! empty( $this->query_vars['join'] ) ) {
+		//	$join = $this->deduplicate_joins( $join );
+		}
+
+		/*
+		 * Fix for php error "WordPress database error Not unique table/alias: 'wp_tec_occurrences' 
+   		 * for query SELECT SQL_CALC_FOUND_ROWS..."
+		 *
+		 * Moved from above 'else if'. Function filter_posts_join needs to check for dups regardless of 
+		 * whether or not there are any redirects because the external join from wp_query still needs to 
+		 * be tested against the existing query vars.
+		 */
+		if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );
 		}
 

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -226,17 +226,10 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			if ( ! in_array( $join_clause, $this->query_vars['join'], true ) ) {
 				$this->query_vars['join'][] = $join_clause;
 			}
-		//} else if ( ! empty( $this->query_vars['join'] ) ) {
-		//	$join = $this->deduplicate_joins( $join );
 		}
 
 		/*
-		 * Fix for php error "WordPress database error Not unique table/alias: 'wp_tec_occurrences' 
-   		 * for query SELECT SQL_CALC_FOUND_ROWS..."
-		 *
-		 * Moved from above 'else if'. Function filter_posts_join needs to check for dups regardless of 
-		 * whether or not there are any redirects because the external join from wp_query still needs to 
-		 * be tested against the existing query vars.
+		 * @since TBD Changed from 'else if' to `if`.
 		 */
 		if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1562]

### 🗒️ Description

Bug fix: php error "WordPress database error Not unique table/alias: 'wp_tec_occurrences' for query SELECT SQL_CALC_FOUND_ROWS..."

Function `filter_posts_join` needs to check for dups regardless of whether or not there are any redirects because the external join from `wp_query` still needs to be tested against the existing query vars.

I initially posted a query about this on the WordPress forum: https://wordpress.org/support/topic/not-unique-table-alias-wp-tec_occurrences-2/#post-17856396. The response I received from Jes referred to bug report [ECP-1562]. I'm not sure if that's the same thing as a ticket ID, so apologies if that info is inaccurate.

What follows is an overview of how I came to this solution, in case it's useful to you. There are three separate instances where a JOIN clause is being created for table wp_tec_occurrences:

1. The first instance is created via class `WP_Query`, `function get_sql(); $clauses = $this->meta_query->get_sql( 'post', $wpdb->posts, 'ID', $this )`. The meta_query `get_sql()` calls `get_sql_clauses()`, which calls `get_sql_for_clauses()`. The latter function is overridden by TEC class `Custom_Table_Meta_Query` extension, using `get_sql_for_clauses()` to create an `INNER JOIN` on `wp_tec_occurrences`. There is a check for duplicate clauses here (`array $joined_tables`), but only within the class. `WP_Query` later passes this `INNER JOIN` clause on via argument `$join` to the two callback functions described below.
2. The second instance is the result of `WP_Query` invoking a callback function for filter hook `posts_join` using `apply_filters_ref_array()`. TEC class `Custom_Tables_Query`, an extension of `WP_Query`, creates the callback function `join_occurrences_table()`. This function reviews the `$join` parameter passed from `WP_Query` to make sure it does not add a duplicate join clause. If no duplicate is found, it adds the new clause to `$join`.
3. A third instance is invoked via the same filter hook described in Instance 2 (`posts_join`). In this case, TEC class `Tribe__Repository__Query_Filters`, function `join()`, creates a callback for function `filter_posts_join()` using hook `posts_join`. TEC extension class `Custom_Tables_Query_Filters` overrides this function, using `filters_post_join()` to create another `JOIN` on `wp_tec_occurrences`. There is a check for duplicate clauses here (`function deduplicate_joins()`), but it only runs under certain conditions. The duplicate test is excluded when there are no existing redirects, even though this condition results in the creation of a new `JOIN` on `wp_tec_occurrences`. Regardless of the redirects count, `deduplicate_joins() `should be called prior to return if CTQF variable `$query_vars['join']` is not empty.

### 🎥 Artifacts 

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ECP-1562]: https://stellarwp.atlassian.net/browse/ECP-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ