### PR TITLE
[TEC-5363] Check `$_FILES` before adding param

### DIFF
--- a/changelog/tweak-TEC-5363-check-FILES-before-setting-param
+++ b/changelog/tweak-TEC-5363-check-FILES-before-setting-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Added check that `$_FILES` is set before setting the param on an HTTP request. [TEC-5363]

--- a/src/Events/Custom_Tables/V1/Updates/Requests.php
+++ b/src/Events/Custom_Tables/V1/Updates/Requests.php
@@ -48,8 +48,10 @@ class Requests {
 		$route   = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 		$request = new WP_REST_Request( $method, $route );
 		$request->set_query_params( wp_unslash( $_GET ) );
-		$request->set_body_params( wp_unslash( $_POST ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$request->set_body_params( wp_unslash( $_POST ) );
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$request->set_file_params( $_FILES ?? [] );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		$server = new WP_REST_Server();
 		$request->set_headers( $server->get_headers( wp_unslash( $_SERVER ) ) );
 		$request->set_body( WP_REST_Server::get_raw_data() );

--- a/src/Events/Custom_Tables/V1/Updates/Requests.php
+++ b/src/Events/Custom_Tables/V1/Updates/Requests.php
@@ -49,7 +49,7 @@ class Requests {
 		$request = new WP_REST_Request( $method, $route );
 		$request->set_query_params( wp_unslash( $_GET ) );
 		$request->set_body_params( wp_unslash( $_POST ) );
-		$request->set_file_params($_FILES ?? []);
+		$request->set_file_params( $_FILES ?? [] );
 		$server = new WP_REST_Server();
 		$request->set_headers( $server->get_headers( wp_unslash( $_SERVER ) ) );
 		$request->set_body( WP_REST_Server::get_raw_data() );

--- a/src/Events/Custom_Tables/V1/Updates/Requests.php
+++ b/src/Events/Custom_Tables/V1/Updates/Requests.php
@@ -48,7 +48,7 @@ class Requests {
 		$route   = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 		$request = new WP_REST_Request( $method, $route );
 		$request->set_query_params( wp_unslash( $_GET ) );
-		$request->set_body_params( wp_unslash( $_POST ) );
+		$request->set_body_params( wp_unslash( $_POST ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$request->set_file_params( $_FILES ?? [] );
 		$server = new WP_REST_Server();
 		$request->set_headers( $server->get_headers( wp_unslash( $_SERVER ) ) );

--- a/src/Events/Custom_Tables/V1/Updates/Requests.php
+++ b/src/Events/Custom_Tables/V1/Updates/Requests.php
@@ -38,6 +38,7 @@ class Requests {
 	 * Models the current HTTP request using a WP REST Request object.
 	 *
 	 * @since 6.0.0
+	 * @since TBD Added check that `$_FILES` exists, otherwise use an empty array.
 	 *
 	 * @return WP_REST_Request A reference to an instance of the WP_Rest_Request
 	 *                         set up to provide information about the current HTTP request.
@@ -48,7 +49,7 @@ class Requests {
 		$request = new WP_REST_Request( $method, $route );
 		$request->set_query_params( wp_unslash( $_GET ) );
 		$request->set_body_params( wp_unslash( $_POST ) );
-		$request->set_file_params( $_FILES );
+		$request->set_file_params($_FILES ?? []);
 		$server = new WP_REST_Server();
 		$request->set_headers( $server->get_headers( wp_unslash( $_SERVER ) ) );
 		$request->set_body( WP_REST_Server::get_raw_data() );


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5363]

### 🗒️ Description

A user reported there’s a conflict with ECP and ACFE Pro, where we assume that the `$_FILES` variable will be set. ACFE Pro form submission with Events Calendar Pro activated results in PHP error, terminating post submission PHP & JS script loading. They are getting this warning:

```
Warning: Undefined global variable $_ FILES in /Users/dougfoster/Local Sites/illumecollective/app/public/wp- content/plugins/the-events-calendar/src/Events/Custom _ Tables/V1/Updates/Requests.php on line 5 1
```
This seems like a unique edge case scenario of a third-party plugin, but adding a check to not assume that the `$_FILES` variable exists makes our code more defensive and is an easy win. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5363]: https://stellarwp.atlassian.net/browse/TEC-5363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ