### PR TITLE
Hide notice from Astra Theme archive template

### DIFF
--- a/changelog/fix-hide_Astra_theme_notice
+++ b/changelog/fix-hide_Astra_theme_notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide Not-Found notice in Astra Theme archive page [TEC-4853]

--- a/src/resources/postcss/base/full/_view.pcss
+++ b/src/resources/postcss/base/full/_view.pcss
@@ -14,3 +14,13 @@
 	margin-left: auto;
 	margin-right: auto;
 }
+
+
+/* ------------------------
+ * Astra Theme Overrides
+ * ------------------------ */
+.page-template-astra.post-type-archive-tribe_events {
+	header.entry-header p {
+		display: none;
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4853]

### 🗒️ Description
[This function](https://themes.trac.wordpress.org/browser/astra/4.8.11/inc/blog/blog.php?rev=257601#L468) in Astra Theme prints the below message in our main Events page:

> It seems we can’t find what you’re looking for. Perhaps searching can help.

Unfortunately they are offering no filters there, thus we can only hide it with CSS.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-4853]: https://stellarwp.atlassian.net/browse/TEC-4853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ