### PR TITLE
Create an option to allow duplicate venue creation

### DIFF
--- a/changelog/fix-TEC-4941-dont-overwrite-existing-venue
+++ b/changelog/fix-TEC-4941-dont-overwrite-existing-venue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add an option to allow for duplicate Venue creation as part of creating/editing Events.

--- a/src/Tribe/Venue.php
+++ b/src/Tribe/Venue.php
@@ -427,7 +427,10 @@ class Tribe__Events__Venue extends Tribe__Events__Linked_Posts__Base { // phpcs:
 			unset( $data['VenueID'] );
 		}
 
-		return $this->create( $data, $post_status, true );
+		// Check the option for whether duplicate venues are allowed.
+		$avoid_duplicates = ! tribe_get_option( 'allow_duplicate_venues', false );
+
+		return $this->create( $data, $post_status, $avoid_duplicates );
 	}
 
 	/**

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -322,6 +322,13 @@ $tec_events_general_editing = [
 		'default'         => true,
 		'validation_type' => 'boolean',
 	],
+	'allow_duplicate_venues'                    => [
+		'type'            => 'checkbox_bool',
+		'label'           => esc_html__( 'Allow duplicate Venues', 'the-events-calendar' ),
+		'tooltip'         => esc_html__( 'Allow the creation of duplicate Venues.', 'the-events-calendar' ),
+		'default'         => false,
+		'validation_type' => 'boolean',
+	],
 ];
 
 $general_tab_fields += apply_filters( 'tribe_general_settings_editing_section', $tec_events_general_editing );

--- a/tests/wpunit/Tribe/Events/VenueTest.php
+++ b/tests/wpunit/Tribe/Events/VenueTest.php
@@ -356,7 +356,14 @@ class VenueTest extends Events_TestCase {
 		$venue_3       = $venue->save( false, $data, false, 'publish' );
 
 		$this->assertNotEquals( $venue_1, $venue_3, 'Venue should not have the same ID' );
-		$this->assertNotEquals( tribe_get_address( $venue_1 ), tribe_get_address( $venue_3 ), 'Venue address should not be updated' );
+
+		// Address of 1 and 2 should still be the same
+		$this->assertEquals( tribe_get_full_address( $venue_1 ), tribe_get_full_address( $venue_2 ), 'Venue address should be the same' );
+
+		// City, State, and Zip of 1 and 3 should be different.
+		$this->assertNotEquals( tribe_get_city( $venue_1 ), tribe_get_city( $venue_3 ), 'Venue city should be different' );
+		$this->assertNotEquals( tribe_get_state( $venue_1 ), tribe_get_state( $venue_3 ), 'Venue state should be different' );
+		$this->assertNotEquals( tribe_get_zip( $venue_1 ), tribe_get_zip( $venue_3 ), 'Venue zip should be different' );
 
 		// Disable the filter after we're done.
 		remove_filter( 'tribe_get_option_allow_duplicate_venues', '__return_true' );

--- a/tests/wpunit/Tribe/Events/VenueTest.php
+++ b/tests/wpunit/Tribe/Events/VenueTest.php
@@ -11,6 +11,14 @@ use Tribe__Events__Venue as Venue;
  * Really a proxy to test the base class.
  */
 class VenueTest extends Events_TestCase {
+
+	/**
+	 * Cleanup after the tests finish running.
+	 */
+	public static function wpTearDownAfterClass() {
+		remove_all_filters( 'tribe_get_option_allow_duplicate_venues' );
+	}
+
 	/**
 	 * It should allow searching like in title
 	 * @test
@@ -313,5 +321,44 @@ class VenueTest extends Events_TestCase {
 
 		$this->assertEquals( $venue_3, $venue_4, 'Venue should be updated keeping the same ID' );
 		$this->assertEquals( tribe_get_address( $venue_3 ), tribe_get_address( $venue_4 ), 'Venue address should be updated properly' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_duplicate_venues_when_the_option_is_enabled() {
+		$venue = $this->make_instance();
+
+		add_filter( 'tribe_get_option_allow_duplicate_venues', '__return_true' );
+
+		$data = [
+			'Venue'         => 'Test Venue A',
+			'Description'   => 'This is Venue A ',
+			'Address'       => 'Road A',
+			'City'          => 'Providence',
+			'Province'      => 'Rhode Island',
+			'State'         => 'NewYork',
+			'StateProvince' => '',
+			'Zip'           => '09090',
+			'Phone'         => 883383,
+		];
+
+		// Using same data should return different venues.
+		$venue_1 = $venue->save( false, $data, false, 'publish' );
+		$venue_2 = $venue->save( false, $data, false, 'publish' );
+
+		$this->assertNotEquals( $venue_1, $venue_2, 'Venue ID should not be same for same data when duplicates are allowed.' );
+
+		// Using same title with different address should NOT update the existing venue.
+		$data['City']  = 'Austin';
+		$data['State'] = 'Texas';
+		$data['Zip']   = '123';
+		$venue_3       = $venue->save( false, $data, false, 'publish' );
+
+		$this->assertNotEquals( $venue_1, $venue_3, 'Venue should not have the same ID' );
+		$this->assertNotEquals( tribe_get_address( $venue_1 ), tribe_get_address( $venue_3 ), 'Venue address should not be updated' );
+
+		// Disable the filter after we're done.
+		remove_filter( 'tribe_get_option_allow_duplicate_venues', '__return_true' );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4941]

### 🗒️ Description

#3285 Introduced some changes to how Venues are handled when an Event is created or updated. Previously, if you did not choose an existing Venue, it was possible to create a new Venue that was a duplicate of an existing Venue. After that PR, some logic was introduced to prevent duplicate Venues from being created. If you created a "new" Venue with the same title as an existing Venue, the existing Venue would be updated.

Since [TEC-4941] includes feedback that the previous behavior is desirable for some users, I thought that adding a setting for users to choose would be the best option of both approaches. Users who like the current duplicate prevention do not need to do anything, and nothing will change. Users who would like to have duplicate Venues can change the option, and they will see the behavior of Venues change to allow duplicates.

### 🎥 Artifacts <!-- if applicable-->

<img width="973" alt="Screenshot 2024-08-06 at 17 24 57" src="https://github.com/user-attachments/assets/e26b5736-969f-41ef-becf-79866cf3a05a">


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[TEC-4941]: https://stellarwp.atlassian.net/browse/TEC-4941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEC-4941]: https://stellarwp.atlassian.net/browse/TEC-4941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ