### PR TITLE
[ECP-1562] Update `Custom_Tables_Query_Filters.php` Logic

### DIFF
--- a/changelog/fix-ecp-1562_update_custom_tables_query_filters
+++ b/changelog/fix-ecp-1562_update_custom_tables_query_filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Changed logic within the custom tables query to avoid a database error. (props @datadiver0x0) [ECP-1562]

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -200,6 +200,7 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 	 * to the custom tables.
 	 *
 	 * @since 6.0.0
+	 * @since TBD Changed from 'else if' to `if` for handling deduplication of join clauses.
 	 *
 	 * {@inheritdoc}
 	 */
@@ -228,9 +229,6 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			}
 		}
 
-		/*
-		 * @since TBD Changed from 'else if' to `if`.
-		 */
 		if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );
 		}

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -226,7 +226,12 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			if ( ! in_array( $join_clause, $this->query_vars['join'], true ) ) {
 				$this->query_vars['join'][] = $join_clause;
 			}
-		} else if ( ! empty( $this->query_vars['join'] ) ) {
+		}
+
+		/*
+		 * @since TBD Changed from 'else if' to `if`.
+		 */
+		if ( ! empty( $this->query_vars['join'] ) ) {
 			$join = $this->deduplicate_joins( $join );
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1562]

### 🗒️ Description

From original PR #4651  : 
Bug fix: php error "WordPress database error Not unique table/alias: 'wp_tec_occurrences' for query SELECT SQL_CALC_FOUND_ROWS..."

Function filter_posts_join needs to check for dups regardless of whether or not there are any redirects because the external join from wp_query still needs to be tested against the existing query vars.

I initially posted a query about this on the WordPress forum: [wordpress.org/support/topic/not-unique-table-alias-wp-tec_occurrences-2#post-17856396](https://wordpress.org/support/topic/not-unique-table-alias-wp-tec_occurrences-2/#post-17856396). The response I received from Jes referred to bug report [ECP-1562](https://stellarwp.atlassian.net/browse/ECP-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ). I'm not sure if that's the same thing as a ticket ID, so apologies if that info is inaccurate.

What follows is an overview of how I came to this solution, in case it's useful to you. There are three separate instances where a JOIN clause is being created for table wp_tec_occurrences:

The first instance is created via class WP_Query, function get_sql(); $clauses = $this->meta_query->get_sql( 'post', $wpdb->posts, 'ID', $this ). The meta_query get_sql() calls get_sql_clauses(), which calls get_sql_for_clauses(). The latter function is overridden by TEC class Custom_Table_Meta_Query extension, using get_sql_for_clauses() to create an INNER JOIN on wp_tec_occurrences. There is a check for duplicate clauses here (array $joined_tables), but only within the class. WP_Query later passes this INNER JOIN clause on via argument $join to the two callback functions described below.
The second instance is the result of WP_Query invoking a callback function for filter hook posts_join using apply_filters_ref_array(). TEC class Custom_Tables_Query, an extension of WP_Query, creates the callback function join_occurrences_table(). This function reviews the $join parameter passed from WP_Query to make sure it does not add a duplicate join clause. If no duplicate is found, it adds the new clause to $join.
A third instance is invoked via the same filter hook described in Instance 2 (posts_join). In this case, TEC class Tribe__Repository__Query_Filters, function join(), creates a callback for function filter_posts_join() using hook posts_join. TEC extension class Custom_Tables_Query_Filters overrides this function, using filters_post_join() to create another JOIN on wp_tec_occurrences. There is a check for duplicate clauses here (function deduplicate_joins()), but it only runs under certain conditions. The duplicate test is excluded when there are no existing redirects, even though this condition results in the creation of a new JOIN on wp_tec_occurrences. Regardless of the redirects count, deduplicate_joins() should be called prior to return if CTQF variable $query_vars['join'] is not empty.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ECP-1562]: https://stellarwp.atlassian.net/browse/ECP-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ