### PR TITLE
TEC-5411 first time setup page keeps appearing

### DIFF
--- a/changelog/fix-TEC-5411-first-time-setup-page-keeps-appearing
+++ b/changelog/fix-TEC-5411-first-time-setup-page-keeps-appearing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Make sure the Setup Guide page shows up only when asked for. [TEC-5411]

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -108,7 +108,7 @@ class Controller extends Controller_Contract {
 	 * @since 6.8.4
 	 */
 	public function remove_actions(): void {
-		remove_action( 'admin_menu', [ $this, 'landing_page' ] );
+		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
 		remove_action( 'admin_init', [ $this, 'enqueue_scripts' ] );
 		remove_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
 		remove_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -68,6 +68,7 @@ class Controller extends Controller_Contract {
 	 * Add the action hooks.
 	 *
 	 * @since 6.8.4
+	 * @since TBD Changed the priority of `admin_menu` to reposition menu item.
 	 */
 	public function add_actions(): void {
 		add_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
@@ -106,6 +107,7 @@ class Controller extends Controller_Contract {
 	 * Remove the action hooks.
 	 *
 	 * @since 6.8.4
+	 * @since TBD Changed the priority of `admin_menu`.
 	 */
 	public function remove_actions(): void {
 		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -70,7 +70,7 @@ class Controller extends Controller_Contract {
 	 * @since 6.8.4
 	 */
 	public function add_actions(): void {
-		add_action( 'admin_menu', [ $this, 'landing_page' ] );
+		add_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
 		add_action( 'admin_init', [ $this, 'enqueue_assets' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
 		add_action( 'admin_post_' . Landing_Page::DISMISS_ONBOARDING_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -455,7 +455,7 @@ class Landing_Page extends Abstract_Admin_Page {
 			<section class="tec-admin-page__sidebar-section has-icon">
 				<span class="tec-admin-page__icon tec-admin-page__sidebar-icon tec-admin-page__icon--stars" role="presentation"></span>
 				<div>
-					<h3 class="tec-admin-page__sidebar-header"><?php esc_html_e( 'Our AI Chatbot is here to help you', 'the-events-calendar' ); ?></h2>
+					<h3 class="tec-admin-page__sidebar-header"><?php esc_html_e( 'Our AI Chatbot is here to help you', 'the-events-calendar' ); ?></h3>
 					<p><?php esc_html_e( 'You have questions? The TEC Chatbot has the answers.', 'the-events-calendar' ); ?></p>
 					<p><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=tribe_events&page=tec-events-help-hub' ) ); ?>" class="tec-admin-page__link"><?php esc_html_e( 'Talk to TEC Chatbot', 'the-events-calendar' ); ?></a></p>
 				</div>

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -97,7 +97,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return string The page title.
 	 */
 	public function get_the_page_title(): string {
-		return esc_html__( 'TEC First Time Setup Page', 'the-events-calendar' );
+		return esc_html__( 'TEC Setup Guide', 'the-events-calendar' );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return string The menu title.
 	 */
 	public function get_the_menu_title(): string {
-		return esc_html__( 'First Time Setup', 'the-events-calendar' );
+		return esc_html__( 'Setup Guide', 'the-events-calendar' );
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -166,7 +166,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @since 6.8.4
 	 *
-	 * @return void The required capability.
+	 * @return void
 	 */
 	public function handle_onboarding_page_dismiss(): void {
 		if ( ! current_user_can( $this->required_capability() ) ) {

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -90,6 +90,66 @@ class Landing_Page extends Abstract_Admin_Page {
 	public int $menu_position = 0;
 
 	/**
+	 * Constructor.
+	 *
+	 * @since 6.8.4
+	 */
+	public function __construct() {
+		// Add our custom menu registration.
+		add_action( 'admin_menu', [ $this, 'register_menu_item' ], 51 );
+	}
+
+	/**
+	 * Register the menu item in the correct position.
+	 *
+	 * @since 6.8.4
+	 */
+	public function register_menu_item(): void {
+		global $submenu;
+
+		if ( static::is_dismissed() ) {
+			return;
+		}
+
+		// Wait until Settings is registered.
+		if ( ! isset( $submenu['edit.php?post_type=tribe_events'] ) ) {
+			return;
+		}
+
+		// Find the Settings position.
+		$settings_position = null;
+		foreach ( $submenu['edit.php?post_type=tribe_events'] as $position => $item ) {
+			// Remove the original submenu item
+			if ( isset( $item[2] ) && $item[2] === 'first-time-setup' ) {
+				unset( $submenu['edit.php?post_type=tribe_events'][ $position ] );
+			}
+
+			// Reindex the array.
+			$submenu['edit.php?post_type=tribe_events'] = array_values( $submenu['edit.php?post_type=tribe_events'] );
+
+			if ( isset( $item[2] ) && $item[2] === 'tec-events-settings' ) {
+				$settings_position = $position;
+				break;
+			}
+		}
+
+		if ( $settings_position === null ) {
+			return;
+		}
+
+		// Register our menu item right before Settings.
+		add_submenu_page(
+			'edit.php?post_type=tribe_events',
+			$this->get_the_page_title(),
+			$this->get_the_menu_title(),
+			$this->required_capability(),
+			static::$slug,
+			[ $this, 'admin_page_content' ],
+			$settings_position - 1
+		);
+	}
+
+	/**
 	 * Get the admin page title.
 	 *
 	 * @since 6.8.4

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -84,6 +84,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * The position of the submenu in the menu.
 	 *
 	 * @since 6.8.4
+	 * @since TBD Changed menu position.
 	 *
 	 * @var int
 	 */
@@ -93,6 +94,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Get the admin page title.
 	 *
 	 * @since 6.8.4
+	 * @since TBD Changed page title.
 	 *
 	 * @return string The page title.
 	 */
@@ -115,6 +117,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Get the admin menu title.
 	 *
 	 * @since 6.8.4
+	 * @since TBD Changed menu title.
 	 *
 	 * @return string The menu title.
 	 */
@@ -127,7 +130,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @since 6.8.4
 	 *
-	 * @return string The class(es) string.
+	 * @return array The class(es) array.
 	 */
 	public function content_wrapper_classes(): array {
 		$classes   = parent::content_classes();
@@ -159,11 +162,11 @@ class Landing_Page extends Abstract_Admin_Page {
 	}
 
 	/**
-	 * Get the required capability to view the page.
+	 * Handle the dismissal of the onboarding page.
 	 *
 	 * @since 6.8.4
 	 *
-	 * @return string The required capability.
+	 * @return void The required capability.
 	 */
 	public function handle_onboarding_page_dismiss(): void {
 		if ( ! current_user_can( $this->required_capability() ) ) {
@@ -180,6 +183,8 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Render the landing page content.
 	 *
 	 * @since 6.8.4
+	 *
+	 * @return void
 	 */
 	public function admin_page_main_content(): void {
 		$this->admin_content_checklist_section();
@@ -187,7 +192,7 @@ class Landing_Page extends Abstract_Admin_Page {
 		$this->admin_content_resources_section();
 
 
-		// Only show the wizard if we're doing a new install.
+		// Only show the wizard if we're doing a new installation.
 		$this->tec_onboarding_wizard_target();
 	}
 
@@ -198,7 +203,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @return void
 	 */
-	public function admin_content_checklist_section() {
+	public function admin_content_checklist_section(): void {
 		$settings_url   = 'edit.php?page=tec-events-settings&post_type=tribe_events';
 		$data           = tribe( Data::class );
 		$completed_tabs = array_flip( (array) $data->get_wizard_setting( 'completed_tabs', [] ) );
@@ -408,7 +413,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @return void
 	 */
-	public function admin_content_resources_section() {
+	public function admin_content_resources_section(): void {
 		$chatbot_link   = admin_url( 'edit.php?post_type=tribe_events&page=tec-events-help-hub' );
 		$guide_link     = 'https://theeventscalendar.com/knowledgebase/guide/the-events-calendar/';
 		$customize_link = 'https://theeventscalendar.com/knowledgebase/guide/customization/';
@@ -449,6 +454,8 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Render the admin page sidebar.
 	 *
 	 * @since 6.8.4
+	 *
+	 * @return void
 	 */
 	public function admin_page_sidebar_content(): void {
 		?>
@@ -475,6 +482,8 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Render the admin page footer.
 	 *
 	 * @since 6.8.4
+	 *
+	 * @return void
 	 */
 	public function admin_page_footer_content(): void {
 		// no op.
@@ -526,8 +535,8 @@ class Landing_Page extends Abstract_Admin_Page {
 		 *
 		 * @since 6.8.4
 		 *
-		 * @param array    $initial_data The initial data.
-		 * @param Controller $controller The controller object.
+		 * @param array      $initial_data The initial data.
+		 * @param Controller $controller   The controller object.
 		 *
 		 * @return array
 		 */
@@ -551,6 +560,8 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * );
 	 *
 	 * @since 6.8.4
+	 *
+	 * @return void
 	 */
 	public function tec_onboarding_wizard_target(): void {
 		$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
@@ -578,8 +589,10 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * Register the assets for the landing page.
 	 *
 	 * @since 6.8.4
+	 *
+	 * @return void
 	 */
-	public function register_assets() {
+	public function register_assets(): void {
 		Asset::add(
 			'tec-events-onboarding-wizard-script',
 			'index.js'

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -108,7 +108,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return bool
 	 */
 	public static function is_dismissed(): bool {
-		return false && (bool) tribe_get_option( 'tec_events_onboarding_page_dismissed', false );
+		return (bool) tribe_get_option( 'tec_events_onboarding_page_dismissed', false );
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -87,67 +87,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @var int
 	 */
-	public int $menu_position = 0;
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 6.8.4
-	 */
-	public function __construct() {
-		// Add our custom menu registration.
-		add_action( 'admin_menu', [ $this, 'register_menu_item' ], 51 );
-	}
-
-	/**
-	 * Register the menu item in the correct position.
-	 *
-	 * @since 6.8.4
-	 */
-	public function register_menu_item(): void {
-		global $submenu;
-
-		if ( static::is_dismissed() ) {
-			return;
-		}
-
-		// Wait until Settings is registered.
-		if ( ! isset( $submenu['edit.php?post_type=tribe_events'] ) ) {
-			return;
-		}
-
-		// Find the Settings position.
-		$settings_position = null;
-		foreach ( $submenu['edit.php?post_type=tribe_events'] as $position => $item ) {
-			// Remove the original submenu item
-			if ( isset( $item[2] ) && $item[2] === 'first-time-setup' ) {
-				unset( $submenu['edit.php?post_type=tribe_events'][ $position ] );
-			}
-
-			// Reindex the array.
-			$submenu['edit.php?post_type=tribe_events'] = array_values( $submenu['edit.php?post_type=tribe_events'] );
-
-			if ( isset( $item[2] ) && $item[2] === 'tec-events-settings' ) {
-				$settings_position = $position;
-				break;
-			}
-		}
-
-		if ( $settings_position === null ) {
-			return;
-		}
-
-		// Register our menu item right before Settings.
-		add_submenu_page(
-			'edit.php?post_type=tribe_events',
-			$this->get_the_page_title(),
-			$this->get_the_menu_title(),
-			$this->required_capability(),
-			static::$slug,
-			[ $this, 'admin_page_content' ],
-			$settings_position - 1
-		);
-	}
+	public int $menu_position = 21;
 
 	/**
 	 * Get the admin page title.
@@ -168,7 +108,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return bool
 	 */
 	public static function is_dismissed(): bool {
-		return (bool) tribe_get_option( 'tec_events_onboarding_page_dismissed', false );
+		return false && (bool) tribe_get_option( 'tec_events_onboarding_page_dismissed', false );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5411]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

When a user has completed all the steps inside the Wizard, and they click on the "Events" menu item, they are still taken to the “First Time Setup” page, because that is the first menu item. This behavior can be confusing to users, so the submenu item has been moved to the bottom and renamed to "Setup Guide".

### 🎥 Artifacts <!-- if applicable-->
[Screen rec](https://docs.google.com/videos/d/1wAVhzQxJo03M6bTcvRKfhoImvDQtPfqyOZy7F6lmQhM/edit?usp=sharing)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5411]: https://stellarwp.atlassian.net/browse/TEC-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ