### PR TITLE
Docblocks: `Tribe__Events__Repositories__Organizer` class

### DIFF
--- a/changelog/fix-docblocks-Tribe__Events__Repositories__Organizer
+++ b/changelog/fix-docblocks-Tribe__Events__Repositories__Organizer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Updated docblocks in the `Tribe__Events__Repositories__Organizer` class
+Updated the docblocks in the `Tribe__Events__Repositories__Organizer` class.

--- a/changelog/fix-docblocks-Tribe__Events__Repositories__Organizer
+++ b/changelog/fix-docblocks-Tribe__Events__Repositories__Organizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updated docblocks in the `Tribe__Events__Repositories__Organizer` class

--- a/src/Tribe/Repositories/Organizer.php
+++ b/src/Tribe/Repositories/Organizer.php
@@ -74,13 +74,11 @@ class Tribe__Events__Repositories__Organizer extends Tribe__Events__Repositories
 	}
 
 	/**
-	 * Filters a organizer query by ones that have associated events.
+	 * Filters the organizer query by ones that have associated events.
 	 *
 	 * @since 5.5.0
-	 *
-	 * @return array An array of query arguments that will be added to the main query.
 	 */
-	public function filter_by_has_events() {
+	public function filter_by_has_events(): void {
 		global $wpdb;
 
 		$this->filter_query->join(
@@ -96,13 +94,11 @@ class Tribe__Events__Repositories__Organizer extends Tribe__Events__Repositories
 	}
 
 	/**
-	 * Filters a organizer query by ones that DO NOT have associated events.
+	 * Filters the organizer query by ones that DO NOT have associated events.
 	 *
 	 * @since 5.5.0
-	 *
-	 * @return array An array of query arguments that will be added to the main query.
 	 */
-	public function filter_by_has_no_events() {
+	public function filter_by_has_no_events(): void {
 		global $wpdb;
 
 		$this->filter_query->where(


### PR DESCRIPTION
Update the docblocks in the `Tribe__Events__Repositories__Organizer` class.