### PR TITLE
Tweaked when isSaving is set to false

### DIFF
--- a/changelog/fix-TEC-5409-adjust-feedback-on-install-ET
+++ b/changelog/fix-TEC-5409-adjust-feedback-on-install-ET
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adjusted logic for when to reset isSaving state for Onboarding Wizard. [TEC-5409]

--- a/src/resources/packages/wizard/components/buttons/next.tsx
+++ b/src/resources/packages/wizard/components/buttons/next.tsx
@@ -25,7 +25,7 @@ const NextButton = ({ disabled, moveToNextTab, tabSettings }) => {
 
 	// Reset isSaving state when any field in tabSettings changes
 	useEffect(() => {
-		if (tabSettings) {
+		if (tabSettings && !isSaving) {
 			// If the user changes any field, we reset the saving state
 			setSaving(false);
 			// and the button clicked state.


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5409]

### 🗒️ Description

We were resetting the `isSaving` to `false` too early, causing the 'next' button to never show the 'Saving...' text to give the user feedback that the next tab is coming or on the last tab that the modal is about to close.

This adjustment ensures that i`sSaving` is only reset after the necessary processes complete.

### 🎥 Artifacts 
After:
https://github.com/user-attachments/assets/456fe92e-919e-4e15-9628-0694c69bf5b8



### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5409]: https://stellarwp.atlassian.net/browse/TEC-5409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ