### PR TITLE
Feat/ece fe amends

### DIFF
--- a/src/Events/Calendar_Embeds/Calendar_Embeds.php
+++ b/src/Events/Calendar_Embeds/Calendar_Embeds.php
@@ -239,7 +239,8 @@ class Calendar_Embeds extends Controller_Contract {
 	 *
 	 * @since TBD
 	 *
-	 * @param int $post_id The post ID.
+	 * @param int  $post_id                  The post ID.
+	 * @param bool $throw_when_not_published Whether to throw an exception if the calendar is not published.
 	 *
 	 * @return string
 	 * @throws NotPublishedCalendarException When the calendar is not published.
@@ -261,7 +262,7 @@ class Calendar_Embeds extends Controller_Contract {
 
 		$embed_url = 'publish' === $embed->post_status ? get_post_embed_url( $embed ) : get_preview_post_link( $embed, [ 'embed' => 1 ] );
 
-		$iframe = '<iframe src="' . esc_url( $embed_url ) . '" width="100%" height="600" style="max-width:100%;" frameborder="0"></iframe>';
+		$iframe = '<iframe src="' . esc_url( $embed_url ) . '" width="100%" height="1065" style="max-width:100%;" frameborder="0"></iframe>';
 
 		/**
 		 * Filter the iframe code for the calendar embed.

--- a/src/Events/Calendar_Embeds/Frontend.php
+++ b/src/Events/Calendar_Embeds/Frontend.php
@@ -12,6 +12,7 @@ namespace TEC\Events\Calendar_Embeds;
 use TEC\Common\Contracts\Container;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use Tribe\Events\Views\V2\Assets as Event_Assets;
+use TEC\Common\StellarWP\Assets\Asset;
 
 /**
  * Class Controller
@@ -53,6 +54,7 @@ class Frontend extends Controller_Contract {
 	 * @return void
 	 */
 	public function do_register(): void {
+		$this->register_assets();
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_filter( 'embed_template', [ $this, 'overwrite_embed_template' ] );
 		add_filter( 'the_content', [ $this, 'overwrite_content' ] );
@@ -84,6 +86,15 @@ class Frontend extends Controller_Contract {
 		}
 
 		tribe_asset_enqueue_group( Event_Assets::$group_key );
+
+		/**
+		 * Fires when the calendar embeds scripts are enqueued.
+		 *
+		 * Applicable to frontend and only singular screen.
+		 *
+		 * @since TBD
+		 */
+		do_action( 'tec_events_calendar_embeds_enqueue_scripts' );
 	}
 
 	/**
@@ -132,5 +143,32 @@ class Frontend extends Controller_Contract {
 		}
 
 		return $this->template->get_template_file( 'embed' );
+	}
+
+	/**
+	 * Register assets for the Calendar Embeds singular Frontend page.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function register_assets(): void {
+		Asset::add(
+			'tec-events-calendar-embeds-frontend-script',
+			'js/calendar-embeds/page.js'
+		)
+			->add_to_group_path( 'tec-events-resources' )
+			->enqueue_on( 'tec_events_calendar_embeds_enqueue_scripts' )
+			->set_dependencies( 'jquery' )
+			->in_footer()
+			->register();
+
+		Asset::add(
+			'tec-events-calendar-embeds-frontend-style',
+			'css/calendar-embeds/page.css'
+		)
+			->add_to_group_path( 'tec-events-resources' )
+			->enqueue_on( 'tec_events_calendar_embeds_enqueue_scripts' )
+			->register();
 	}
 }

--- a/src/resources/js/calendar-embeds/page.js
+++ b/src/resources/js/calendar-embeds/page.js
@@ -1,0 +1,53 @@
+/**
+ * Init the tec.main.ece object.
+ *
+ * @since TBD
+ */
+window.tec = window.tec || {};
+window.tec.main = window.tec.main || {};
+window.tec.main.ece = window.tec.main.ece || {};
+
+(function($,obj){
+	const $document = $(document);
+
+	/**
+	 * Selectors used to attach listeners.
+	 *
+	 * @since TBD
+	 * @type {Object}
+	 */
+	obj.selectors = {
+		eventsInDay: '.tribe-events-calendar-month__calendar-event a',
+		eventsInToolTip: '.tribe-events-tooltip-theme a',
+	};
+
+	/**
+	 * Open the event in a new tab.
+	 *
+	 * @since TBD
+	 * @param {Event} e
+	 */
+	obj.openEventInNewTab = ( e ) => {
+		if ( ! e.target.href ) {
+			return;
+		}
+
+		e.preventDefault();
+
+		window.open( e.target.href, '_blank' );
+	};
+
+	/**
+	 * Ready function.
+	 *
+	 * @since TBD
+	 * @type {Function}
+	 */
+	obj.ready = () => {
+		$document.on( 'click', obj.selectors.eventsInDay, obj.openEventInNewTab );
+		$document.on( 'click', obj.selectors.eventsInToolTip, obj.openEventInNewTab );
+	};
+
+	// Init on dom ready.
+	$( obj.ready() );
+})(jQuery, window.tec.main.ece);

--- a/src/resources/postcss/calendar-embeds/page.pcss
+++ b/src/resources/postcss/calendar-embeds/page.pcss
@@ -1,0 +1,25 @@
+body.single-tec_calendar_embed {
+	.tribe-events {
+		.tribe-events-l-container {
+			padding: var(--tec-spacer-4);
+		}
+
+		&.tribe-common--breakpoint-medium .tribe-events-calendar-month__day {
+			min-height: 140px;
+		}
+
+		.tribe-events-c-subscribe-dropdown {
+			margin-bottom: 0;
+			position:relative;
+		}
+
+		#tribe-events-c-subscribe-dropdown-content {
+			bottom: 55px;
+			position: absolute;
+		}
+
+		.tribe-common-c-svgicon--caret-down {
+			display: none;
+		}
+	}
+}

--- a/tests/embed_calendar_integration/Admin/__snapshots__/List_Page_Test__it_should_render_the_expected_column_content__0.snapshot.html
+++ b/tests/embed_calendar_integration/Admin/__snapshots__/List_Page_Test__it_should_render_the_expected_column_content__0.snapshot.html
@@ -1,10 +1,10 @@
 <a href="http://wordpress.test/wp-admin/term.php?taxonomy=tribe_events_cat&#038;tag_ID={CAT_ID}&#038;post_type=tribe_events">
-						Cat1</a>, <a href="http://wordpress.test/wp-admin/term.php?taxonomy=tribe_events_cat&#038;tag_ID={CAT_ID}&#038;post_type=tribe_events">
-						Cat2</a>
+				Cat1</a>, <a href="http://wordpress.test/wp-admin/term.php?taxonomy=tribe_events_cat&#038;tag_ID={CAT_ID}&#038;post_type=tribe_events">
+				Cat2</a>
 {COLUMN_DIVIDER}
 <a href="http://wordpress.test/wp-admin/term.php?taxonomy=post_tag&#038;tag_ID={TAG_ID}&#038;post_type=post">
-						Tag1</a>, <a href="http://wordpress.test/wp-admin/term.php?taxonomy=post_tag&#038;tag_ID={TAG_ID}&#038;post_type=post">
-						Tag2</a>
+				Tag1</a>, <a href="http://wordpress.test/wp-admin/term.php?taxonomy=post_tag&#038;tag_ID={TAG_ID}&#038;post_type=post">
+				Tag2</a>
 {COLUMN_DIVIDER}
 <div id="tec_events_calendar_embeds_snippet_{ECE_ID}" class="hidden">
 	<div>
@@ -15,7 +15,7 @@
 			class="tec-events-calendar-embeds__snippet-modal-textarea"
 			aria-label="Embed snippet code"
 			rows="3"
-			readonly>&lt;iframe src=&quot;http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&amp;#038;embed=true&quot; width=&quot;100%&quot; height=&quot;600&quot; style=&quot;max-width:100%;&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;</textarea>
+			readonly>&lt;iframe src=&quot;http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&amp;#038;embed=true&quot; width=&quot;100%&quot; height=&quot;1065&quot; style=&quot;max-width:100%;&quot; frameborder=&quot;0&quot;&gt;&lt;/iframe&gt;</textarea>
 		<button
 			class="button button-primary tec-events-calendar-embeds__snippet-modal-copy-button"
 			aria-controls="tec_events_calendar_embeds_snippet_code_{ECE_ID}"

--- a/tests/embed_calendar_integration/Admin/__snapshots__/Singular_Page_Test__it_should_render_embed_preview__0.snapshot.html
+++ b/tests/embed_calendar_integration/Admin/__snapshots__/Singular_Page_Test__it_should_render_embed_preview__0.snapshot.html
@@ -1,1 +1,1 @@
-<iframe src="http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&#038;embed=true" width="100%" height="600" style="max-width:100%;" frameborder="0"></iframe>
+<iframe src="http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&#038;embed=true" width="100%" height="1065" style="max-width:100%;" frameborder="0"></iframe>

--- a/tests/embed_calendar_integration/Admin/__snapshots__/Singular_Page_Test__it_should_replace_iframe_markup_for_auto_drafts__0.snapshot.html
+++ b/tests/embed_calendar_integration/Admin/__snapshots__/Singular_Page_Test__it_should_replace_iframe_markup_for_auto_drafts__0.snapshot.html
@@ -1,3 +1,3 @@
-<iframe src="http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&#038;embed=true" width="100%" height="600" style="max-width:100%;" frameborder="0"></iframe>
+<iframe src="http://wordpress.test/?tec_calendar_embed=ece-static-slug-1&#038;embed=true" width="100%" height="1065" style="max-width:100%;" frameborder="0"></iframe>
 {SNAPSHOT_DIVIDER}
 <p><strong>Please save the embed to see the preview.</strong></p>

--- a/tests/embed_calendar_integration/Frontend_Test.php
+++ b/tests/embed_calendar_integration/Frontend_Test.php
@@ -7,6 +7,7 @@ use Tribe\Tests\Traits\With_Uopz;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 use Tribe\Events\Test\Traits\ECE_Maker;
 use Tribe\Tests\Traits\With_Clock_Mock;
+use TEC\Common\StellarWP\Assets\Assets;
 use Tribe__Date_Utils as Dates;
 use Tribe__Events__Main as TEC;
 use Generator;
@@ -252,5 +253,30 @@ class Frontend_Test extends Controller_Test_Case {
 		$filtered = str_replace( $date, date( 'Y-m-d' ), $filtered );
 
 		$this->assertMatchesHtmlSnapshot( $filtered );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider asset_data_provider
+	 */
+	public function it_should_locate_assets_where_expected( $slug, $path ) {
+		$this->make_controller()->register();
+
+		$this->assertTrue( Assets::init()->exists( $slug ) );
+
+		// We use false, because in CI mode the assets are not build so min aren't available. Its enough to check that the non-min is as expected.
+		$asset_url = Assets::init()->get( $slug )->get_url( false );
+		$this->assertEquals( plugins_url( $path, TRIBE_EVENTS_FILE ), $asset_url );
+	}
+
+	public function asset_data_provider() {
+		$assets = [
+			'tec-events-calendar-embeds-frontend-script' => 'src/resources/js/calendar-embeds/page.js',
+			'tec-events-calendar-embeds-frontend-style'  => 'src/resources/css/calendar-embeds/page.css',
+		];
+
+		foreach ( $assets as $slug => $path ) {
+			yield $slug => [ $slug, $path ];
+		}
 	}
 }

--- a/tests/embed_calendar_integration/__snapshots__/Calendar_Embeds_Test__it_should_retrieve_iframes_markup__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Calendar_Embeds_Test__it_should_retrieve_iframes_markup__0.snapshot.html
@@ -1,1 +1,1 @@
-<iframe src="http://wordpress.test/?tec_calendar_embed=ece&#038;embed=true" width="100%" height="600" style="max-width:100%;" frameborder="0"></iframe>
+<iframe src="http://wordpress.test/?tec_calendar_embed=ece&#038;embed=true" width="100%" height="1065" style="max-width:100%;" frameborder="0"></iframe>

--- a/tests/embed_calendar_integration/__snapshots__/Calendar_Embeds_Test__it_should_retrieve_iframes_markup_not_published__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Calendar_Embeds_Test__it_should_retrieve_iframes_markup_not_published__0.snapshot.html
@@ -1,1 +1,1 @@
-<iframe src="http://wordpress.test/?post_type=tec_calendar_embed&#038;p={ECE_ID}&#038;embed=1&#038;preview=true" width="100%" height="600" style="max-width:100%;" frameborder="0"></iframe>
+<iframe src="http://wordpress.test/?post_type=tec_calendar_embed&#038;p={ECE_ID}&#038;embed=1&#038;preview=true" width="100%" height="1065" style="max-width:100%;" frameborder="0"></iframe>


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5391]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Changelog has already been included for this feature.

Performs some amends for the FE appearance of calendar embeds. More specifically:

- Per strategy - events inside the calendar will open in a new tab.
- Adjusts with CSS spacing of the calendar.
- Adjusts height of each day of the calendar.
- The two above result in the embed to "save" about 600px of height.
- Raises the height of the iframe to 1065px - combined with the above - the calendar renders without a scrollbar now.
- Makes the "Subscribe" to calendar dropdowns of absolute position so that they would not take more height when they open. It also makes them appear in the top side of the button.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/0e6e3ab183c14e549dab35f7dfe40f36

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5391]: https://stellarwp.atlassian.net/browse/TEC-5391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ