### PR TITLE
TEC-5343 Add check that `$content` is not `null`

### DIFF
--- a/changelog/fix-TEC-5343-disable_blocks_on_display-remove-string-requirement
+++ b/changelog/fix-TEC-5343-disable_blocks_on_display-remove-string-requirement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added check to `disable_blocks_on_display` for if `$content` is `null`. [TEC-5343]

--- a/src/Events/Integrations/Plugins/Elementor/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Controller.php
@@ -301,6 +301,7 @@ class Controller extends Integration_Abstract {
 	 * By filtering them out of the post content on display.
 	 *
 	 * @since 6.4.0
+	 * @since TBD Added check that content is not null.
 	 *
 	 * @param string $content The post content.
 	 *
@@ -308,6 +309,11 @@ class Controller extends Integration_Abstract {
 	 */
 	public function disable_blocks_on_display( $content ): string {
 		global $post;
+
+		// Check that content is not null.
+		if ( null === $content ) {
+			return '';
+		}
 
 		// Not a post.
 		if ( ! $post instanceof WP_Post ) {


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5343]

### 🗒️ Description

There was a case reported where Elementor and Yoast were causing a fatal error in TEC's Elementor integration due to the return value being `null` instead of a string. This fix adds a conditional to the first part of `disable_blocks_on_display()` to convert the `$content` to an empty string if it is `null` to avoid causing a fatal error. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5343]: https://stellarwp.atlassian.net/browse/TEC-5343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ