### PR TITLE
Fix All Day events start and end time when EOD cutoff is changed

### DIFF
--- a/changelog/fix-TECTRIA-395-fix-all-day-events-cutoff-update
+++ b/changelog/fix-TECTRIA-395-fix-all-day-events-cutoff-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Updated handling of "All Day" events to correctly adjust event start and end times when the "End of Day" (EOD) cutoff setting is changed. Introduced a filter (`tec_ignore_all_day_event_fix`) to allow custom solutions to override this functionality.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -1721,7 +1721,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			 * Example usage:
 			 * add_filter('tec_ignore_all_day_event_fix', '__return_true');
 			 */
-			if (apply_filters('tec_ignore_all_day_event_fix', false)) {
+			if ( apply_filters( 'tec_ignore_all_day_event_fix', false ) ) {
 				return;
 			}
 			// Avoid PHP notices by ensuring the `multiDayCutoff` value is always set.
@@ -1739,9 +1739,8 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 			}
 			global $wpdb;
 			$event_start_time = $new_value['multiDayCutoff'] . ':00';
-			error_log( 'The new Cutoff Time is: ' . $event_start_time );
 
-			//Update _tec_events table
+			//Update _tec_events table.
 			$sql = "
                 UPDATE {$wpdb->tec_events} tec
                 INNER JOIN {$wpdb->postmeta} pm
@@ -1757,10 +1756,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
             ";
 
 			$wpdb->query(
-				$wpdb->prepare($sql, $event_start_time, $event_start_time, $event_start_time, $event_start_time)
+				$wpdb->prepare( $sql, $event_start_time, $event_start_time, $event_start_time, $event_start_time )
 			);
 
-			//Update _postmeta table
+			// Update _postmeta table.
 			$sql_meta = "
                 UPDATE {$wpdb->postmeta} pm1
                 INNER JOIN {$wpdb->tec_events} tec
@@ -1781,11 +1780,11 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
             ";
 
 			$wpdb->query(
-				$wpdb->prepare($sql_meta, $event_start_time, $event_start_time, $event_start_time, $event_start_time)
+				$wpdb->prepare( $sql_meta, $event_start_time, $event_start_time, $event_start_time, $event_start_time )
 			);
 
 			// Flush the WordPress object cache to ensure updated data is visible immediately.
-			if (function_exists('wp_cache_flush')) {
+			if ( function_exists( 'wp_cache_flush' ) ) {
 				wp_cache_flush();
 			}
 		}


### PR DESCRIPTION
Updated handling of "All Day" events to correctly adjust event start and end times when the "End of Day" (EOD) cutoff setting is changed.
Introduced a filter (`tec_ignore_all_day_event_fix`) to allow custom solutions to override this functionality.

### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
