### PR TITLE
ECP-1613 Divi Z-Index Conflict

### DIFF
--- a/changelog/fix-ECP-1613-Divi-z-index-conflict
+++ b/changelog/fix-ECP-1613-Divi-z-index-conflict
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Increased z-index of admin dialouge box to not conflict with Divi loader. [ECP-1613]

--- a/changelog/fix-ECP-1613-Divi-z-index-conflict
+++ b/changelog/fix-ECP-1613-Divi-z-index-conflict
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Increased z-index of admin dialouge box to not conflict with Divi loader. [ECP-1613]
+Increased z-index of admin dialog box to not conflict with Divi loader. [ECP-1613]

--- a/src/resources/postcss/events-admin.pcss
+++ b/src/resources/postcss/events-admin.pcss
@@ -279,7 +279,7 @@
 }
 
 .ui-front {
-	z-index: 1000000;
+	z-index: 2000001;
 }
 
 .events-cal .ui-widget-overlay.ui-front {

--- a/src/resources/postcss/events-admin.pcss
+++ b/src/resources/postcss/events-admin.pcss
@@ -279,7 +279,7 @@
 }
 
 .ui-front {
-	z-index: 2000001;
+	z-index: 3000000;
 }
 
 .events-cal .ui-widget-overlay.ui-front {


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1613]

### 🗒️ Description

When editing a recurring event, the Divi loader has a z-index of `2000000` while our dialogue box asking which recurring events to apply the changes to (`ui-front`) had a z-index of `1000000`, causing it to be unusable/blocked. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ECP-1613]: https://stellarwp.atlassian.net/browse/ECP-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ