### PR TITLE
[TEC-5410] Adjusted logic for Install ET button rendering

### DIFF
--- a/changelog/fix-TEC-5410-install-ET-button-logic
+++ b/changelog/fix-TEC-5410-install-ET-button-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adjusted logic for when the Install Event Tickets button is rendered on the First Time Setup Page. [TEC-5410]

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -526,8 +526,8 @@ class Landing_Page extends Abstract_Admin_Page {
 		 *
 		 * @since 6.8.4
 		 *
-		 * @param array    $initial_data The initial data.
-		 * @param Controller $controller The controller object.
+		 * @param array                   $initial_data The initial data.
+		 * @param Controller|Landing_Page $controller The controller object.
 		 *
 		 * @return array
 		 */

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -382,8 +382,8 @@ class Landing_Page extends Abstract_Admin_Page {
 								<span class="step-list__item-icon" role="presentation"></span>
 								<?php esc_html_e( 'Install Event Tickets', 'the-events-calendar' ); ?>
 							</div>
-							<?php if ( ! isset( $completed_tabs[5] ) && ( ! $et_installed || ! $et_activated ) ) : ?>
-							<div class="step-list__item-right">
+							<?php if ( ! $et_installed || ! $et_activated ) : ?>
+							<div class="step-list__item-right tec-event-tickets-install-button">
 								<?php
 								Installer::get()->render_plugin_button(
 									'event-tickets',

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -382,7 +382,7 @@ class Landing_Page extends Abstract_Admin_Page {
 								<span class="step-list__item-icon" role="presentation"></span>
 								<?php esc_html_e( 'Install Event Tickets', 'the-events-calendar' ); ?>
 							</div>
-							<?php if ( ! $et_installed || ! $et_activated ) : ?>
+							<?php if ( ! isset( $completed_tabs[5] ) && ( ! $et_installed || ! $et_activated ) ) : ?>
 							<div class="step-list__item-right">
 								<?php
 								Installer::get()->render_plugin_button(

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -383,7 +383,7 @@ class Landing_Page extends Abstract_Admin_Page {
 								<?php esc_html_e( 'Install Event Tickets', 'the-events-calendar' ); ?>
 							</div>
 							<?php if ( ! $et_installed || ! $et_activated ) : ?>
-							<div class="step-list__item-right tec-event-tickets-install-button">
+							<div class="step-list__item-right">
 								<?php
 								Installer::get()->render_plugin_button(
 									'event-tickets',

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -75,11 +75,11 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 				});
 
 				if ( tabSettings.currentTab === 5 ) {
-					// If we've already installed Event Tickets, temporarily hide the button to install Event Tickets.
+					// If we've already installed Event Tickets, temporarily remove the button to install Event Tickets.
 					const installButton = document.querySelector('.tec-event-tickets-install-button');
 
 					if ( installButton ) {
-						installButton.style.display = 'none';
+						installButton.parentNode.removeChild( installButton);
 					}
 				}
 

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -74,6 +74,15 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 					stepIndicator.classList.add('tec-admin-page__onboarding-step--completed');
 				});
 
+				if ( tabSettings.currentTab === 5 ) {
+					// If we're on step 5, we should remove the button to install Event Tickets.
+					const installButton = document.querySelector('.tec-event-tickets-install-button');
+
+					if ( installButton ) {
+						installButton.style.display = 'none';
+					}
+				}
+
 				// Reset the saving state.
 				setSaving(false);
 

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -76,10 +76,10 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 
 				if ( tabSettings.currentTab === 5 ) {
 					// If we've already installed Event Tickets, temporarily remove the button to install Event Tickets.
-					const installButton = document.querySelector('.tec-event-tickets-install-button');
+					const installButton = document.querySelector('.stellarwp-installer-tec__install-button--event-tickets');
 
 					if ( installButton ) {
-						installButton.parentNode.removeChild( installButton);
+						installButton.parentNode.removeChild( installButton );
 					}
 				}
 

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -76,7 +76,7 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 
 				if ( tabSettings.currentTab === 5 ) {
 					// If we've already installed Event Tickets, temporarily remove the button to install Event Tickets.
-					const installButton = document.querySelector('.stellarwp-installer-tec__install-button--event-tickets');
+					const installButton = document.querySelector( '.stellarwp-installer-tec__install-button--event-tickets' );
 
 					if ( installButton ) {
 						installButton.parentNode.removeChild( installButton );

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -75,7 +75,7 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 				});
 
 				if ( tabSettings.currentTab === 5 ) {
-					// If we're on step 5, we should remove the button to install Event Tickets.
+					// If we've already installed Event Tickets, temporarily hide the button to install Event Tickets.
 					const installButton = document.querySelector('.tec-event-tickets-install-button');
 
 					if ( installButton ) {


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5410]

### 🗒️ Description

On completely fresh WP installs, if the Onboarding Wizard step 5 was completed to install and activate ET, when the Wizard closed, the green check mark would successfully show, but the 'Install Event Tickets' button would still show incorrectly and cause a console error if clicked. 

This PR adds some logic to remove the 'Install Event Tickets' button if the Onboarding Wizard has been completed. 

I also had to add `Landing_Page` as a controller option to a docblock to satisfy a phpstan comment. 

### 🎥 Artifacts 
Before: 
![image](https://github.com/user-attachments/assets/1a7a9dfe-5cfa-427c-a2ae-02e209314976)

After: 
![CleanShot 2025-02-24 at 15 57 57@2x](https://github.com/user-attachments/assets/44a90678-a9e9-4a71-99ef-4a8c83055bd0)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5410]: https://stellarwp.atlassian.net/browse/TEC-5410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ