### PR TITLE
Support Additional Fields in Events REST API

### DIFF
--- a/changelog/fix-TEC-5015_additional_fields_in_rest
+++ b/changelog/fix-TEC-5015_additional_fields_in_rest
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Support Additional Fields in Events REST API [TEC-5015]

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 
 			// Support the additional fields.
 			$custom_fields = tribe_get_option( 'custom-fields', false );
-			if ( ! empty( $custom_fields && is_array( $custom_fields ) ) ) {
+			if ( ! empty( $custom_fields ) && is_array( $custom_fields ) ) {
 				foreach ( $custom_fields as $field ) {
 					$args[ $field['name'] ] = get_post_meta( $event_id, $field['name'], true );
 				}

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -88,6 +88,14 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				$args['edit_date'] = true;
 			}
 
+			// Support the additional fields.
+			$custom_fields = tribe_get_option( 'custom-fields', false );
+			if ( ! empty( $custom_fields && is_array( $custom_fields ) ) ) {
+				foreach ( $custom_fields as $field ) {
+					$args[ $field['name'] ] = get_post_meta( $event_id, $field['name'], true );
+				}
+			}
+
 			/**
 			 * Allow hooking prior the update of an event and meta fields.
 			 *

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -96,6 +96,22 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 		$venue     = $this->get_venue_data( $event_id, $context );
 		$organizer = $this->get_organizer_data( $event_id, $context );
 
+		$fields        = [];
+		$custom_fields = tribe_get_option( 'custom-fields', false );
+		if ( ! empty( $custom_fields && is_array( $custom_fields ) ) ) {
+			foreach ( $custom_fields as $field ) {
+				$field_value = get_post_meta( $event_id, $field['name'], true );
+				if ( empty( $field_value ) ) {
+					continue;
+				}
+
+				$fields[ $field['name'] ] = [
+					'label' => $field['label'] ?? '',
+					'value' => $field_value ?? '',
+				];
+			}
+		}
+
 		$data = array(
 			'id'                     => $event_id,
 			'global_id'              => false,
@@ -141,6 +157,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 			'tags'                   => $this->get_tags( $event_id ),
 			'venue'                  => is_wp_error( $venue ) ? array() : $venue,
 			'organizer'              => is_wp_error( $organizer ) ? array() : $organizer,
+			'custom_fields'          => $fields,
 		);
 
 		/**

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -98,7 +98,7 @@ class Tribe__Events__REST__V1__Post_Repository implements Tribe__Events__REST__I
 
 		$fields        = [];
 		$custom_fields = tribe_get_option( 'custom-fields', false );
-		if ( ! empty( $custom_fields && is_array( $custom_fields ) ) ) {
+		if ( ! empty( $custom_fields ) && is_array( $custom_fields ) ) {
 			foreach ( $custom_fields as $field ) {
 				$field_value = get_post_meta( $event_id, $field['name'], true );
 				if ( empty( $field_value ) ) {

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Archive_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Archive_EventTest.php
@@ -1076,4 +1076,74 @@ class Archive_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 		);
 		$this->assertMatchesJsonSnapshot( $json );
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_show_additional_fields() {
+		$additional = [
+			[
+				"name" => "_ecp_custom_1",
+				"label" => "Cool Field",
+				"type" => "text",
+				"values" => "",
+				"gutenberg_editor" => false,
+			],
+			[
+				"name" => "_ecp_custom_2",
+				"label" => "Awesome Field",
+				"type" => "text",
+				"values" => "",
+				"gutenberg_editor" => false,
+			],
+		];
+
+		tribe_update_option( 'custom-fields', $additional );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		tribe_update_option( 'posts_per_page', 10 );
+		$this->freeze_time( Dates::immutable( '2084-06-13 17:25:00' ) );
+		$event_ids = [];
+		foreach( range( 1, 3 ) as $i ) {
+			$event_ids[] = tribe_events()->set_args(
+				[
+					'title'      => 'Test Event ' . $i,
+					'status'     => 'publish',
+					'start_date' => '2084-07-14 12:00:00',
+					'duration'   => 2 * HOUR_IN_SECONDS,
+				]
+			)->create()->ID;
+		}
+
+		$this->assertEquals( '2084-06-13 17:25:00', date( 'Y-m-d H:i:s' ) );
+
+		update_post_meta( $event_ids[0], '_ecp_custom_1', 'Cool Value' );
+
+		update_post_meta( $event_ids[1], '_ecp_custom_2', 'Awesome Value' );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$data = $response->get_data();
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertCount( 3, $data['events'] );
+
+		$json = wp_json_encode( $data, JSON_PRETTY_PRINT );
+		$json = str_replace(
+			array_map( static fn( $id ) => '"id": ' . $id, $event_ids ),
+			'"id": "{EVENT_ID}"',
+			$json
+		);
+		$json = str_replace(
+			array_map( static fn( $id ) => '?id=' . $id, $event_ids ),
+			'?id={EVENT_ID}',
+			$json
+		);
+		$json = str_replace(
+			array_map( static fn( $id ) => '\/events\/' . $id, $event_ids ),
+			'\/events\/{EVENT_ID}',
+			$json
+		);
+		$this->assertMatchesJsonSnapshot( $json );
+	}
 }

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/__snapshots__/Archive_EventTest__it_should_hide_password_protected_fields__0.snapshot.json
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/__snapshots__/Archive_EventTest__it_should_hide_password_protected_fields__0.snapshot.json
@@ -74,7 +74,8 @@
             "categories": [],
             "tags": [],
             "venue": [],
-            "organizer": []
+            "organizer": [],
+            "custom_fields": []
         },
         {
             "id": "{EVENT_ID}",
@@ -150,7 +151,8 @@
             "categories": [],
             "tags": [],
             "venue": [],
-            "organizer": []
+            "organizer": [],
+            "custom_fields": []
         },
         {
             "id": "{EVENT_ID}",
@@ -226,7 +228,8 @@
             "categories": [],
             "tags": [],
             "venue": [],
-            "organizer": []
+            "organizer": [],
+            "custom_fields": []
         },
         {
             "id": "{EVENT_ID}",
@@ -302,7 +305,8 @@
             "categories": [],
             "tags": [],
             "venue": [],
-            "organizer": []
+            "organizer": [],
+            "custom_fields": []
         },
         {
             "id": "{EVENT_ID}",
@@ -378,7 +382,8 @@
             "categories": [],
             "tags": [],
             "venue": [],
-            "organizer": []
+            "organizer": [],
+            "custom_fields": []
         }
     ],
     "rest_url": "http:\/\/wordpress.test\/index.php?rest_route=%2Ftribe%2Fevents%2Fv1%2Fevents%2F&per_page=10&status=publish",

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/__snapshots__/Archive_EventTest__it_should_show_additional_fields__0.snapshot.json
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/__snapshots__/Archive_EventTest__it_should_show_additional_fields__0.snapshot.json
@@ -1,0 +1,248 @@
+{
+    "events": [
+        {
+            "id": "{EVENT_ID}",
+            "global_id": "wordpress.test?id={EVENT_ID}",
+            "global_id_lineage": [
+                "wordpress.test?id={EVENT_ID}"
+            ],
+            "author": "0",
+            "status": "publish",
+            "date": "2084-06-13 17:25:00",
+            "date_utc": "2084-06-13 17:25:00",
+            "modified": "2084-06-13 17:25:00",
+            "modified_utc": "2084-06-13 17:25:00",
+            "url": "http:\/\/wordpress.test\/?tribe_events=test-event-1",
+            "rest_url": "http:\/\/wordpress.test\/index.php?rest_route=\/tribe\/events\/v1\/events\/{EVENT_ID}",
+            "title": "Test Event 1",
+            "description": "",
+            "excerpt": "",
+            "slug": "test-event-1",
+            "image": false,
+            "all_day": false,
+            "start_date": "2084-07-14 12:00:00",
+            "start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "end_date": "2084-07-14 14:00:00",
+            "end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_start_date": "2084-07-14 12:00:00",
+            "utc_start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_end_date": "2084-07-14 14:00:00",
+            "utc_end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "timezone": "UTC",
+            "timezone_abbr": "UTC",
+            "cost": "",
+            "cost_details": {
+                "currency_symbol": "",
+                "currency_code": "",
+                "currency_position": "",
+                "values": []
+            },
+            "website": "http:\/\/wordpress.test\/?tribe_events=test-event-1",
+            "show_map": true,
+            "show_map_link": true,
+            "hide_from_listings": false,
+            "sticky": false,
+            "featured": false,
+            "categories": [],
+            "tags": [],
+            "venue": [],
+            "organizer": [],
+            "custom_fields": {
+                "_ecp_custom_1": {
+                    "label": "Cool Field",
+                    "value": "Cool Value"
+                }
+            }
+        },
+        {
+            "id": "{EVENT_ID}",
+            "global_id": "wordpress.test?id={EVENT_ID}",
+            "global_id_lineage": [
+                "wordpress.test?id={EVENT_ID}"
+            ],
+            "author": "0",
+            "status": "publish",
+            "date": "2084-06-13 17:25:00",
+            "date_utc": "2084-06-13 17:25:00",
+            "modified": "2084-06-13 17:25:00",
+            "modified_utc": "2084-06-13 17:25:00",
+            "url": "http:\/\/wordpress.test\/?tribe_events=test-event-2",
+            "rest_url": "http:\/\/wordpress.test\/index.php?rest_route=\/tribe\/events\/v1\/events\/{EVENT_ID}",
+            "title": "Test Event 2",
+            "description": "",
+            "excerpt": "",
+            "slug": "test-event-2",
+            "image": false,
+            "all_day": false,
+            "start_date": "2084-07-14 12:00:00",
+            "start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "end_date": "2084-07-14 14:00:00",
+            "end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_start_date": "2084-07-14 12:00:00",
+            "utc_start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_end_date": "2084-07-14 14:00:00",
+            "utc_end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "timezone": "UTC",
+            "timezone_abbr": "UTC",
+            "cost": "",
+            "cost_details": {
+                "currency_symbol": "",
+                "currency_code": "",
+                "currency_position": "",
+                "values": []
+            },
+            "website": "http:\/\/wordpress.test\/?tribe_events=test-event-2",
+            "show_map": true,
+            "show_map_link": true,
+            "hide_from_listings": false,
+            "sticky": false,
+            "featured": false,
+            "categories": [],
+            "tags": [],
+            "venue": [],
+            "organizer": [],
+            "custom_fields": {
+                "_ecp_custom_2": {
+                    "label": "Awesome Field",
+                    "value": "Awesome Value"
+                }
+            }
+        },
+        {
+            "id": "{EVENT_ID}",
+            "global_id": "wordpress.test?id={EVENT_ID}",
+            "global_id_lineage": [
+                "wordpress.test?id={EVENT_ID}"
+            ],
+            "author": "0",
+            "status": "publish",
+            "date": "2084-06-13 17:25:00",
+            "date_utc": "2084-06-13 17:25:00",
+            "modified": "2084-06-13 17:25:00",
+            "modified_utc": "2084-06-13 17:25:00",
+            "url": "http:\/\/wordpress.test\/?tribe_events=test-event-3",
+            "rest_url": "http:\/\/wordpress.test\/index.php?rest_route=\/tribe\/events\/v1\/events\/{EVENT_ID}",
+            "title": "Test Event 3",
+            "description": "",
+            "excerpt": "",
+            "slug": "test-event-3",
+            "image": false,
+            "all_day": false,
+            "start_date": "2084-07-14 12:00:00",
+            "start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "end_date": "2084-07-14 14:00:00",
+            "end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_start_date": "2084-07-14 12:00:00",
+            "utc_start_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "12",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "utc_end_date": "2084-07-14 14:00:00",
+            "utc_end_date_details": {
+                "year": "2084",
+                "month": "07",
+                "day": "14",
+                "hour": "14",
+                "minutes": "00",
+                "seconds": "00"
+            },
+            "timezone": "UTC",
+            "timezone_abbr": "UTC",
+            "cost": "",
+            "cost_details": {
+                "currency_symbol": "",
+                "currency_code": "",
+                "currency_position": "",
+                "values": []
+            },
+            "website": "http:\/\/wordpress.test\/?tribe_events=test-event-3",
+            "show_map": true,
+            "show_map_link": true,
+            "hide_from_listings": false,
+            "sticky": false,
+            "featured": false,
+            "categories": [],
+            "tags": [],
+            "venue": [],
+            "organizer": [],
+            "custom_fields": []
+        }
+    ],
+    "rest_url": "http:\/\/wordpress.test\/index.php?rest_route=%2Ftribe%2Fevents%2Fv1%2Fevents%2F&per_page=10&status=publish",
+    "total": 3,
+    "total_pages": 1
+}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5015]

### 🗒️ Description

The initial bug report mentioned that when an event was updated via REST API, the additional fields were emptied. By supporting them in our API, we make additional fields available for all operations.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5015]: https://stellarwp.atlassian.net/browse/TEC-5015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ