### PR TITLE
TEC-5353 Support Venue ORM Results as Decorated Objects

### DIFF
--- a/changelog/fix-TEC-5353-Venue-ORM-object-decoration
+++ b/changelog/fix-TEC-5353-Venue-ORM-object-decoration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added `format_item()` function so venues read from ORM are decorated objects. (props to @m8nmueller) [TEC-5353]

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -82,7 +82,7 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 	 *
 	 * @since TBD Added to Venue ORM.
 	 *
-	 * @param $id int The id of the current venue.
+	 * @param int $id The id of the current venue.
 	 */
 	protected function format_item( $id ) {
 		$formatted = null === $this->formatter

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -8,7 +8,6 @@
 /**
  * Class Tribe__Events__Repositories__Venue
  *
- *
  * @since 4.9
  */
 class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Linked_Posts {
@@ -39,19 +38,22 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 		];
 
 		// Add venue specific aliases.
-		$this->update_fields_aliases = array_merge( $this->update_fields_aliases, [
-			'venue'         => 'post_title',
-			'address'       => '_VenueAddress',
-			'city'          => '_VenueCity',
-			'state'         => '_VenueState',
-			'province'      => '_VenueProvince',
-			'stateprovince' => '_VenueStateProvince',
-			'postal_code'   => '_VenueZip',
-			'zip'           => '_VenueZip',
-			'country'       => '_VenueCountry',
-			'phone'         => '_VenuePhone',
-			'website'       => '_VenueURL',
-		] );
+		$this->update_fields_aliases = array_merge(
+			$this->update_fields_aliases,
+			[
+				'venue'         => 'post_title',
+				'address'       => '_VenueAddress',
+				'city'          => '_VenueCity',
+				'state'         => '_VenueState',
+				'province'      => '_VenueProvince',
+				'stateprovince' => '_VenueStateProvince',
+				'postal_code'   => '_VenueZip',
+				'zip'           => '_VenueZip',
+				'country'       => '_VenueCountry',
+				'phone'         => '_VenuePhone',
+				'website'       => '_VenueURL',
+			]
+		);
 
 		$this->linked_id_meta_key = '_EventVenueID';
 
@@ -69,10 +71,32 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 		$this->schema = array_merge(
 			$this->schema,
 			[
-				'has_events'          => [ $this, 'filter_by_has_events' ],
-				'has_no_events'       => [ $this, 'filter_by_has_no_events' ],
+				'has_events'    => [ $this, 'filter_by_has_events' ],
+				'has_no_events' => [ $this, 'filter_by_has_no_events' ],
 			]
 		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function format_item( $id ) {
+		$formatted = null === $this->formatter
+			? tribe_get_venue_object( $id )
+			: $this->formatter->format_item( $id );
+
+		/**
+		 * Filters a single formatted venue result.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed|WP_Post                $formatted The formatted venue result, usually a post object.
+		 * @param int                          $id        The formatted post ID.
+		 * @param Tribe__Repository__Interface $this      The current repository object.
+		 */
+		$formatted = apply_filters( 'tribe_repository_venues_format_item', $formatted, $id, $this );
+
+		return $formatted;
 	}
 
 	/**

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -39,21 +39,24 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 		];
 
 		// Add venue specific aliases.
-		$this->update_fields_aliases = array_merge( $this->update_fields_aliases, [
-			'venue'         => 'post_title',
-			'address'       => '_VenueAddress',
-			'city'          => '_VenueCity',
-			'state'         => '_VenueState',
-			'province'      => '_VenueProvince',
-			'stateprovince' => '_VenueStateProvince',
-			'postal_code'   => '_VenueZip',
-			'zip'           => '_VenueZip',
-			'country'       => '_VenueCountry',
-			'phone'         => '_VenuePhone',
-			'website'       => '_VenueURL',
-			'show_map'      => '_VenueShowMap',
-			'show_map_link' => '_VenueShowMapLink',
-		] );
+		$this->update_fields_aliases = array_merge(
+			$this->update_fields_aliases,
+			[
+				'venue'         => 'post_title',
+				'address'       => '_VenueAddress',
+				'city'          => '_VenueCity',
+				'state'         => '_VenueState',
+				'province'      => '_VenueProvince',
+				'stateprovince' => '_VenueStateProvince',
+				'postal_code'   => '_VenueZip',
+				'zip'           => '_VenueZip',
+				'country'       => '_VenueCountry',
+				'phone'         => '_VenuePhone',
+				'website'       => '_VenueURL',
+				'show_map'      => '_VenueShowMap',
+				'show_map_link' => '_VenueShowMapLink',
+			]
+		);
 
 		$this->linked_id_meta_key = '_EventVenueID';
 
@@ -78,11 +81,12 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Formats a venue handled by the repository to the expected format.
 	 *
 	 * @since TBD Added to Venue ORM.
 	 *
-	 * @param int|WP_Post $id The id or object of the venue to be formatted.
+	 * @param int|WP_Post $id The ID or object of the venue to be formatted.
+	 * @return WP_Post The formatted Venue object.
 	 */
 	protected function format_item( $id ) {
 		$formatted = null === $this->formatter

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -79,6 +79,10 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @since TBD Added to Venue ORM.
+	 *
+	 * @param $id int The id of the current venue.
 	 */
 	protected function format_item( $id ) {
 		$formatted = null === $this->formatter

--- a/src/Tribe/Repositories/Venue.php
+++ b/src/Tribe/Repositories/Venue.php
@@ -82,7 +82,7 @@ class Tribe__Events__Repositories__Venue extends Tribe__Events__Repositories__Li
 	 *
 	 * @since TBD Added to Venue ORM.
 	 *
-	 * @param int $id The id of the current venue.
+	 * @param int|WP_Post $id The id or object of the venue to be formatted.
 	 */
 	protected function format_item( $id ) {
 		$formatted = null === $this->formatter


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5353]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
[Original PR](https://github.com/the-events-calendar/the-events-calendar/pull/4870) - credit to @m8nmueller

This is the second issue addressed in the PR above - currently what is returned from our Venue ORM is a "bare" WP Object:
 
![CleanShot 2025-01-23 at 10 55 26@2x](https://github.com/user-attachments/assets/fdf754f1-ea07-408e-a8de-d753dd071124)

These changes allow the venue object that is returned to be a decorated object: 

![CleanShot 2025-01-23 at 10 57 32@2x](https://github.com/user-attachments/assets/7fe69916-714f-4e58-b168-63ab32c0f648)

These changes are based on the [same function in the Event Repository](https://github.com/the-events-calendar/the-events-calendar/blob/4d14db270f88d2af1bec67149bb7694392a00393/src/Tribe/Repositories/Event.php#L1499-L1519).


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5353]: https://stellarwp.atlassian.net/browse/TEC-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ