### PR TITLE
TEC-5402 Adjust space below steps in the onboarding wizard

### DIFF
--- a/changelog/fix-TEC-5402-adjust-space-below-steps
+++ b/changelog/fix-TEC-5402-adjust-space-below-steps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Adjusted vertical spacing in the onboarding wizard to better fit the content on the screen. [TEC-5402]

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -125,7 +125,7 @@
 @media (min-width: 1024px) {
 	.tec-events-onboarding__tabs {
 		column-gap: 100px;
-		row-gap: 5vh;
+		row-gap: calc(20vh - 100px);
 		grid-template-columns: none;
 		grid-template-rows: 84px auto;
 	}

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -124,7 +124,8 @@
 
 @media (min-width: 1024px) {
 	.tec-events-onboarding__tabs {
-		gap: 100px;
+		column-gap: 100px;
+		row-gap: 5vh;
 		grid-template-columns: none;
 		grid-template-rows: 84px auto;
 	}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5402]

### 🗒️ Description

Starting on Step 2 and in all subsequent steps, the space between the steps and the current icon/name is too big.
To give the vertical gap some flexibility, I used vh instead of a fixed px value for the row-gap.

### 🎥 Artifacts <!-- if applicable-->
[Screen rec](https://1drv.ms/v/s!Aqh6lbOjUW1ThcIWRwNxiFNFzczAEg?e=BdEvrv)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5402]: https://stellarwp.atlassian.net/browse/TEC-5402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ