### PR TITLE
Removing the landing/update page from the plugin, but not the notice.

### DIFF
--- a/changelog/fix-remove-update-page
+++ b/changelog/fix-remove-update-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Deprecated the unused update/activation page [TEC-5311]

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -149,18 +149,6 @@ class Tribe__Events__Assets {
 			]
 		);
 
-		// Admin update page CSS
-		tribe_asset(
-			$plugin,
-			'tribe-events-admin-update-page',
-			'admin-update-page.css',
-			[ ],
-			[ 'admin_enqueue_scripts', 'wp_enqueue_scripts' ],
-			[
-				'conditionals' => [ $this, 'should_enqueue_admin_update_page_assets' ],
-			]
-		);
-
 		// Setting page Assets
 		tribe_asset(
 			$plugin,
@@ -457,9 +445,14 @@ class Tribe__Events__Assets {
 	 *
 	 * @since  6.0.0
 	 *
+	 * @deprecated TBD
+	 *
 	 * @return bool
 	 */
 	public function should_enqueue_admin_update_page_assets() {
+		_deprecated_function( __METHOD__, 'TBD', 'No replacement' );
+		return false;
+
 		$should_enqueue = isset( $_GET[ 'update-message-the-events-calendar' ] );
 
 		/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -445,13 +445,12 @@ class Tribe__Events__Assets {
 	 *
 	 * @since  6.0.0
 	 *
-	 * @deprecated TBD
+	 * @deprecated TBD The page this function is testing for no longer exists.
 	 *
 	 * @return bool
 	 */
 	public function should_enqueue_admin_update_page_assets() {
-		_deprecated_function( __METHOD__, 'TBD', 'No replacement' );
-		return false;
+		_deprecated_function( __METHOD__, 'TBD', 'No alternative' );
 
 		$should_enqueue = isset( $_GET[ 'update-message-the-events-calendar' ] );
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -726,10 +726,6 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 * Load all the required library files.
 		 */
 		protected function loadLibraries() {
-			// Setup the Activation page
-			// no. $this->activation_page();
-			add_filter( 'tec_admin_update_page_bypass', '__return_true' );
-
 			// Tribe common resources
 			require_once $this->plugin_path . 'vendor/tribe-common-libraries/tribe-common-libraries.class.php';
 
@@ -1094,7 +1090,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		public function activation_page() {
 			_deprecated_function( __METHOD__, 'TBD', 'No replacement' );
-			return '';
+
 			// Setup the activation page only if the relevant class exists (in some edge cases, if another
 			// plugin hosting an earlier version of tribe-common is already active we could hit fatals
 			// if we don't take this precaution).

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -167,6 +167,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		/**
 		 * A Stored version of the Welcome and Update Pages.
 		 * @var Tribe__Admin__Activation_Page
+		 *
+		 * @deprecated TBD
 		 */
 		public $activation_page;
 
@@ -722,8 +724,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 */
 		protected function loadLibraries() {
 			// Setup the Activation page
-			$this->activation_page();
-			add_filter( 'tec_admin_update_page_bypass', '__return_false' );
+			// no. $this->activation_page();
+			add_filter( 'tec_admin_update_page_bypass', '__return_true' );
 
 			// Tribe common resources
 			require_once $this->plugin_path . 'vendor/tribe-common-libraries/tribe-common-libraries.class.php';
@@ -1084,8 +1086,12 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 		/**
 		 * @return Tribe__Admin__Activation_Page
+		 *
+		 * @deprecated TBD
 		 */
 		public function activation_page() {
+			_deprecated_function( __METHOD__, 'TBD', 'No replacement' );
+			return '';
 			// Setup the activation page only if the relevant class exists (in some edge cases, if another
 			// plugin hosting an earlier version of tribe-common is already active we could hit fatals
 			// if we don't take this precaution).

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1086,7 +1086,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		/**
 		 * @return Tribe__Admin__Activation_Page
 		 *
-		 * @deprecated TBD
+		 * @deprecated TBD Activation page no longer used.
 		 */
 		public function activation_page() {
 			_deprecated_function( __METHOD__, 'TBD', 'No replacement' );

--- a/src/admin-views/settings/sidebars/default-sidebar.php
+++ b/src/admin-views/settings/sidebars/default-sidebar.php
@@ -67,11 +67,6 @@ $hero_section->add_section(
 		->add_elements(
 			[
 				new Link(
-					tribe( 'tec.main' )->settings()->get_url( [ Tribe__Events__Main::instance()->activation_page->welcome_slug => 1 ] ),
-					__( 'View Welcome Page', 'the-events-calendar' )
-				),
-				$break,
-				new Link(
 					'https://evnt.is/1bbv',
 					__( 'Getting started guide', 'the-events-calendar' ),
 					null,

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -38,13 +38,6 @@ $general_tab_fields = [
 		'html' => '<ul class="tec-settings-header-links-section__documentation">'
 			. '<li>' . esc_html__( 'Documentation', 'the-events-calendar' ) . '</li>',
 	],
-	'tec-documentation-section-welcome-page-link'    => [
-		'type' => 'html',
-		'html' => '<li><a href="'
-			. esc_url( tribe( 'tec.main' )->settings()->get_url( [ Tribe__Events__Main::instance()->activation_page->welcome_slug => 1 ] ) ) . '">'
-			. esc_html__( 'View Welcome Page', 'the-events-calendar' )
-			. '</a></li>',
-	],
 	'tec-documentation-section-getting-started-link' => [
 		'type' => 'html',
 		'html' => '<li><a href="'


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5311]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This removes all the calls for the activation and update page.

### 🎥 Artifacts <!-- if applicable-->

#### BAD:
<img width="1792" alt="Screenshot 2024-11-11 at 10 28 20 AM" src="https://github.com/user-attachments/assets/e6533acf-badf-4cb4-a7fe-a1244b8f369e">

#### GOOD:
<img width="1792" alt="Screenshot 2024-11-11 at 10 28 24 AM" src="https://github.com/user-attachments/assets/b65dc6c6-46ea-496b-a919-909ae7c19a79">


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5311]: https://stellarwp.atlassian.net/browse/TEC-5311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ