### PR TITLE
Docblocks for methods in the `Tribe__Events__Importer__Column_Mapper` class

### DIFF
--- a/changelog/fix-docblock-column-mapper-get_column_label
+++ b/changelog/fix-docblock-column-mapper-get_column_label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add docblocks to the methods in the `Tribe__Events__Importer__Column_Mapper` class.

--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -49,6 +49,15 @@ class Tribe__Events__Importer__Column_Mapper {
 		return $html;
 	}
 
+	/**
+	 * Get the label of a column.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param string $key The array key of the column for which we need the label.
+	 *
+	 * @return mixed|string The label of the column, or an empty string if column is not found.
+	 */
 	public function get_column_label( $key ) {
 		if ( isset( $this->column_names[ $key ] ) ) {
 			return $this->column_names[ $key ];

--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -141,6 +141,13 @@ class Tribe__Events__Importer__Column_Mapper {
 		return apply_filters( 'tribe_events_importer_venue_column_names', $column_names );
 	}
 
+	/**
+	 * Retrieve column names for organizer import.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return mixed|null
+	 */
 	private function get_organizer_column_names() {
 		$column_names = array(
 			'organizer_name'        => esc_html__( 'Organizer Name', 'the-events-calendar' ),

--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -111,6 +111,13 @@ class Tribe__Events__Importer__Column_Mapper {
 		return apply_filters( 'tribe_events_importer_event_column_names', $column_names );
 	}
 
+	/**
+	 * Retrieve column names for venue import.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return mixed|null
+	 */
 	private function get_venue_column_names() {
 		$column_names = array(
 			'venue_name'        => esc_html__( 'Venue Name', 'the-events-calendar' ),

--- a/src/Tribe/Importer/Column_Mapper.php
+++ b/src/Tribe/Importer/Column_Mapper.php
@@ -66,6 +66,13 @@ class Tribe__Events__Importer__Column_Mapper {
 		return '';
 	}
 
+	/**
+	 * Retrieve column names for event import.
+	 *
+	 * @since 3.2.0
+	 *
+	 * @return mixed|null
+	 */
 	private function get_event_column_names() {
 		$column_names = array(
 			'event_name'              => esc_html__( 'Event Name', 'the-events-calendar' ),


### PR DESCRIPTION
Add docblocks to the following methods in the `Tribe__Events__Importer__Column_Mapper` class.
* `get_column_label()`
* `get_event_column_names()`
* `get_venue_column_names()`
* `get_organizer_column_names()`