### PR TITLE
TEC-5360 Subscribe to google calendar issue

### DIFF
--- a/changelog/fix-TEC-5360-subscribe-to-google-calendar
+++ b/changelog/fix-TEC-5360-subscribe-to-google-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the time zone blocks in the iCal feed to make sure the iCal feed is valid and the calendar can be subscribed to. [TEC-5360]

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -603,6 +603,8 @@ class Tribe__Events__iCal {
 				$transitions[] = array_values( $transitions )[ 0 ];
 			}
 
+			$item[] = 'BEGIN:VTIMEZONE';
+
 			$id = $timezone->getName();
 			$item[] = 'TZID:' .  $id;
 
@@ -630,6 +632,8 @@ class Tribe__Events__iCal {
 				$item[] = 'END:' . $type;
 				$last_transition = $transition;
 			}
+
+			$item[] = 'END:VTIMEZONE';
 		}
 
 		/**
@@ -642,7 +646,7 @@ class Tribe__Events__iCal {
 		 */
 		$item = apply_filters( 'tribe_ical_feed_vtimezone', $item, $timezones );
 
-		return "BEGIN:VTIMEZONE\r\n" . implode( "\r\n", $item ) . "\r\nEND:VTIMEZONE\r\n";
+		return implode( "\r\n", $item ) . "\r\n";
 	}
 
 	/**

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -560,13 +560,14 @@ class Tribe__Events__iCal {
 	}
 
 	/**
-	 * Add the VTIMEZONE group to the file
+	 * Add the VTIMEZONE groups to the file.
 	 *
 	 * @since 4.9.4
+	 * @since TBD Make sure that each time zone definition has its own group.
 	 *
-	 * @param array $events
+	 * @param array $events An array with all the events.
 	 *
-	 * @return string
+	 * @return string The string containing all the time zone information needed in the iCal feed/file.
 	 */
 	protected function get_timezones( $events = [] ) {
 		$timezones = $this->parse_timezones( $events );
@@ -637,12 +638,12 @@ class Tribe__Events__iCal {
 		}
 
 		/**
-		 * Allow for customization of an individual "VTIMEZONE" item to be rendered inside an iCal export file.
+		 * Allows customization of the "VTIMEZONE" items rendered inside an iCal export file.
 		 *
 		 * @since 4.9.4
 		 *
-		 * @param array $item The various iCal file format components of this specific event item.
-		 * @param array $timezones The various iCal timzone components of this specific event item.
+		 * @param array $item      The various iCal file format components of the time zones.
+		 * @param array $timezones The various iCal time zone components.
 		 */
 		$item = apply_filters( 'tribe_ical_feed_vtimezone', $item, $timezones );
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5360]

### 🗒️ Description

On some calendars, clicking on the “Subscribe to… Google Calendar” option makes it seem like the calendar is successfully created, but no events are actually imported. In testing, it seems like the Google Importer never actually makes it to the site’s database.
The source of the issue is that All time zones used in the feed for the different events need to be defined at the top, and all time zone definitions should be in their own block.
The bug is that there is only one time zone block containing info about all time zones.
This PR makes sure that all time zones get their own block.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot showing part of the iCal feed and pointing out the lines that were missing.](https://dl.dropbox.com/scl/fi/cy137xc7g0qymc57jdd0k/shot_250205_123047.png?rlkey=jcntz5ql2cj13p32o11di69ab&dl=0)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5360]: https://stellarwp.atlassian.net/browse/TEC-5360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ