### PR TITLE
Ensure that Fix appears before Tweak in changelogs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,8 @@
       "types": {
         "version" : "Version",
         "feat" : "Feature",
-        "tweak" : "Tweak",
         "fix" : "Fix",
+        "tweak" : "Tweak",
         "performance" : "Performance",
         "security" : "Security",
         "accessibility" : "Accessibility",


### PR DESCRIPTION
I believe this is the key to adjusting the order (but I'm not entirely sure). The `Fix` type should appear above `Tweak`.