### PR TITLE
Hide second label in inline edit for calendar embeds

### DIFF
--- a/src/resources/postcss/calendar-embeds/admin/page.pcss
+++ b/src/resources/postcss/calendar-embeds/admin/page.pcss
@@ -2,6 +2,12 @@
 	display: none;
 }
 
+.inline-edit-tec_calendar_embed .inline-edit-col-left .inline-edit-col {
+	label:nth-child(2) {
+		display: none;
+	}
+}
+
 .post-type-tec_calendar_embed {
 	.tec-events-calendar-embeds__snippet-modal-text {
 		font-size: var(--tec-font-size-2);


### PR DESCRIPTION
Hide slug input field from quick edit form - We disallow edit from php's side as well. This just amends the specific UI.


sshot with markup attached.

![image](https://github.com/user-attachments/assets/d712715d-807b-40bb-bba9-351361dfd8ab)
