### PR TITLE
Latest Past Events list in Category Views

### DIFF
--- a/changelog/BTRIA-2353
+++ b/changelog/BTRIA-2353
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Adding small adjustment to WPML integration to allow for location searches on a translated site. (props to @dgwatkins) [BTRIA-2353]

--- a/changelog/docblock-column-mapper-set_defaults
+++ b/changelog/docblock-column-mapper-set_defaults
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add docblock for `set_defaults()` in the Tribe__Events__Importer__Column_Mapper class.

--- a/changelog/fix-Latest_Past_Events_Categories
+++ b/changelog/fix-Latest_Past_Events_Categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Latest Past Events appearing properly in Category views [TEC-4991]

--- a/changelog/fix-TEC-4941-dont-overwrite-existing-venue
+++ b/changelog/fix-TEC-4941-dont-overwrite-existing-venue
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Add an option to allow for duplicate Venue creation as part of creating/editing Events.

--- a/changelog/fix-TEC-5105-fix-rest-api-disabled-notice
+++ b/changelog/fix-TEC-5105-fix-rest-api-disabled-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update the logic that displays the "REST API blocked" banner to reduce false positives. [TEC-5105]

--- a/changelog/fix-docblock-column-mapper-get_column_label
+++ b/changelog/fix-docblock-column-mapper-get_column_label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add docblocks to the methods in the `Tribe__Events__Importer__Column_Mapper` class.

--- a/changelog/fix-docblock-make_select_box
+++ b/changelog/fix-docblock-make_select_box
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add docblock for make_select_box()

--- a/changelog/fix-docblock-tribe_embed_google_map
+++ b/changelog/fix-docblock-tribe_embed_google_map
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update the docblock of the `tribe_embed_google_map()` method, change a variable name to match current naming conventions, and added a docblock to the `tribe_embed_google_map` filter.

--- a/changelog/fix-docblock-tribe_get_listview_dir_link
+++ b/changelog/fix-docblock-tribe_get_listview_dir_link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Add information and missing tags to `tribe_get_listview_dir_link()` docblock.

--- a/changelog/fix-docblock-tribe_get_listview_link
+++ b/changelog/fix-docblock-tribe_get_listview_link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Add information and missing tags to `tribe_get_listview_link()` docblock.

--- a/changelog/fix-docblock-tribe_get_listview_past_link
+++ b/changelog/fix-docblock-tribe_get_listview_past_link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Add information and missing tags to `tribe_get_listview_past_link()` docblock.

--- a/changelog/fix-docblock-tribe_show_google_map_link
+++ b/changelog/fix-docblock-tribe_show_google_map_link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update the docblock of the `tribe_embed_google_map_link()` method, change a variable name to match current naming conventions, and added a docblock to the `tribe_embed_google_map_link` filter.

--- a/changelog/fix-ecp-1562_update_custom_tables_query_filters
+++ b/changelog/fix-ecp-1562_update_custom_tables_query_filters
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Changed logic within the custom tables query to avoid a database error. (props @datadiver0x0) [ECP-1562]

--- a/changelog/tweak-make-string-in-settings-translatable
+++ b/changelog/tweak-make-string-in-settings-translatable
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Made a string translatable in `settings.php` file. (props to @DAnn2012) [TECTRIA-292]

--- a/changelog/tweak-make-string-in-settings-translatable 
+++ b/changelog/tweak-make-string-in-settings-translatable 
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Made a string translatable in `settings.php` file. (props to @DAnn2012) [TECTRIA-292]

--- a/src/Tribe/Views/V2/Views/Latest_Past_View.php
+++ b/src/Tribe/Views/V2/Views/Latest_Past_View.php
@@ -14,7 +14,7 @@ use Tribe__Context;
 
 class Latest_Past_View extends List_View {
 	use With_Noindex;
-  
+
 	/**
 	 * Slug for this view
 	 *
@@ -171,7 +171,7 @@ class Latest_Past_View extends List_View {
 	 * {@inheritDoc}
 	 */
 	protected function setup_repository_args( Tribe__Context $context = null ) {
-		$context = null !== $context ? $context : $this->context;
+		$context = null !== $context ?: $this->context;
 		$args    = parent::setup_repository_args( $context );
 
 		$args['posts_per_page'] = $this->context->get( 'latest_past_per_page', 3 );

--- a/src/Tribe/Views/V2/Views/Latest_Past_View.php
+++ b/src/Tribe/Views/V2/Views/Latest_Past_View.php
@@ -171,14 +171,15 @@ class Latest_Past_View extends List_View {
 	 * {@inheritDoc}
 	 */
 	protected function setup_repository_args( Tribe__Context $context = null ) {
-		$context          = null !== $context ? $context : $this->context;
-		$this->repository = tribe_events();
+		$context = null !== $context ? $context : $this->context;
+		$args    = parent::setup_repository_args( $context );
 
-		$date                   = $context->get( 'event_date', 'now' );
 		$args['posts_per_page'] = $this->context->get( 'latest_past_per_page', 3 );
 		$args['order_by']       = 'event_date';
 		$args['order']          = 'DESC';
-		$args['ends_before']    = $date;
+		$args['ends_before']    = tribe_beginning_of_day( current_time( 'mysql' ) );
+
+		unset( $args['ends_after'] );
 
 		return $args;
 	}

--- a/src/views/v2/latest-past.php
+++ b/src/views/v2/latest-past.php
@@ -13,6 +13,10 @@
  *
  * @var array $events The array containing the events.
  */
+
+if ( count( $events ) === 0 ) {
+	return;
+}
 ?>
 <div class="tribe-events-calendar-latest-past">
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4991]

### 🗒️ Description
When in the Events page and no current of future events exist, we shoe a Latest Past Events list below the calendar with previous events. If we are in a category archive then that Past Events list should be from the same queried object.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-4991]: https://stellarwp.atlassian.net/browse/TEC-4991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ