### PR TITLE
[EA-476] Event Aggregator: Replace  deprecated `get_page_by_title` function

### DIFF
--- a/changelog/fix-EA-476-replace-deprecated-functions
+++ b/changelog/fix-EA-476-replace-deprecated-functions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Replaced deprecated functions with their modern equivalents to maintain compatibility. [EA-476]

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1812,15 +1812,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 							if ( empty( $venue_unique_field ) || ( $lookup_venues_by_title && empty( $venue ) ) ) {
 								$venue_query = new WP_Query(
 									[
-										'post_type'              => Tribe__Events__Venue::POSTTYPE,
-										'title'                  => $event['Venue']['Venue'],
-										'post_status'            => 'all',
-										'posts_per_page'         => 1,
-										'no_found_rows'          => true,
-										'ignore_sticky_posts'    => true,
+										'post_type'      => Tribe__Events__Venue::POSTTYPE,
+										'title'          => $event['Venue']['Venue'],
+										'post_status'    => 'all',
+										'posts_per_page' => 1,
+										'no_found_rows'  => true,
+										'ignore_sticky_posts' => true,
 										'update_post_term_cache' => false,
-										'orderby'                => 'post_date ID',
-										'order'                  => 'ASC',
+										'orderby'        => 'post_date ID',
+										'order'          => 'ASC',
 
 									]
 								);
@@ -1996,15 +1996,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 									} else {
 										$organizer_query = new WP_Query(
 											[
-												'post_type'              => Tribe__Events__Organizer::POSTTYPE,
-												'title'                  => $organizer_data['Organizer'],
-												'post_status'            => 'all',
-												'posts_per_page'         => 1,
-												'no_found_rows'          => true,
-												'ignore_sticky_posts'    => true,
+												'post_type'      => Tribe__Events__Organizer::POSTTYPE,
+												'title'          => $organizer_data['Organizer'],
+												'post_status'    => 'all',
+												'posts_per_page' => 1,
+												'no_found_rows'  => true,
+												'ignore_sticky_posts' => true,
 												'update_post_term_cache' => false,
-												'orderby'                => 'post_date ID',
-												'order'                  => 'ASC',
+												'orderby'        => 'post_date ID',
+												'order'          => 'ASC',
 
 											]
 										);

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1810,7 +1810,22 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 							}
 
 							if ( empty( $venue_unique_field ) || ( $lookup_venues_by_title && empty( $venue ) ) ) {
-								$venue = get_page_by_title( $event['Venue']['Venue'], 'OBJECT', Tribe__Events__Venue::POSTTYPE );
+								$venue_query = new WP_Query(
+									[
+										'post_type'              => Tribe__Events__Venue::POSTTYPE,
+										'title'	                 => $event['Venue']['Venue'],
+										'post_status'            => 'all',
+										'posts_per_page'         => 1,
+										'no_found_rows'          => true,
+										'ignore_sticky_posts'    => true,
+										'update_post_term_cache' => false,
+										'update_post_meta_cache' => false,
+										'orderby'                => 'post_date ID',
+										'order'                  => 'ASC',
+
+									]
+								);
+								$venue = ! empty( $venue_query->post ) ? $venue_query->post : null;
 							}
 
 							if ( $venue ) {
@@ -1980,7 +1995,22 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 										$value     = $organizer_data[ $target ];
 										$organizer = Tribe__Events__Aggregator__Event::get_post_by_meta( "_Organizer{$target}", $value );
 									} else {
-										$organizer = get_page_by_title( $organizer_data['Organizer'], 'OBJECT', Tribe__Events__Organizer::POSTTYPE );
+										$organizer_query = new WP_Query(
+											[
+												'post_type'              => Tribe__Events__Organizer::POSTTYPE,
+												'title'	                 => $organizer_data['Organizer'],
+												'post_status'            => 'all',
+												'posts_per_page'         => 1,
+												'no_found_rows'          => true,
+												'ignore_sticky_posts'    => true,
+												'update_post_term_cache' => false,
+												'update_post_meta_cache' => false,
+												'orderby'                => 'post_date ID',
+												'order'                  => 'ASC',
+
+											]
+										);
+										$organizer = ! empty( $organizer_query->post ) ? $organizer_query->post : null;
 									}
 								}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1813,13 +1813,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 								$venue_query = new WP_Query(
 									[
 										'post_type'              => Tribe__Events__Venue::POSTTYPE,
-										'title'	                 => $event['Venue']['Venue'],
+										'title'                  => $event['Venue']['Venue'],
 										'post_status'            => 'all',
 										'posts_per_page'         => 1,
 										'no_found_rows'          => true,
 										'ignore_sticky_posts'    => true,
 										'update_post_term_cache' => false,
-										'update_post_meta_cache' => false,
 										'orderby'                => 'post_date ID',
 										'order'                  => 'ASC',
 
@@ -1998,13 +1997,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 										$organizer_query = new WP_Query(
 											[
 												'post_type'              => Tribe__Events__Organizer::POSTTYPE,
-												'title'	                 => $organizer_data['Organizer'],
+												'title'                  => $organizer_data['Organizer'],
 												'post_status'            => 'all',
 												'posts_per_page'         => 1,
 												'no_found_rows'          => true,
 												'ignore_sticky_posts'    => true,
 												'update_post_term_cache' => false,
-												'update_post_meta_cache' => false,
 												'orderby'                => 'post_date ID',
 												'order'                  => 'ASC',
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1996,15 +1996,15 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 									} else {
 										$organizer_query = new WP_Query(
 											[
-												'post_type'      => Tribe__Events__Organizer::POSTTYPE,
-												'title'          => $organizer_data['Organizer'],
-												'post_status'    => 'all',
+												'post_type' => Tribe__Events__Organizer::POSTTYPE,
+												'title'   => $organizer_data['Organizer'],
+												'post_status' => 'all',
 												'posts_per_page' => 1,
-												'no_found_rows'  => true,
+												'no_found_rows' => true,
 												'ignore_sticky_posts' => true,
 												'update_post_term_cache' => false,
-												'orderby'        => 'post_date ID',
-												'order'          => 'ASC',
+												'orderby' => 'post_date ID',
+												'order'   => 'ASC',
 
 											]
 										);

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1814,11 +1814,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 									[
 										'post_type'      => Tribe__Events__Venue::POSTTYPE,
 										'title'          => $event['Venue']['Venue'],
-										'post_status'    => 'all',
+										'post_status'    => 'any',
 										'posts_per_page' => 1,
 										'no_found_rows'  => true,
 										'ignore_sticky_posts' => true,
 										'update_post_term_cache' => false,
+										'update_post_meta_cache' => false,
 										'orderby'        => 'post_date ID',
 										'order'          => 'ASC',
 
@@ -1998,11 +1999,12 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 											[
 												'post_type' => Tribe__Events__Organizer::POSTTYPE,
 												'title'   => $organizer_data['Organizer'],
-												'post_status' => 'all',
+												'post_status' => 'any',
 												'posts_per_page' => 1,
 												'no_found_rows' => true,
 												'ignore_sticky_posts' => true,
 												'update_post_term_cache' => false,
+												'update_post_meta_cache' => false,
 												'orderby' => 'post_date ID',
 												'order'   => 'ASC',
 

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -539,9 +539,7 @@ class AbstractTest extends Events_TestCase {
 	}
 
 	/**
-	 * It should correctly create and link new organizers to events
-	 *
-	 * When an organizer UID is not provided
+	 * It should correctly link existing organizers to events.
 	 *
 	 * @test
 	 */
@@ -577,9 +575,7 @@ class AbstractTest extends Events_TestCase {
 	}
 
 	/**
-	 * It should correctly create and link new organizers to events
-	 *
-	 * When an organizer UID is not provided
+	 * It should correctly link existing venues to events.
 	 *
 	 * @test
 	 */

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/AbstractTest.php
@@ -539,6 +539,80 @@ class AbstractTest extends Events_TestCase {
 	}
 
 	/**
+	 * It should correctly create and link new organizers to events
+	 *
+	 * When an organizer UID is not provided
+	 *
+	 * @test
+	 */
+	public function should_correctly_link_existing_organizers_to_events() {
+		// Create existing organizer.
+		$organizer_name = 'Organizer-1';
+		$original_organizer_id = $this->factory()->organizer->create();
+		wp_update_post( [
+			'ID'         => $original_organizer_id,
+			'post_title' => $organizer_name,
+		] );
+
+		$event_data = $this->factory()->import_record->create_and_get_event_data( 'ical' );
+		$event_data->organizer = [
+			(object) [
+				'organizer' => $organizer_name,
+			],
+		];
+
+		$this->track_last_inserted_or_updated();
+
+		/** @var Base $record */
+		$record = $this->extend_base_w_origin( 'ical' );
+		$record->insert_posts( [ $event_data ] );
+
+		$this->assertNotEmpty( get_post( $this->last_inserted_or_updated ) );
+		$organizers = (array) get_post_meta( $this->last_inserted_or_updated, '_EventOrganizerID', true );
+		$this->assertNotEmpty( $organizers );
+		$assigned_organizer_id = reset( $organizers );
+		$this->assertEquals( $original_organizer_id, $assigned_organizer_id );
+		$organizer = get_post( $assigned_organizer_id );
+		$this->assertEquals( $organizer_name, $organizer->post_title );
+	}
+
+	/**
+	 * It should correctly create and link new organizers to events
+	 *
+	 * When an organizer UID is not provided
+	 *
+	 * @test
+	 */
+	public function should_correctly_link_existing_venues_to_events() {
+		// Create existing organizer.
+		$venue_name = 'Venue-1';
+		$original_venue_id = $this->factory()->venue->create();
+		wp_update_post( [
+			'ID'         => $original_venue_id,
+			'post_title' => $venue_name,
+		] );
+
+		$event_data = $this->factory()->import_record->create_and_get_event_data( 'ical' );
+		$event_data->venue = (object) [
+			'venue' => $venue_name,
+		];
+
+		$this->track_last_inserted_or_updated();
+
+		/** @var Base $record */
+		$record = $this->extend_base_w_origin( 'ical' );
+		$record->insert_posts( [ $event_data ] );
+
+		$this->assertNotEmpty( get_post( $this->last_inserted_or_updated ) );
+		$venues = (array) get_post_meta( $this->last_inserted_or_updated, '_EventVenueID', true );
+		$this->assertNotEmpty( $venues );
+		$assigned_venue_id = reset( $venues );
+		$this->assertEquals( $original_venue_id, $assigned_venue_id );
+		$venue = get_post( $assigned_venue_id );
+		$this->assertEquals( $venue_name, $venue->post_title );
+	}
+
+	/**
 	 * It should not track modified fields when creating events no matter the authority
 	 *
 	 * @test I should


### PR DESCRIPTION
### 🎫 Ticket
[EA-476]

### 🗒️ Description
The WP function `get_page_by_title` has been deprecated as of version 6.2. This PR replaces the function with an equivalent `WP_Query` call.

### 🎥 Artifacts <!-- if applicable-->
https://share.zight.com/7KuwbZgE

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[EA-476]: https://stellarwp.atlassian.net/browse/EA-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ