### PR TITLE
Fixes for the venue ORM repository

### DIFF
--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -77,6 +77,26 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 		);
 	}
 
+        protected function format_item( $id ) {
+                $formatted = null === $this->formatter
+                        ? tribe_get_venue_object( $id )
+                        : $this->formatter->format_item( $id );
+
+                /**
+                 * Filters a single formatted venue result.
+                 *
+                 * @since 4.9.11
+                 *
+                 * @param mixed|WP_Post                $formatted The formatted venue result, usually a post object.
+                 * @param int                          $id        The formatted post ID.
+                 * @param Tribe__Repository__Interface $this      The current repository object.
+                 */
+                $formatted = apply_filters( 'tribe_repository_venues_format_item', $formatted, $id, $this );
+
+                return $formatted;
+        }
+
+
 	/**
 	 * {@inheritdoc}
 	 */

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -51,6 +51,8 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 			'country'       => '_VenueCountry',
 			'phone'         => '_VenuePhone',
 			'website'       => '_VenueURL',
+			'show_map'      => '_VenueShowMap',
+			'show_map_link' => '_VenueShowMapLink',
 		] );
 
 		$this->linked_id_meta_key = '_EventVenueID';


### PR DESCRIPTION
### 🎫 Ticket

_none_

### 🗒️ Description

This is a simple proposal for enhancing the venue ORM repository so that it
 - supports setting show_map and show_map_link with the usual names (currently users have to write _VenueShowMap)
 - supports reading venues as decorated objects (currently bare post objects without the venue data are returned)

The implementation is heavily inspired by the event repository. The update_fields_aliases now supports all fields that are shown in the example from the [documentation](https://docs.theeventscalendar.com/apis/orm/create/venues/).

Note: the version _since_ tag for the hook is taken from the abstract method (tribe-common/src/Tribe/Repository.php) that uses the same hook name. The event hook exists since v4.9.7.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
I'm sorry but I don't intend to dig deep into your plugin development. I suppose the new code is simple enough (and similar enough to the event repository) for you to follow easily.

- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
