### PR TITLE
Fix/organizer venue continue

### DIFF
--- a/src/Events/Admin/Onboarding/Data.php
+++ b/src/Events/Admin/Onboarding/Data.php
@@ -393,6 +393,15 @@ class Data {
 		return null;
 	}
 
+	/**
+	 * Find a country key by its value.
+	 *
+	 * @since 6.8.4
+	 *
+	 * @param string $value The country value.
+	 *
+	 * @return string|null The country key or null if not found.
+	 */
 	public function find_country_by_value( $value ): ?string {
 		if ( empty( $value ) ) {
 			return null;

--- a/src/Events/Admin/Onboarding/Data.php
+++ b/src/Events/Admin/Onboarding/Data.php
@@ -60,7 +60,7 @@ class Data {
 			'name'    => get_the_title( $venue_id ),
 			'address' => get_post_meta( $venue_id, '_VenueAddress', true ),
 			'city'    => get_post_meta( $venue_id, '_VenueCity', true ),
-			'country' => get_post_meta( $venue_id, '_VenueCountry', true ),
+			'country' => $this->find_country_by_value( get_post_meta( $venue_id, '_VenueCountry', true ) ),
 			'phone'   => get_post_meta( $venue_id, '_VenuePhone', true ),
 			'state'   => get_post_meta( $venue_id, '_VenueState', true ),
 			'website' => get_post_meta( $venue_id, '_VenueWebsite', true ),
@@ -376,7 +376,7 @@ class Data {
 	 *
 	 * @return string|null The country name or null if not found.
 	 */
-	public function find_country_by_key( $key ) {
+	public function find_country_by_key( $key ): ?string {
 		if ( empty( $key ) ) {
 			return null;
 		}
@@ -390,6 +390,24 @@ class Data {
 			$continent = reset( $filtered ); // Get the first match.
 			return $continent[ $key ];
 		}
+		return null;
+	}
+
+	public function find_country_by_value( $value ): ?string {
+		if ( empty( $value ) ) {
+			return null;
+		}
+
+		$countries = $this->get_country_list();
+		// Use array_filter to locate the array containing the key.
+		$filtered = array_filter( $countries, fn( $country_list ) => in_array( $value, $country_list ) );
+
+		// If the filtered array is not empty, fetch the value.
+		if ( ! empty( $filtered ) ) {
+			$continent = reset( $filtered ); // Get the first match.
+			return array_search( $value, $continent );
+		}
+
 		return null;
 	}
 

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -569,7 +569,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @since 6.8.4
 	 */
 	public function tec_onboarding_wizard_target(): void {
-		$tec_versions = tribe_get_option( 'previous_ecp_versions', [] );
+		$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
 		// If there is more than one previous version, don't show the wizard.
 		if ( count( $tec_versions ) > 1 ) {
 			return;

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -569,6 +569,12 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @since 6.8.4
 	 */
 	public function tec_onboarding_wizard_target(): void {
+		$tec_versions = tribe_get_option( 'previous_ecp_versions', [] );
+		// If there is more than one previous version, don't show the wizard.
+		if ( count( $tec_versions ) > 1 ) {
+			return;
+		}
+
 		$data = tribe( Data::class );
 		// Don't display if we've finished the wizard.
 		if ( $data->get_wizard_setting( 'finished', false ) ) {

--- a/src/resources/packages/wizard/components/tabs/organizer/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/organizer/tab.tsx
@@ -89,7 +89,7 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidName = () => {
 		const inputId = 'organizer-name';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!name;
+		const isValid = !!name;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -103,8 +103,12 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidEmail = () => {
 		const inputId = 'organizer-email';
 		const isVisited = visitedFields.includes(inputId);
+		if (!isVisited) {
+			return true;
+		}
+
 		const emailPattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-		const isValid = !isVisited || emailPattern.test(email);
+		const isValid = emailPattern.test(email);
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -118,8 +122,12 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidPhone = () => {
 		const inputId = 'organizer-phone';
 		const isVisited = visitedFields.includes(inputId);
+		if (!isVisited) {
+			return true;
+		}
+
 		const phonePattern = /^\+?\d?[\s.-]?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/;
-		const isValid = !isVisited || phonePattern.test(phone);
+		const isValid = phonePattern.test(phone);
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -133,6 +141,9 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidWebsite = () => {
 		const inputId = 'organizer-website';
 		const isVisited = visitedFields.includes(inputId);
+		if (!isVisited) {
+			return true;
+		}
 
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');

--- a/src/resources/packages/wizard/components/tabs/organizer/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/organizer/tab.tsx
@@ -30,7 +30,6 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 	const [showEmail, setShowEmail] = useState(!!organizer.organizerId || !!organizer.email || false);
 	const [canContinue, setCanContinue] = useState(false);
 
-	// Check if any fields are pre-filled.
 	const disabled = !!organizer.organizerId;
 
 	useEffect(() => {
@@ -66,6 +65,12 @@ const OrganizerContent = ({moveToNextTab, skipToNextTab}) => {
 
 	// Compute whether the "Continue" button should be enabled
 	useEffect(() => {
+		if (organizerId) {
+			// If organizerId is set, bypass the check and enable "Continue"
+			setCanContinue(true);
+			return;
+		}
+
 		const fieldsToCheck = {
 			'organizer-name': isValidName(),
 			'organizer-phone': isValidPhone(),

--- a/src/resources/packages/wizard/components/tabs/venue/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/venue/tab.tsx
@@ -41,8 +41,15 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const [showWebsite, setShowWebsite] = useState(!!venue.venueId ||!!venue.website || false);
 	const [showPhone, setShowPhone] = useState(!!venue.venueId || !!venue.phone || false);
 	const [canContinue, setCanContinue] = useState( false);
+
 	// Compute whether the "Continue" button should be enabled
     useEffect(() => {
+		if (venueId) {
+			// If organizerId is set, bypass the check and enable "Continue"
+			setCanContinue(true);
+			return;
+		}
+
         const fieldsToCheck = {
             'venue-name': isValidName(),
 			'venue-address': isValidAddress(),

--- a/src/resources/packages/wizard/components/tabs/venue/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/venue/tab.tsx
@@ -91,7 +91,7 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidName = () => {
 		const inputId = 'venue-name';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!name;
+		const isValid = !!name;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -105,7 +105,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidAddress = () => {
 		const inputId = 'venue-address';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!address;
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !!address;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -119,7 +124,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidCity = () => {
 		const inputId = 'venue-city';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!city;
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !!city;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -133,7 +143,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidState = () => {
 		const inputId = 'venue-state';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!state;
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !!state;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -148,7 +163,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 		const inputId = 'venue-zip';
 		const zipPattern = /^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/i;
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || ( !!zip && zipPattern.test(zip) );
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !!zip && zipPattern.test(zip);
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -162,7 +182,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidCountry = () => {
 		const inputId = 'venue-country';
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || !!country;
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !!country;
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -177,7 +202,12 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 		const inputId = 'venue-phone';
 		const phonePattern = /^\+?\d?[\s.-]?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/;
 		const isVisited = visitedFields.includes(inputId);
-		const isValid = !isVisited || (!showPhone || ( !!phone && phonePattern.test(phone) ));
+
+		if (!isVisited) {
+			return true;
+		}
+
+		const isValid = !showPhone || ( !!phone && phonePattern.test(phone) );
 		const fieldEle = document.getElementById(inputId);
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');
 
@@ -191,6 +221,11 @@ const VenueContent = ({moveToNextTab, skipToNextTab}) => {
 	const isValidWebsite = () => {
 		const inputId = 'venue-website';
 		const isVisited = visitedFields.includes(inputId);
+
+		if (!isVisited) {
+			return true;
+		}
+
 
 		const fieldEle = document.getElementById('venue-website');
 		const parentEle = fieldEle?.closest('.tec-events-onboarding__form-field');


### PR DESCRIPTION
### 🎫 Ticket

Sheet issue

### 🗒️ Description

Organizer tab > Optional fields are treated as required
Organizer tab > Continue button is blocked if organizer exists
Venue tab > All fields are treated as required
Venue tab > Country field isn't updated
Venue tab > Continue button is blocked if venue exists


### 🎥 Artifacts <!-- if applicable-->
Name is sufficient  (can continue)
<img width="1230" alt="Screenshot 2024-12-12 at 12 49 35 PM" src="https://github.com/user-attachments/assets/20b0d51e-1b6f-4b4a-b159-029a2b0f85fa" />
existing is "valid" (can continue)
<img width="1232" alt="Screenshot 2024-12-12 at 12 49 51 PM" src="https://github.com/user-attachments/assets/aa01e210-5728-4bc0-83ba-a0925e2a1d39" />
Doesn't break validation of optional fields:
<img width="1160" alt="Screenshot 2024-12-12 at 12 49 41 PM" src="https://github.com/user-attachments/assets/6c110aa7-f805-4544-b0d9-bd2a5a58d092" />
