### PR TITLE
TEC-5352 Add Aliases to Venue ORM 

### DIFF
--- a/changelog/tweak-TEC-5352-add-aliases-to-venue-orm
+++ b/changelog/tweak-TEC-5352-add-aliases-to-venue-orm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Added aliases for Venue ORM for `show_map` and `show_map_link`. (props to @m8nmueller) [TEC-5352]

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -26,6 +26,7 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 	 * Sets up the repository default parameters and schema.
 	 *
 	 * @since 4.9
+	 * @since TBD Added `show_map` and `show_map_link` aliases.
 	 */
 	public function __construct() {
 		parent::__construct();

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -51,6 +51,8 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 			'country'       => '_VenueCountry',
 			'phone'         => '_VenuePhone',
 			'website'       => '_VenueURL',
+			'show_map'      => '_VenueShowMap',
+			'show_map_link' => '_VenueShowMapLink',
 		] );
 
 		$this->linked_id_meta_key = '_EventVenueID';


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5352]

### 🗒️ Description

[Original PR](https://github.com/the-events-calendar/the-events-calendar/pull/4870) - credit to @m8nmueller

Currently, our Venue ORM does not have aliases for `_VenueShowMap` or `_VenueShowMapLink` - this PR amends that. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![CleanShot 2025-01-23 at 10 39 09@2x](https://github.com/user-attachments/assets/f0c353b6-34e4-489e-bc95-487830574cd0)
![CleanShot 2025-01-23 at 10 50 03@2x](https://github.com/user-attachments/assets/a355e284-8653-4f30-bfcb-5ff4c0590245)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5352]: https://stellarwp.atlassian.net/browse/TEC-5352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ