### PR TITLE
Help Hub - Update link slugs

### DIFF
--- a/src/admin-views/settings/sidebars/default-sidebar.php
+++ b/src/admin-views/settings/sidebars/default-sidebar.php
@@ -107,7 +107,7 @@ $hero_section->add_section(
 				),
 
 				new Link(
-					admin_url( 'edit.php?post_type=tribe_events&page=tec-events-help' ),
+					admin_url( 'edit.php?post_type=tribe_events&page=tec-events-help-hub' ),
 					__( 'Help', 'the-events-calendar' )
 				),
 				$break,

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -76,7 +76,7 @@ $general_tab_fields = [
 		'html' => '<ul>'
 			. '<li>' . esc_html__( 'Having trouble?', 'the-events-calendar' ) . '</li>'
 			. '<li><a href="'
-			. esc_url( 'edit.php?post_type=tribe_events&page=tec-events-help' ) . '">'
+			. esc_url( 'edit.php?post_type=tribe_events&page=tec-events-help-hub' ) . '">'
 			. esc_html__( 'Help', 'the-events-calendar' )
 			. '</a></li>'
 			. '<li><a href="'


### PR DESCRIPTION
This PR focuses on updating the old Help page slugs from `tec-events-help` to `tec-events-help-hub`