### PR TITLE
Missing Timezone settings

### DIFF
--- a/src/Tribe/Admin/Timezone_Settings.php
+++ b/src/Tribe/Admin/Timezone_Settings.php
@@ -10,7 +10,7 @@ class Tribe__Events__Admin__Timezone_Settings {
 	public function __construct() {
 		$this->listen();
 		add_action( 'wp_ajax_tribe_timezone_update', [ $this, 'ajax_updater' ] );
-		add_filter( 'tribe_display_settings_date_section', [ $this, 'settings_ui' ], 20 );
+		add_filter( 'tec_events_settings_display_date_time_section', [ $this, 'settings_ui' ], 20 );
 	}
 
 	/**
@@ -20,7 +20,7 @@ class Tribe__Events__Admin__Timezone_Settings {
 	 * events then only the update tool will be exposed in this area, in all other cases this
 	 * is not exposed and the ordinary timezone settings will be visible.
 	 *
-	 * @param array $display_settings
+	 * @param $display_settings
 	 *
 	 * @return array
 	 */

--- a/src/Tribe/Admin/Timezone_Settings.php
+++ b/src/Tribe/Admin/Timezone_Settings.php
@@ -20,9 +20,9 @@ class Tribe__Events__Admin__Timezone_Settings {
 	 * events then only the update tool will be exposed in this area, in all other cases this
 	 * is not exposed and the ordinary timezone settings will be visible.
 	 *
-	 * @param $display_settings
+	 * @param array $display_settings The settings array for the Display->Date & Time sub-tab.
 	 *
-	 * @return array
+	 * @return array $display_settings The settings array with timezone settings added
 	 */
 	public function settings_ui( array $display_settings ) {
 		$updater = new Tribe__Events__Admin__Timezone_Updater;

--- a/src/admin-views/tribe-options-imports.php
+++ b/src/admin-views/tribe-options-imports.php
@@ -691,7 +691,7 @@ if ( $show_all_ea_settings ) {
 	$fields[] = $event_aggregator_control;
 }
 
-return new Tribe__Settings_Tab(
+$imports_tab = new Tribe__Settings_Tab(
 	'imports',
 	esc_html__( 'Imports', 'the-events-calendar' ),
 	[
@@ -699,3 +699,14 @@ return new Tribe__Settings_Tab(
 		'fields'   => $fields,
 	]
 );
+
+/**
+ * Fires after the imports settings tab has been created.
+ *
+ * @since TBD
+ *
+ * @param Tribe__Settings_Tab $imports_tab The imports settings tab.
+ */
+do_action( 'tec_events_settings_tab_imports', $imports_tab );
+
+return $imports_tab;


### PR DESCRIPTION
This fixes the timezone settings being dropped from the Display->Date & Time subtab.

[TEC-5126]

Fixed:
<img width="1099" alt="Screenshot 2024-08-26 at 5 17 22 PM" src="https://github.com/user-attachments/assets/428b61bb-dd26-440a-91b5-400e00145e74">



[TEC-5126]: https://stellarwp.atlassian.net/browse/TEC-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ