### PR TITLE
[TEC-5119] Incorrect variable used on settings page

### DIFF
--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -116,9 +116,9 @@ $tec_events_general_toc = [
  *
  * @since TBD
  *
- * @param array $tec_events_display_toc Array of items of the TOC.
+ * @param array $tec_events_general_toc Array of items of the TOC.
  */
-$tec_events_display_fields += apply_filters( 'tec_events_display_settings_toc', $tec_events_display_toc );
+$tec_events_display_fields += apply_filters( 'tec_events_display_settings_toc', $tec_events_general_toc );
 
 // Start the form content wrapper.
 $tec_events_general_form_end = [


### PR DESCRIPTION
Fixed an issue where the variable used for the filter `tec_events_display_settings_toc` was incorrect and didn't exist. Switched to using the original field `$tec_events_general_toc`.