### PR TITLE
Fix order of past events in the list view

### DIFF
--- a/changelog/fix-tec-5309-past-events-order
+++ b/changelog/fix-tec-5309-past-events-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Order of past events in the list view when no future events exist. [TEC-5309]

--- a/src/Tribe/Views/V2/Views/Latest_Past_View.php
+++ b/src/Tribe/Views/V2/Views/Latest_Past_View.php
@@ -171,6 +171,7 @@ class Latest_Past_View extends List_View {
 	 * {@inheritDoc}
 	 */
 	protected function setup_repository_args( Tribe__Context $context = null ) {
+		$this->repository = tribe_events();
 		$context ??= $this->context;
 		$args    = parent::setup_repository_args( $context );
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
@@ -288,51 +288,6 @@
 		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
 
 	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
-	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
-		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
-			Feb		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
-			15		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
-			2020		</span>
-	</time>
-</div>
-
-	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
-			
-			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
-
-				<header class="tribe-events-calendar-latest-past__event-header">
-					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
-		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
-		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
-	</div>
-					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
-	<a
-		href="http://test.tri.be/?tribe_events=single-event-1"
-		title="Single Event 1"
-		rel="bookmark"
-		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
-	>
-		Single Event 1	</a>
-</h3>
-									</header>
-
-				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
-	<p>Snapshot event 23</p>
-</div>
-				
-			</div>
-		</article>
-	</div>
-
-</div>
-
-			
-		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
-
-	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-20" aria-hidden="true">
 		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
 			Feb		</span>
@@ -366,6 +321,51 @@
 
 				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
 	<p>Snapshot event 89</p>
+</div>
+				
+			</div>
+		</article>
+	</div>
+
+</div>
+
+			
+		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
+
+	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
+	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
+		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
+			Feb		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+			15		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
+			2020		</span>
+	</time>
+</div>
+
+	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+			
+			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
+
+				<header class="tribe-events-calendar-latest-past__event-header">
+					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
+		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
+		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
+	</div>
+					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
+	<a
+		href="http://test.tri.be/?tribe_events=single-event-1"
+		title="Single Event 1"
+		rel="bookmark"
+		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
+	>
+		Single Event 1	</a>
+</h3>
+									</header>
+
+				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
+	<p>Snapshot event 23</p>
 </div>
 				
 			</div>

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
@@ -288,51 +288,6 @@
 		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
 
 	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
-	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
-		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
-			Feb		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
-			15		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
-			2020		</span>
-	</time>
-</div>
-
-	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
-			
-			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
-
-				<header class="tribe-events-calendar-latest-past__event-header">
-					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
-		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
-		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
-	</div>
-					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
-	<a
-		href="http://test.tri.be/?tribe_events=single-event-1"
-		title="Single Event 1"
-		rel="bookmark"
-		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
-	>
-		Single Event 1	</a>
-</h3>
-									</header>
-
-				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
-	<p>Snapshot event 23</p>
-</div>
-				
-			</div>
-		</article>
-	</div>
-
-</div>
-
-			
-		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
-
-	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-20" aria-hidden="true">
 		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
 			Feb		</span>
@@ -366,6 +321,51 @@
 
 				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
 	<p>Snapshot event 89</p>
+</div>
+				
+			</div>
+		</article>
+	</div>
+
+</div>
+
+			
+		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
+
+	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
+	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
+		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
+			Feb		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+			15		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
+			2020		</span>
+	</time>
+</div>
+
+	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+			
+			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
+
+				<header class="tribe-events-calendar-latest-past__event-header">
+					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
+		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
+		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
+	</div>
+					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
+	<a
+		href="http://test.tri.be/?tribe_events=single-event-1"
+		title="Single Event 1"
+		rel="bookmark"
+		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
+	>
+		Single Event 1	</a>
+</h3>
+									</header>
+
+				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
+	<p>Snapshot event 23</p>
 </div>
 				
 			</div>

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
@@ -296,51 +296,6 @@
 		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
 
 	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
-	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
-		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
-			Feb		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
-			15		</span>
-		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
-			2020		</span>
-	</time>
-</div>
-
-	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
-		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
-			
-			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
-
-				<header class="tribe-events-calendar-latest-past__event-header">
-					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
-		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
-		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
-	</div>
-					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
-	<a
-		href="http://test.tri.be/?tribe_events=single-event-1"
-		title="Single Event 1"
-		rel="bookmark"
-		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
-	>
-		Single Event 1	</a>
-</h3>
-									</header>
-
-				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
-	<p>Snapshot event 23</p>
-</div>
-				
-			</div>
-		</article>
-	</div>
-
-</div>
-
-			
-		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
-
-	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
 	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-20" aria-hidden="true">
 		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
 			Feb		</span>
@@ -374,6 +329,51 @@
 
 				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
 	<p>Snapshot event 89</p>
+</div>
+				
+			</div>
+		</article>
+	</div>
+
+</div>
+
+			
+		<div  class="tribe-common-g-row tribe-events-calendar-latest-past__event-row" >
+
+	<div class="tribe-events-calendar-latest-past__event-date-tag tribe-common-g-col">
+	<time class="tribe-events-calendar-latest-past__event-date-tag-datetime" datetime="2020-02-15" aria-hidden="true">
+		<span class="tribe-events-calendar-latest-past__event-date-tag-month">
+			Feb		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-daynum tribe-common-h5 tribe-common-h4--min-medium">
+			15		</span>
+		<span class="tribe-events-calendar-latest-past__event-date-tag-year">
+			2020		</span>
+	</time>
+</div>
+
+	<div class="tribe-events-calendar-latest-past__event-wrapper tribe-common-g-col">
+		<article  class="tribe-events-calendar-latest-past__event tribe-common-g-row tribe-common-g-row--gutters post-23 tribe_events type-tribe_events status-publish hentry" >
+			
+			<div class="tribe-events-calendar-latest-past__event-details tribe-common-g-col">
+
+				<header class="tribe-events-calendar-latest-past__event-header">
+					<div class="tribe-events-calendar-latest-past__event-datetime-wrapper tribe-common-b2">
+		<time class="tribe-events-calendar-latest-past__event-datetime" datetime="2020-02-15">
+		<span class="tribe-event-date-start">February 15, 2020 @ 8:00 am</span> - <span class="tribe-event-time">5:00 pm</span>	</time>
+	</div>
+					<h3 class="tribe-events-calendar-latest-past__event-title tribe-common-h6 tribe-common-h4--min-medium">
+	<a
+		href="http://test.tri.be/?tribe_events=single-event-1"
+		title="Single Event 1"
+		rel="bookmark"
+		class="tribe-events-calendar-latest-past__event-title-link tribe-common-anchor-thin"
+	>
+		Single Event 1	</a>
+</h3>
+									</header>
+
+				<div class="tribe-events-calendar-latest-past__event-description tribe-common-b2 tribe-common-a11y-hidden">
+	<p>Snapshot event 23</p>
 </div>
 				
 			</div>


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5309]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fix order of past events in the list view when no future events exist. The order should be: the closer to the present past event appears first.

### 🎥 Artifacts <!-- if applicable-->

Using the updated code events are displayed from closer to now first.
![image](https://github.com/user-attachments/assets/a25a9b82-ccb5-42a7-a1f7-edfc52423eac)

Before the change you can see the issue in the loom below.
https://www.loom.com/share/63b99b41a5b849aaaca2fbe14659492b

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5309]: https://stellarwp.atlassian.net/browse/TEC-5309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ