### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   workflow_dispatch:
     paths:
+      - '.github/**/*'
       - 'src/modules/**.js'
       - 'src/resources/js/**.js'
       - 'src/resources/postcss/**.pcss'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,8 +2,9 @@ name: 'PHPStan Tests'
 on:
   pull_request:
     paths:
-      - 'src/**.php'
+      - '.github/**/*'
       - '*.php'
+      - 'src/**.php'
 jobs:
   phpstan:
     strategy:

--- a/.github/workflows/tests-integrations.yml
+++ b/.github/workflows/tests-integrations.yml
@@ -2,13 +2,13 @@ name: 'Third-Party Integration Tests'
 on:
   pull_request:
     paths:
-      - 'tests/**.php'
-      - 'src/**.php'
+      - '.github/**/*'
       - '*.php'
+      - 'codeception.dist.yml'
       - 'composer.json'
       - 'composer.lock'
-      - 'codeception.dist.yml'
-      - '.github/workflows/tests-integrations.yaml'
+      - 'src/**.php'
+      - 'tests/**.php'
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests-integrations.yml
+++ b/.github/workflows/tests-integrations.yml
@@ -21,7 +21,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -34,17 +34,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -2,6 +2,7 @@ name: 'npm jest'
 on:
   pull_request:
     paths:
+      - '.github/**/*'
       - 'src/modules/**.js'
 jobs:
   jest:

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/tests-php-seo-plugin.yml
+++ b/.github/workflows/tests-php-seo-plugin.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive
@@ -37,17 +37,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic

--- a/.github/workflows/tests-php-seo-plugin.yml
+++ b/.github/workflows/tests-php-seo-plugin.yml
@@ -2,13 +2,13 @@ name: 'SEO Plugin Tests'
 on:
   pull_request:
     paths:
-      - 'tests/**.php'
-      - 'src/**.php'
+      - '.github/**/*'
       - '*.php'
+      - 'codeception.dist.yml'
       - 'composer.json'
       - 'composer.lock'
-      - 'codeception.dist.yml'
-      - '.github/workflows/tests-php-seo-plugin.yml'
+      - 'src/**.php'
+      - 'tests/**.php'
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive
@@ -59,17 +59,20 @@ jobs:
         run: |
           num_php_files=$(git diff ${{ github.event.pull_request.base.sha }} HEAD --name-only | grep -P "\.php" | wc -l)
           if [[ -z "$num_php_files" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           elif [[ "$num_php_files" == "0" || "$num_php_files" == "" ]]; then
-            echo "::set-output name=value::1"
+            echo "value=1" >> $GITHUB_OUTPUT
+            echo "## No PHP Files changed, PHP tests automatically pass." >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=value::0"
+            echo "value=0" >> $GITHUB_OUTPUT
+            echo "## Found PHP file changes, running PHP tests." >> $GITHUB_STEP_SUMMARY
           fi
       # ------------------------------------------------------------------------------
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -2,14 +2,14 @@ name: 'Codeception Tests'
 on:
   pull_request:
     paths:
-      - 'tests/**.php'
-      - 'src/**.php'
+      - '.github/**/*'
       - '*.php'
+      - 'codeception.dist.yml'
       - 'composer.json'
       - 'composer.lock'
-      - 'codeception.dist.yml'
-      - '.github/workflows/tests-php.yaml'
       - 'package.json'
+      - 'src/**.php'
+      - 'tests/**.php'
 jobs:
   test:
     strategy:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -45,7 +45,7 @@ jobs:
       # Checkout the repo
       # ------------------------------------------------------------------------------
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           token: ${{ secrets.GH_BOT_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       # Checkout the tut
       # ------------------------------------------------------------------------------
       - name: Checkout tut
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
           repository: the-events-calendar/tut
@@ -78,7 +78,7 @@ jobs:
           path: tut
           fetch-depth: 1
       - name: Checkout jenkins-scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_BOT_TOKEN }}
           repository: the-events-calendar/jenkins-scripts


### PR DESCRIPTION
to avoid issues with deprecated artifact upload/download actions.

Add summary output to test skip check.

Requires: https://github.com/the-events-calendar/tribe-common/pull/2203