### PR TITLE
Added check for `$subscribe_links` and updated docblock

### DIFF
--- a/changelog/fix-TEC-5357-add-type-check-for-single-event-links
+++ b/changelog/fix-TEC-5357-add-type-check-for-single-event-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added a check for `$subscribe_links` in `single_event_links` function. [TEC-5357]

--- a/src/Tribe/Views/V2/iCalendar/Single_Events.php
+++ b/src/Tribe/Views/V2/iCalendar/Single_Events.php
@@ -62,8 +62,10 @@ class Single_Events {
 	 * @see   `tribe_events_ical_single_event_links` filter.
 	 *
 	 * @since 5.16.0
+	 * @since TBD Added a check for `$subscribe_links` to avoid fataling.
 	 *
 	 * @param string $calendar_links The link content.
+	 * @param array $subscribe_links An array of subscription links.
 	 *
 	 * @return string The altered link content.
 	 */
@@ -81,6 +83,11 @@ class Single_Events {
 		 * @param View|null            $view            The current View implementation.
 		 */
 		apply_filters_deprecated( 'tec_views_v2_single_subscribe_links', [ [], null ], '5.16.0', '', 'Single event subscribe links use the subscribe dropdown, there is no replacement for this filter.' );
+
+		// If the subscribe links array is false, bail.
+		if ( false === $subscribe_links ) {
+			return '';
+		}
 
 		if ( 1 === count( $subscribe_links ) ) {
 			// If we only have one link in the list, show a "button".

--- a/src/Tribe/Views/V2/iCalendar/Single_Events.php
+++ b/src/Tribe/Views/V2/iCalendar/Single_Events.php
@@ -84,8 +84,8 @@ class Single_Events {
 		 */
 		apply_filters_deprecated( 'tec_views_v2_single_subscribe_links', [ [], null ], '5.16.0', '', 'Single event subscribe links use the subscribe dropdown, there is no replacement for this filter.' );
 
-		// If the subscribe links array is false, bail.
-		if ( false === $subscribe_links ) {
+		// If the subscribe links are not in an array, bail.
+		if ( ! is_array( $subscribe_links ) ) {
 			return '';
 		}
 

--- a/src/Tribe/Views/V2/iCalendar/Single_Events.php
+++ b/src/Tribe/Views/V2/iCalendar/Single_Events.php
@@ -65,7 +65,7 @@ class Single_Events {
 	 * @since TBD Added a check for `$subscribe_links` to avoid fataling.
 	 *
 	 * @param string $calendar_links The link content.
-	 * @param array $subscribe_links An array of subscription links.
+	 * @param array  $subscribe_links An array of subscription links.
 	 *
 	 * @return string The altered link content.
 	 */


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5357]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

A user reported that they were getting a fatal error because `$subscribe_links` were somehow `false` and triggering a fatal in the `single_event_links` method. This adds a defensive check for the variable type to avoid that fatal. 

### 🎥 Artifacts 
https://github.com/user-attachments/assets/9ee9cf96-4e7b-4e7d-b673-53033f10ed31


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5357]: https://stellarwp.atlassian.net/browse/TEC-5357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ