### PR TITLE
Optimize performance for context locations

### DIFF
--- a/src/Tribe/Service_Providers/Context.php
+++ b/src/Tribe/Service_Providers/Context.php
@@ -41,18 +41,16 @@ class Context extends Service_Provider {
 	}
 
 	/**
-	 * Filters the context locations to add the ones used by The Events Calendar.
+	 * Get the locations array for filtering.
 	 *
-	 * @since 4.9.4
+	 * This function makes sure it is only initialized once.
 	 *
-	 * @param array $locations The array of context locations.
-	 *
-	 * @return array The modified context locations.
+	 * @return array The array of context locations.
 	 */
-	public function filter_context_locations( array $locations = [] ) {
-		$locations = array_merge(
-			$locations,
-			[
+	private static function context_locations_array() {
+		static $locations_array = [];
+		if ( empty( $locations_array ) ) {
+			$locations_array = [
 				'event_display'        => [
 					'read'  => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
@@ -162,8 +160,8 @@ class Context extends Service_Provider {
 						Tribe__Context::WP_MATCHED_QUERY => 'featured',
 					],
 					'write' => [
-						Tribe__Context::REQUEST_VAR      => 'featured',
-						Tribe__Context::QUERY_VAR        => 'featured',
+						Tribe__Context::REQUEST_VAR => 'featured',
+						Tribe__Context::QUERY_VAR   => 'featured',
 					],
 				],
 				TEC::TAXONOMY          => [
@@ -198,12 +196,12 @@ class Context extends Service_Provider {
 						Tribe__Context::QUERY_VAR   => [ 'eventDisplay', 'tribe_event_display' ],
 					],
 				],
-				'tribe_event_display'   => [
+				'tribe_event_display'  => [
 					/**
 					 * On V1 we depend on `tribe_event_display` to handle Plain permalink usage of `past` events.
 					 * The context need to be aware of where to read and write this from.
 					 */
-					'read' => [
+					'read'  => [
 						Tribe__Context::REQUEST_VAR => [ 'tribe_event_display' ],
 						Tribe__Context::WP_PARSED   => [ 'tribe_event_display' ],
 						Tribe__Context::QUERY_VAR   => [ 'tribe_event_display' ],
@@ -215,12 +213,12 @@ class Context extends Service_Provider {
 				],
 				'keyword'              => [
 					'read' => [
-						Tribe__Context::FUNC        => [
+						Tribe__Context::FUNC          => [
 							static function () {
 								return Utils\View::get_data( 'bar-keyword', Tribe__Context::NOT_FOUND );
 							},
 						],
-						Tribe__Context::REQUEST_VAR => [ 's', 'search', 'tribe-bar-search' ],
+						Tribe__Context::REQUEST_VAR   => [ 's', 'search', 'tribe-bar-search' ],
 						Tribe__Context::LOCATION_FUNC => [
 							'view_data',
 							static function ( $data ) {
@@ -256,8 +254,8 @@ class Context extends Service_Provider {
 					'read' => [
 						Tribe__Context::FUNC => static function () {
 							return Dates::build_date_object()
-										->setTime( 0, 0, 0 )
-										->format( Dates::DBDATETIMEFORMAT );
+							            ->setTime( 0, 0, 0 )
+							            ->format( Dates::DBDATETIMEFORMAT );
 						},
 					],
 				],
@@ -295,6 +293,7 @@ class Context extends Service_Provider {
 										[ TEC::POSTTYPE, Venue::POSTTYPE, Organizer::POSTTYPE, ]
 									)
 								);
+
 								return $found ?: Tribe__Context::NOT_FOUND;
 							},
 						],
@@ -386,7 +385,7 @@ class Context extends Service_Provider {
 					],
 				],
 				'view_request'         => [
-					'read'  => [
+					'read' => [
 						Tribe__Context::WP_MATCHED_QUERY => [ 'eventDisplay' ],
 						Tribe__Context::WP_PARSED        => [ 'eventDisplay' ],
 						Tribe__Context::REQUEST_VAR      => [ 'view', 'tribe_view', 'tribe_event_display', 'eventDisplay' ],
@@ -409,9 +408,26 @@ class Context extends Service_Provider {
 						Tribe__Context::TRIBE_OPTION => [ 'earliest_date' ],
 					],
 				],
-			]
+			];
+		}
+
+		return $locations_array;
+	}
+
+	/**
+	 * Filters the context locations to add the ones used by The Events Calendar.
+	 *
+	 * @since 4.9.4
+	 *
+	 * @param array $locations The array of context locations.
+	 *
+	 * @return array The modified context locations.
+	 */
+	public function filter_context_locations( array $locations = [] ) {
+		return array_merge(
+			$locations,
+			self::context_locations_array()
 		);
 
-		return $locations;
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket
N/A

### 🗒️ Description
The `tribe_context_locations` filter gets called a lot. On my local testing machine it gets called 500+ times pr. page load. 

This PR makes it so that the large array with closures in it will only be created once instead of each filter call. In my unscientific testing this PR makes the "Own Memory" for each page load go from ~25 MB to ~0.0788 MB for the `Tribe\Events\Service_Providers\Context->filter_context_locations` function. This will considerably improve performance.

#### How to test
The only testing is to see that everything works the same as always :) 

### 🎥 Artifacts <!-- if applicable-->
#### Screenshots from PHPStorm's xdebug profiler
##### Before
![before](https://github.com/user-attachments/assets/731ffc41-e6eb-4f32-a49c-0dabf98738c8)
##### After
![after](https://github.com/user-attachments/assets/94ce0c1f-6043-4691-88dd-d090dba30643)


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
