### PR TITLE
Fix "Move to trash events older than" bug

### DIFF
--- a/changelog/TEC-5319-move-to-trash-bug
+++ b/changelog/TEC-5319-move-to-trash-bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+When using "Move to trash events older than", trashed imported events are now ignored. [TEC-5319]

--- a/changelog/TEC-5319-move-to-trash-bug
+++ b/changelog/TEC-5319-move-to-trash-bug
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fix
 
 When using "Move to trash events older than", trashed imported events are now ignored. [TEC-5319]

--- a/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
+++ b/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
@@ -36,7 +36,7 @@ class Event_Cleaner {
 			    	INNER JOIN {$occurrence_table} ON {$wpdb->posts}.ID = {$occurrence_table}.post_id
 				WHERE {$wpdb->posts}.post_type = %s
 					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %3s )
-					AND {$wpdb->posts}.post_status != 'trash'
+					AND {$wpdb->posts}.post_status NOT IN ( 'trash', 'tribe-ignored' )
 				GROUP BY {$occurrence_table}.post_id
 				HAVING COUNT(*) = 1
 				ORDER BY {$occurrence_table}.start_date_utc ASC, {$occurrence_table}.end_date_utc ASC

--- a/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
+++ b/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
@@ -35,12 +35,12 @@ class Event_Cleaner {
 		return "SELECT {$occurrence_table}.post_id
 				FROM {$wpdb->posts}
 			    	INNER JOIN {$occurrence_table} ON {$wpdb->posts}.ID = {$occurrence_table}.post_id
-				WHERE {$wpdb->posts}.post_type = %s
-					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %s )
+				WHERE {$wpdb->posts}.post_type = %1s
+					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %2d %4s )
 					AND {$wpdb->posts}.post_status NOT IN ( 'trash', 'tribe-ignored' )
 				GROUP BY {$occurrence_table}.post_id
 				HAVING COUNT(*) = 1
 				ORDER BY {$occurrence_table}.start_date_utc ASC, {$occurrence_table}.end_date_utc ASC
-				LIMIT %d";
+				LIMIT %3d";
 	}
 }

--- a/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
+++ b/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
@@ -35,12 +35,12 @@ class Event_Cleaner {
 		return "SELECT {$occurrence_table}.post_id
 				FROM {$wpdb->posts}
 			    	INNER JOIN {$occurrence_table} ON {$wpdb->posts}.ID = {$occurrence_table}.post_id
-				WHERE {$wpdb->posts}.post_type = %1s
-					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %2d %4s )
+				WHERE {$wpdb->posts}.post_type = " . '"%1$s"' . "
+					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL " . '%2$d %4$s' . " )
 					AND {$wpdb->posts}.post_status NOT IN ( 'trash', 'tribe-ignored' )
 				GROUP BY {$occurrence_table}.post_id
 				HAVING COUNT(*) = 1
 				ORDER BY {$occurrence_table}.start_date_utc ASC, {$occurrence_table}.end_date_utc ASC
-				LIMIT %3d";
+				LIMIT " . '%3$d';
 	}
 }

--- a/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
+++ b/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
@@ -36,7 +36,7 @@ class Event_Cleaner {
 				FROM {$wpdb->posts}
 			    	INNER JOIN {$occurrence_table} ON {$wpdb->posts}.ID = {$occurrence_table}.post_id
 				WHERE {$wpdb->posts}.post_type = %s
-					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %3s )
+					AND {$occurrence_table}.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %s )
 					AND {$wpdb->posts}.post_status NOT IN ( 'trash', 'tribe-ignored' )
 				GROUP BY {$occurrence_table}.post_id
 				HAVING COUNT(*) = 1

--- a/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
+++ b/src/Events/Custom_Tables/V1/Events/Event_Cleaner/Event_Cleaner.php
@@ -20,6 +20,7 @@ class Event_Cleaner {
 	 * recurring events.
 	 *
 	 * @since 6.0.13
+	 * @since TBD Adjust SQL to ignore trashed imported events during cleanup.
 	 *
 	 * @param string $sql The original query to retrieve expired events.
 	 *

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -173,15 +173,15 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 			FROM {$wpdb->posts} AS t1
 			INNER JOIN {$wpdb->postmeta} AS t2 ON t1.ID = t2.post_id
 			WHERE
-				t1.post_type = %s
+				t1.post_type = %1s
 				AND t2.meta_key = '_EventEndDate'
-				AND t2.meta_value <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %3s )
+				AND t2.meta_value <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %2d %4s )
 				AND t2.meta_value != 0
 				AND t2.meta_value != ''
 				AND t2.meta_value IS NOT NULL
 				AND t1.post_parent = 0
 				AND t1.ID NOT IN ( $posts_with_parents_sql )
-			LIMIT %d
+			LIMIT %3d
 		";
 
 		/**

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -182,8 +182,7 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 				AND t2.meta_value IS NOT NULL
 				AND t1.post_parent = 0
 				AND t1.ID NOT IN ( $posts_with_parents_sql )
-			LIMIT " . '%3$d'
-		;
+			LIMIT " . '%3$d';
 
 		/**
 		 * Filter - Allows users to manipulate the cleanup query

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -190,7 +190,7 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 		 *
 		 * @since 4.6.13
 		 * @since 6.0.13 Added a limit param to the default query.
-		 * @since 6.2.9 Added a mysql `interval` parameter (e.g. 'MONTH' or 'MINUTE'), to go in hand with the `date` field.
+		 * @since 6.2.9  Added a mysql `interval` parameter (e.g. 'MONTH' or 'MINUTE'), to go in hand with the `date` field.
 		 *
 		 * @param string $sql - The query statement.
 		 */
@@ -208,7 +208,7 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 		 *
 		 * @since 4.6.13
 		 * @since 6.0.13 Added a limit arg, defaulting to 100.
-		 * @since 6.2.9 Added a mysql `interval` field (e.g. 'MONTH' or 'MINUTE'), to go in hand with the `date` field.
+		 * @since 6.2.9  Added a mysql `interval` field (e.g. 'MONTH' or 'MINUTE'), to go in hand with the `date` field.
 		 *
 		 * @param array $args - The array of variables.
 		 */

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -198,8 +198,8 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 		$args = [
 			'post_type' => $event_post_type,
 			'date'      => $frequency,
-			'interval'  => $interval,
 			'limit'     => 15,
+			'interval'  => $interval,
 		];
 
 		/**

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -144,6 +144,7 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 	 *
 	 * @since 4.6.13
 	 * @since 6.0.13 Now batches each purge. By default, it limits to 15 occurrences.
+	 * @since 6.2.9  Add an optional 'frequency|interval' format for the events to retrieve field, e.g. '15|MINUTE'.
 	 *
 	 * @param int $month - The value chosen by user to purge all events older than x months
 	 *

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -174,16 +174,16 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 			FROM {$wpdb->posts} AS t1
 			INNER JOIN {$wpdb->postmeta} AS t2 ON t1.ID = t2.post_id
 			WHERE
-				t1.post_type = %1s
+				t1.post_type = " . '"%1$s"' . "
 				AND t2.meta_key = '_EventEndDate'
-				AND t2.meta_value <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %2d %4s )
+				AND t2.meta_value <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL " . '%2$d %4$s' . " )
 				AND t2.meta_value != 0
 				AND t2.meta_value != ''
 				AND t2.meta_value IS NOT NULL
 				AND t1.post_parent = 0
 				AND t1.ID NOT IN ( $posts_with_parents_sql )
-			LIMIT %3d
-		";
+			LIMIT " . '%3$d'
+		;
 
 		/**
 		 * Filter - Allows users to manipulate the cleanup query
@@ -197,10 +197,10 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 		$sql = apply_filters( 'tribe_events_delete_old_events_sql', $sql );
 
 		$args = [
-			'post_type' => $event_post_type,
+			'post_type' => esc_sql( $event_post_type ),
 			'date'      => $frequency,
 			'limit'     => 15,
-			'interval'  => $interval,
+			'interval'  => esc_sql( $interval ),
 		];
 
 		/**

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Event_Cleaner_SchedulerTest__should_have_occurrence_sql__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Event_Cleaner_SchedulerTest__should_have_occurrence_sql__1.php
@@ -1,10 +1,10 @@
 <?php return 'SELECT test_tec_occurrences.post_id
 				FROM test_posts
 			    	INNER JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
-				WHERE test_posts.post_type = %s
-					AND test_tec_occurrences.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %d %3s )
-					AND test_posts.post_status != \'trash\'
+				WHERE test_posts.post_type = "%1$s"
+					AND test_tec_occurrences.end_date_utc <= DATE_SUB( CURRENT_TIMESTAMP(), INTERVAL %2$d %4$s )
+					AND test_posts.post_status NOT IN ( \'trash\', \'tribe-ignored\' )
 				GROUP BY test_tec_occurrences.post_id
 				HAVING COUNT(*) = 1
 				ORDER BY test_tec_occurrences.start_date_utc ASC, test_tec_occurrences.end_date_utc ASC
-				LIMIT %d';
+				LIMIT %3$d';


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5319]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The "Move events to trash older than" maintenance function checks for all events that don't have the 'trash' post status and deletes them if they are beyond the set threshold. However, there might be "trashed" imported events (with 'tribe-ignored' post status), which are not excluded. So if there are 15 or more 'tribe-ignored' events on a site, the maintenance might keep trashing those (change them to 'tribe-ignored' post status, which they already are).
This PR adjusts the query in question so the 'tribe-ignored' post status will also be ignored, thus making the maintenance work again.

### 🎥 Artifacts <!-- if applicable-->
[Screen rec](https://1drv.ms/v/s!Aqh6lbOjUW1ThapLnZO0wKyruqLD5A?e=CTV1TT)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5319]: https://stellarwp.atlassian.net/browse/TEC-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ