### PR TITLE
[ECP-1725] Template Override Path Correction for Date-Tag

### DIFF
--- a/changelog/fix-ECP-1725-list-view-shortcode-adjustments
+++ b/changelog/fix-ECP-1725-list-view-shortcode-adjustments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Corrected template override file path for Event List Widget date-tag. [ECP-1725]

--- a/src/views/v2/widgets/widget-events-list/event/date-tag.php
+++ b/src/views/v2/widgets/widget-events-list/event/date-tag.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Widget: Events List Event Venue
+ * Widget: Events List - Event Date Tag.
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/events/v2/widgets/widget-events-list/event/venue.php
+ * [your-theme]/tribe/events/v2/widgets/widget-events-list/event/date-tag.php
  *
  * See more documentation about our views templating system.
  *
  * @link http://evnt.is/1aiy
  *
  * @version 5.2.1
+ * @since TBD Corrected template override file path.
  *
  * @var WP_Post $event The event post object with properties added by the `tribe_get_event` function.
  *


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1725]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The template override path referenced venues but should be pointing to the `date-tag.php` file instead.

### 🎥 Artifacts 
![image](https://github.com/user-attachments/assets/479dda07-63e4-4cc6-baec-3c94ce3b3e88)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ECP-1725]: https://stellarwp.atlassian.net/browse/ECP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ