### PR TITLE
Register IAN on action

### DIFF
--- a/changelog/fix-register_notifications_on_action
+++ b/changelog/fix-register_notifications_on_action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove class_exists() and use register_on_action() for Notifications [TEC-5336]

--- a/src/Events/Integrations/Provider.php
+++ b/src/Events/Integrations/Provider.php
@@ -6,10 +6,10 @@
  *
  * @package TEC\Events\Integrations
  */
+
 namespace TEC\Events\Integrations;
 
 use TEC\Common\Contracts\Service_Provider;
-
 
 /**
  * Class Provider

--- a/src/Events/Notifications/Notifications.php
+++ b/src/Events/Notifications/Notifications.php
@@ -9,22 +9,42 @@
 
 namespace TEC\Events\Notifications;
 
+use TEC\Events\Integrations\Integration_Abstract;
+use TEC\Common\Integrations\Traits\Plugin_Integration;
+
 /**
  * Class Notifications
  *
  * @since   6.4.0
  * @package TEC\Events\Notifications
  */
-class Notifications {
+class Notifications extends Integration_Abstract {
+	use Plugin_Integration;
 
 	/**
 	 * The slug of this plugin calling the Notifications class.
 	 *
 	 * @since 6.4.0
 	 *
-	 * @var string
+	 * @return string
 	 */
-	protected static string $slug = 'the-events-calendar';
+	public static function get_slug(): string {
+		return 'the-events-calendar';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function load_conditionals(): bool {
+		return has_action( 'tribe_common_loaded' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function load(): void {
+		add_action( 'admin_footer', [ $this, 'render_icon' ] );
+	}
 
 	/**
 	 * Outputs the hook that renders the Notifications icon on all TEC admin pages.
@@ -42,6 +62,6 @@ class Notifications {
 		 *
 		 * @since 6.4.0
 		 */
-		do_action( 'tec_ian_icon', static::$slug );
+		do_action( 'tec_ian_icon', $this->get_slug() );
 	}
 }

--- a/src/Events/Notifications/Provider.php
+++ b/src/Events/Notifications/Provider.php
@@ -25,20 +25,8 @@ class Provider extends Service_Provider {
 	 * @since 6.4.0
 	 */
 	public function register() {
-		add_action( 'admin_footer', [ $this, 'render_icon' ] );
-	}
+		$this->container->singleton( static::class, $this );
 
-	/**
-	 * Renders the Notification icon.
-	 *
-	 * @since 6.4.0
-	 */
-	public function render_icon() {
-		// TODO: Remove this check when we have a proper way to register it, like register_on_action.
-		if ( ! class_exists( Notifications::class ) ) {
-			return;
-		}
-
-		return $this->container->get( Notifications::class )->render_icon();
+		$this->container->register_on_action( 'tribe_plugins_loaded', Notifications::class );
 	}
 }

--- a/src/Events/Notifications/Provider.php
+++ b/src/Events/Notifications/Provider.php
@@ -25,8 +25,6 @@ class Provider extends Service_Provider {
 	 * @since 6.4.0
 	 */
 	public function register() {
-		$this->container->singleton( static::class, $this );
-
-		$this->container->register_on_action( 'tribe_plugins_loaded', Notifications::class );
+		$this->container->register_on_action( 'tec_common_ian_loaded', Notifications::class );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5336 ]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
During QA for IAN's first release, we discovered that a fatal error was thrown if the user would downgrade from the latest to the previous version of TEC (since the new Notifications class wouldn’t exists in that one).

We patched the fix [with this PR](https://github.com/the-events-calendar/the-events-calendar/pull/4849/files), using a `class_exist()`. 

This PR improves that, by using [register_on_action](https://docs.theeventscalendar.com/reference/classes/tec-common-contracts-container/register_on_action/), and removes the `class_exists()` check.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
