### PR TITLE
Added logic for theme template in display options

### DIFF
--- a/changelog/fix-TEC-5337-theme-template-options
+++ b/changelog/fix-TEC-5337-theme-template-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Re-add logic to add page template options from theme to Display Settings. [TEC-5337]

--- a/src/admin-views/settings/tabs/display/display-calendar.php
+++ b/src/admin-views/settings/tabs/display/display-calendar.php
@@ -4,6 +4,9 @@
  * Subtab of the Display Tab.
  *
  * @since 6.7.0
+ * @since TBD Added logic to include page templates from theme to template options.
+ *
+ * @version TBD
  */
 
 use TEC\Common\Admin\Entities\Div;

--- a/src/admin-views/settings/tabs/display/display-calendar.php
+++ b/src/admin-views/settings/tabs/display/display-calendar.php
@@ -36,9 +36,7 @@ $template_options = [
 $templates = get_page_templates();
 ksort( $templates );
 
-foreach ( array_keys( $templates ) as $template ) {
-	$template_options[ $templates[ $template ] ] = $template;
-}
+$template_options += array_flip( $templates );
 
 $posts_per_page_tooltip = apply_filters(
 	'tec_events_display_calendar_settings_posts_per_page_tooltip',

--- a/src/admin-views/settings/tabs/display/display-calendar.php
+++ b/src/admin-views/settings/tabs/display/display-calendar.php
@@ -30,6 +30,13 @@ $template_options = [
 	'default' => esc_html__( 'Default Page Template', 'the-events-calendar' ),
 ];
 
+$templates = get_page_templates();
+ksort( $templates );
+
+foreach ( array_keys( $templates ) as $template ) {
+	$template_options[ $templates[ $template ] ] = $template;
+}
+
 $posts_per_page_tooltip = apply_filters(
 	'tec_events_display_calendar_settings_posts_per_page_tooltip',
 	esc_html__( 'The number of events per page on the List View. Does not affect other views.', 'the-events-calendar' )


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5337]

### 🗒️ Description

When the new Settings UI was added in TEC v6.7, the logic was removed to add the page templates from the theme into the template options. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5337]: https://stellarwp.atlassian.net/browse/TEC-5337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ