### PR TITLE
Fix/tec 4242 hide subscribe on android

### DIFF
--- a/changelog/fix-TEC-4242-hide-subscribe-on-android
+++ b/changelog/fix-TEC-4242-hide-subscribe-on-android
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Hide the subscribe link for Google Calendar on Android devices to prevent unintended visibility. [TEC-4242]

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -107,6 +107,8 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 		add_filter( 'tec_views_v2_subscribe_links', [ $this, 'filter_tec_views_v2_subscribe_links' ], 10 );
 
 		$this->set_hooked();
+
+		$this->maybe_disable_gcal_subscribe_for_android();
 	}
 
 	/**
@@ -448,5 +450,33 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 			'visible'      => $this->is_visible(),
 			'block_slug'   => $this->block_slug,
 		];
+	}
+
+	/**
+	 * Hides the subscribe link for Google calendar on Android devices.
+	 * The Google Calendar app on Android does not support the "Add calendar" or subscribe feature.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function maybe_disable_gcal_subscribe_for_android(): void {
+		/**
+		 * Allows users to force-show the Google Calendar subscribe link.
+		 * Note: the filter should be placed in the mu-plugins folder.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $disable_gcal_on_android Whether to show (true) or hide (false) the Google Calendar link on
+		 *                                      Android devices. Defaults to false.
+		 */
+		$show_gcal_on_android = apply_filters( 'tec_events_show_gcal_subscribe_on_android', false );
+
+		if (
+			$show_gcal_on_android
+			&& strstr( $_SERVER['HTTP_USER_AGENT'], 'Android' )
+		) {
+			add_filter( 'tec_views_v2_subscribe_link_gcal_visibility', '__return_false' );
+		}
 	}
 }

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -473,7 +473,7 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 		$show_gcal_on_android = apply_filters( 'tec_events_show_gcal_subscribe_on_android', false );
 
 		if (
-			$show_gcal_on_android
+			! $show_gcal_on_android
 			&& strstr( $_SERVER['HTTP_USER_AGENT'], 'Android' )
 		) {
 			add_filter( 'tec_views_v2_subscribe_link_gcal_visibility', '__return_false' );

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -108,7 +108,7 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 
 		$this->set_hooked();
 
-		$this->maybe_disable_gcal_subscribe_for_android();
+		$this->maybe_disable_gcal_subscribe_on_android();
 	}
 
 	/**
@@ -460,7 +460,7 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 	 *
 	 * @return void
 	 */
-	public function maybe_disable_gcal_subscribe_for_android(): void {
+	public function maybe_disable_gcal_subscribe_on_android(): void {
 		/**
 		 * Allows users to force-show the Google Calendar subscribe link.
 		 * Note: the filter should be placed in the mu-plugins folder.

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -474,6 +474,7 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 
 		if (
 			! $show_gcal_on_android
+			&& isset( $_SERVER['HTTP_USER_AGENT'] )
 			&& strstr( $_SERVER['HTTP_USER_AGENT'], 'Android' )
 		) {
 			add_filter( 'tec_views_v2_subscribe_link_gcal_visibility', '__return_false' );

--- a/src/views/v2/components/subscribe-links/list.php
+++ b/src/views/v2/components/subscribe-links/list.php
@@ -17,6 +17,10 @@
 if ( empty( $items ) ) {
 	return;
 }
+
+if ( strstr( $_SERVER['HTTP_USER_AGENT'], 'Android' ) ) {
+	return;
+}
 ?>
 <div class="tribe-events-c-subscribe-dropdown__container">
 	<div class="tribe-events-c-subscribe-dropdown">

--- a/src/views/v2/components/subscribe-links/list.php
+++ b/src/views/v2/components/subscribe-links/list.php
@@ -17,10 +17,6 @@
 if ( empty( $items ) ) {
 	return;
 }
-
-if ( strstr( $_SERVER['HTTP_USER_AGENT'], 'Android' ) ) {
-	return;
-}
 ?>
 <div class="tribe-events-c-subscribe-dropdown__container">
 	<div class="tribe-events-c-subscribe-dropdown">


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4242]

### 🗒️ Description

Choosing Subscribe to calendar > Google Calendar does not work on Android phones. This is due to a limitation in the Google Calendar app for Android.
To avoid users getting confused, we are hiding this option from the 'Subscribe to Calendar' dropdown on the calendar views.
Note: Single event view is different. That doesn't offer 'subscribe' functionality, only 'Add to calendar' which works.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot](https://dl.dropbox.com/scl/fi/vma4ds63jxkf0wuqsv2gs/shot_250218_152613.png?rlkey=0wbxm7d70ehkykavopobg24f7&dl=0) showing faking and Android device in the browser and the Google Calendar link not being visible

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-4242]: https://stellarwp.atlassian.net/browse/TEC-4242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ