### PR TITLE
Cover date and time range separator template tags with tests

### DIFF
--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -186,9 +186,11 @@ if ( ! function_exists( 'tec_events_get_time_range_separator' ) ) {
 		$cache                = tribe_cache();
 		$is_cache_set         = isset( $cache['tec_events_get_time_range_separator'] );
 		$time_range_separator = $cache['tec_events_get_time_range_separator'];
-		if ( $is_cache_set ) {
+
+		if ( $is_cache_set && is_string( $time_range_separator ) ) {
 			return $time_range_separator;
 		}
+
 		$default              = ' - ';
 		$time_range_separator = tribe_get_option( 'timeRangeSeparator', $default );
 
@@ -226,9 +228,11 @@ if ( ! function_exists( 'tec_events_get_date_time_separator' ) ) {
 		$cache                    = tribe_cache();
 		$is_cache_set             = isset( $cache['tec_events_get_date_time_separator'] );
 		$datetime_range_separator = $cache['tec_events_get_date_time_separator'];
-		if ( $is_cache_set ) {
+
+		if ( $is_cache_set && is_string( $datetime_range_separator ) ) {
 			return $datetime_range_separator;
 		}
+
 		$default              = ' @ ';
 		$datetime_range_separator = tribe_get_option( 'dateTimeSeparator', $default );
 

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_no_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_no_custom_classes__1.php
@@ -4,7 +4,7 @@
 					</span>
 
 					<span class="tribe-events-schedule__separator tribe-events-schedule__separator--date">
-				 - 			</span>
+				 @ 			</span>
 			<span class="tribe-events-schedule__time tribe-events-schedule__time--start">
 							</span>
 		

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_with_multiple_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_with_multiple_custom_classes__1.php
@@ -4,7 +4,7 @@
 					</span>
 
 					<span class="tribe-events-schedule__separator tribe-events-schedule__separator--date">
-				 - 			</span>
+				 @ 			</span>
 			<span class="tribe-events-schedule__time tribe-events-schedule__time--start">
 							</span>
 		

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_with_single_custom_class__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/EventDatetimeTest__test_render_with_single_custom_class__1.php
@@ -4,7 +4,7 @@
 					</span>
 
 					<span class="tribe-events-schedule__separator tribe-events-schedule__separator--date">
-				 - 			</span>
+				 @ 			</span>
 			<span class="tribe-events-schedule__time tribe-events-schedule__time--start">
 							</span>
 		

--- a/tests/wpunit/functions/template-tags/date_Test.php
+++ b/tests/wpunit/functions/template-tags/date_Test.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace TEC\Test\functions\template_tags;
+
+use Codeception\TestCase\WPTestCase;
+
+class Date_Test extends WPTestCase {
+	private array $tribe_options = [];
+
+	/**
+	 * @before
+	 * @after
+	 */
+	public function reset_options_cache(): void {
+		tribe_set_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME, null );
+	}
+
+	public function test_tec_events_get_time_range_separator_returns_default_when_option_not_set(): void {
+		$output = tec_events_get_time_range_separator();
+
+		$this->assertEquals( ' - ', $output );
+	}
+
+	public function tec_events_get_time_range_separator_data_provider(): array {
+		return [
+			'empty separator'   => [ '', '' ],
+			'null separator'    => [ null, '' ],
+			'default separator' => [ ' - ', ' - ' ],
+			'custom separator'  => [ '|', '|' ],
+			'numeric separator' => [ '1', '1' ],
+			'script'            => [ '<script>alert("Hello")</script>', 'alert("Hello")' ],
+			'allowed html tag'  => [ ' <strong> - </strong> ', ' <strong> - </strong> ' ],
+			'script in img tag' => [
+				'<img onload="alert(\'Hello\')" src="not-really" onerror="alert(\'Error\')">',
+				'<img src="not-really">'
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider tec_events_get_time_range_separator_data_provider
+	 */
+	public function test_tec_events_get_time_range_separator( $separator, string $expected ): void {
+		tribe_update_option( 'timeRangeSeparator', $separator );
+		$output = tec_events_get_time_range_separator();
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	public function test_tec_events_get_time_range_separator_protects_from_cache_poisoning(): void {
+		$cache                                        = tribe_cache();
+		$cache['tec_events_get_time_range_separator'] = (object) [ 'value' => ' foo ' ];
+
+		$output = tec_events_get_time_range_separator();
+
+		$this->assertEquals( ' - ', $output );
+
+		$cache['tec_events_get_time_range_separator'] = new class {
+			public function __toString() {
+				return ' foo ';
+			}
+		};
+
+		$output = tec_events_get_time_range_separator();
+
+		$this->assertEquals( ' - ', $output );
+	}
+
+	public function test_tec_events_get_date_time_separator_returns_default_when_option_not_set(): void {
+		$output = tec_events_get_date_time_separator();
+
+		$this->assertEquals( ' @ ', $output );
+	}
+
+	public function tec_events_get_date_time_separator_data_provider(): array {
+		return [
+			'empty separator'   => [ '', '' ],
+			'null separator'    => [ null, '' ],
+			'default separator' => [ ' @ ', ' @ ' ],
+			'custom separator'  => [ '|', '|' ],
+			'numeric separator' => [ '1', '1' ],
+			'script'            => [ '<script>alert("Hello")</script>', 'alert("Hello")' ],
+			'allowed html tag'  => [ ' <strong> @ </strong> ', ' <strong> @ </strong> ' ],
+			'script in img tag' => [
+				'<img onload="alert(\'Hello\')" src="not-really" onerror="alert(\'Error\')">',
+				'<img src="not-really">'
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider tec_events_get_date_time_separator_data_provider
+	 */
+	public function test_tec_events_get_date_time_separator( $separator, string $expected ): void {
+		tribe_update_option( 'dateTimeSeparator', $separator );
+		$output = tec_events_get_date_time_separator();
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	public function test_tec_events_get_date_time_separator_protects_from_cache_poisoning(): void {
+		$cache                                       = tribe_cache();
+		$cache['tec_events_get_date_time_separator'] = (object) [ 'value' => ' foo ' ];
+
+		$output = tec_events_get_date_time_separator();
+
+		$this->assertEquals( ' @ ', $output );
+
+		$cache['tec_events_get_date_time_separator'] = new class {
+			public function __toString() {
+				return ' foo ';
+			}
+		};
+
+		$output = tec_events_get_date_time_separator();
+	}
+}


### PR DESCRIPTION
Follow-up to the creation of the template tags to add test coverage and protect from cache poisoning.

