### PR TITLE
TEC-5326 Correct template override paths Event Export 

### DIFF
--- a/changelog/fix-TEC-5326-event-export-template-override
+++ b/changelog/fix-TEC-5326-event-export-template-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Correct template override path to match docblocks for `event-export` directory. [TEC-5326]

--- a/src/views/integrations/elementor/widgets/event-export.php
+++ b/src/views/integrations/elementor/widgets/event-export.php
@@ -70,14 +70,14 @@ if ( empty( $show ) ) {
 ?>
 <div <?php tribe_classes( $widget->get_widget_class() ); ?>>
 	<div <?php tribe_classes( $widget->get_dropdown_class() ); ?>>
-		<?php $this->template( 'views/integrations/elementor/widgets/event-export/button' ); ?>
+		<?php $this->template( 'widgets/event-export/button' ); ?>
 		<div
 			<?php tribe_classes( $widget->get_content_class() ); ?>
 			style="display: none;"
 		>
 			<ul <?php tribe_classes( $widget->get_list_class() ); ?>>
 				<?php foreach ( $links_list as $item ) : ?>
-					<?php $this->template( 'views/integrations/elementor/widgets/event-export/list-item', $item ); ?>
+					<?php $this->template( 'widgets/event-export/list-item', $item ); ?>
 				<?php endforeach; ?>
 			</ul>
 		</div>

--- a/src/views/integrations/elementor/widgets/event-export/list-item.php
+++ b/src/views/integrations/elementor/widgets/event-export/list-item.php
@@ -27,6 +27,6 @@ if ( empty( $link ) || ! $should_display ) {
 ?>
 <li <?php tribe_classes( $link['class'] ); ?>>
 	<?php
-	$this->template( 'views/integrations/elementor/widgets/event-export/link' );
+	$this->template( 'widgets/event-export/link' );
 	?>
 </li>


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5326]

### 🗒️ Description

The template override path in the docblock for the files in `src/views/integrations/elementor/widgets/event-export` were suggesting to override the files at `[your-theme]/tribe/events/integrations/elementor/widgets/event-export.php`, which wasn't working. The override path that was working was `[your-theme]/tribe/events/integrations/elementor/views/integrations/elementor/widgets/event-export/[file].php` This is because the `views/integrations/elementor/` part of the override path was getting added a second time when being passed as the `$name` variable to the `template()` method. 

By removing these extra directories from the `$name` string, the override now works using the path suggested in the docblocks. 

### 🎥 Artifacts 
After changes: 
![CleanShot 2024-11-20 at 15 23 36@2x](https://github.com/user-attachments/assets/6bc17ba8-e945-4c5a-88ff-b3bd9662549a)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5326]: https://stellarwp.atlassian.net/browse/TEC-5326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ