### PR TITLE
Fix/tec 5176 pagination button size

### DIFF
--- a/changelog/fix-TEC-5176-pagination-button-size
+++ b/changelog/fix-TEC-5176-pagination-button-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Increased pagination button sizes on the events page. [TEC-5176]

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -17,6 +17,7 @@
 		justify-content: center;
 		width: 24px;
 	}
+
 	button.tribe-events-c-top-bar__nav-link--prev:disabled,
 	button.tribe-events-c-top-bar__nav-link--next:disabled {
 		background-color: transparent;

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -9,7 +9,8 @@
 }
 
 .tribe-events {
-	.tribe-events-c-top-bar__nav-link--next, .tribe-events-c-top-bar__nav-link--prev {
+	.tribe-events-c-top-bar__nav-link--next,
+	.tribe-events-c-top-bar__nav-link--prev {
 		align-items: center;
 		display: flex;
 		height: 24px;

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -10,11 +10,11 @@
 
 .tribe-events {
 	.tribe-events-c-top-bar__nav-link--next, .tribe-events-c-top-bar__nav-link--prev {
-		width: 24px;
-		height: 24px;
-		display: flex;
-		justify-content: center;
 		align-items: center;
+		display: flex;
+		height: 24px;
+		justify-content: center;
+		width: 24px;
 	}
 	button.tribe-events-c-top-bar__nav-link--prev:disabled,
 	button.tribe-events-c-top-bar__nav-link--next:disabled {

--- a/src/resources/postcss/components/full/_top-bar.pcss
+++ b/src/resources/postcss/components/full/_top-bar.pcss
@@ -9,7 +9,13 @@
 }
 
 .tribe-events {
-
+	.tribe-events-c-top-bar__nav-link--next, .tribe-events-c-top-bar__nav-link--prev {
+		width: 24px;
+		height: 24px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
 	button.tribe-events-c-top-bar__nav-link--prev:disabled,
 	button.tribe-events-c-top-bar__nav-link--next:disabled {
 		background-color: transparent;


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5176]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Increased the pagination button sizes (24x24) to be compliant with accessibilty standards.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/user-attachments/assets/a9c3da4e-ca3a-46ae-bfde-986bf0d7f7f7)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5176]: https://stellarwp.atlassian.net/browse/TEC-5176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ