### PR TITLE
[TEC-5398] Add Notice to Display Tab

### DIFF
--- a/changelog/fix-TEC-5398-add-notice-for-no-views-selected
+++ b/changelog/fix-TEC-5398-add-notice-for-no-views-selected
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add notice that at least one view is required for Onboarding Wizard display tab. [TEC-5398]

--- a/src/resources/packages/wizard/components/tabs/display/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/display/tab.tsx
@@ -123,6 +123,13 @@ const DisplayContent: React.FC = ({moveToNextTab, skipToNextTab}) => {
 					</div>
 
 				))}
+
+				{!isAnyChecked && (
+					<p className="tec-events-onboarding__view_required_notice">
+						{__("Please select at least one view to continue.", "the-events-calendar")}
+					</p>
+				)}
+
 				<NextButton disabled={!isAnyChecked} moveToNextTab={moveToNextTab} tabSettings={tabSettings} />
 
 				<SkipButton skipToNextTab={skipToNextTab} currentTab={1} />

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -759,6 +759,14 @@
 	margin-top: var(--tec-spacer-1);
 }
 
+.tec-events-onboarding__view_required_notice {
+	color: var(--tec-color-wp-error);
+	font-size: var(--tec-font-size-1);
+	font-weight: var(--tec-font-weight-regular);
+	margin-top: var(--tec-spacer-1);
+	margin: auto;
+}
+
 .tec-events-onboarding__form-field.empty .tec-events-onboarding__required-label,
 .tec-events-onboarding__form-field.invalid .tec-events-onboarding__invalid-label {
 	display: block;


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5398]

### 🗒️ Description

Although we were correctly disabling the 'Continue' button if no views were selected on the Display tab for the Onboarding Wizard we needed to add a notice to give feedback to the user so they understand why the button had been disabled. This PR adds that notice and some styling to match other notices in the Wizard. 

### 🎥 Artifacts 
Before:

https://github.com/user-attachments/assets/440409d2-8cfc-4aff-b4db-1fb148416d71

After:

https://github.com/user-attachments/assets/567f0b94-0c0e-4913-88ad-8a4a5ecbd2e7



### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5398]: https://stellarwp.atlassian.net/browse/TEC-5398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ