### PR TITLE
Dont change the ECE slug when trashed

### DIFF
--- a/src/Events/Calendar_Embeds/Calendar_Embeds.php
+++ b/src/Events/Calendar_Embeds/Calendar_Embeds.php
@@ -47,6 +47,7 @@ class Calendar_Embeds extends Controller_Contract {
 		add_filter( 'wp_insert_post_data', [ $this, 'disable_slug_changes' ], 10, 4 );
 		add_filter( 'get_terms', [ $this, 'modify_term_count_on_term_list_table' ], 10, 2 );
 		add_action( 'template_redirect', [ $this, 'redirect_to_embed' ] );
+		add_filter( 'add_trashed_suffix_to_trashed_posts', [ $this, 'do_not_add_trashed_suffix_to_trashed_calendar_embeds' ], 10, 3 );
 	}
 
 	/**
@@ -62,6 +63,7 @@ class Calendar_Embeds extends Controller_Contract {
 		remove_filter( 'wp_insert_post_data', [ $this, 'disable_slug_changes' ] );
 		remove_filter( 'get_terms', [ $this, 'modify_term_count_on_term_list_table' ] );
 		remove_action( 'template_redirect', [ $this, 'redirect_to_embed' ] );
+		remove_filter( 'add_trashed_suffix_to_trashed_posts', [ $this, 'do_not_add_trashed_suffix_to_trashed_calendar_embeds' ] );
 	}
 
 	/**
@@ -164,7 +166,7 @@ class Calendar_Embeds extends Controller_Contract {
 
 		if ( $update ) {
 			// Ensure the post name is not updated.
-			$data['post_name'] = get_post( $post_array['ID'] )->post_name;
+			$data['post_name'] = str_replace( '__trashed', '', get_post( $post_array['ID'] )->post_name );
 
 			return $data;
 		}
@@ -377,5 +379,24 @@ class Calendar_Embeds extends Controller_Contract {
 		}
 
 		return array_filter( $tags, static fn ( $t ) => $t instanceof WP_Term );
+	}
+
+	/**
+	 * Do not add trashed suffix to trashed calendar embeds.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool   $add_trashed_suffix Whether to add the trashed suffix.
+	 * @param string $post_name          The post name.
+	 * @param int    $post_id            The post ID.
+	 *
+	 * @return bool
+	 */
+	public function do_not_add_trashed_suffix_to_trashed_calendar_embeds( bool $add_trashed_suffix, string $post_name, int $post_id ): bool {
+		if ( static::POSTTYPE !== get_post_type( $post_id ) ) {
+			return $add_trashed_suffix;
+		}
+
+		return false;
 	}
 }

--- a/tests/embed_calendar_integration/Calendar_Embeds_Test.php
+++ b/tests/embed_calendar_integration/Calendar_Embeds_Test.php
@@ -204,4 +204,44 @@ class Calendar_Embeds_Test extends Controller_Test_Case {
 
 		$this->assertMatchesHtmlSnapshot( str_replace( (string) $ece_id, '{ECE_ID}', $markup ) );
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_preserve_post_name_after_trash_and_restore(): void {
+		// Create an ECE
+		$ece_id = $this->create_ece( [ 'post_title' => 'Calendar Embed Test' ] );
+
+		// Get the post and store its original post_name
+		$ece = get_post( $ece_id );
+		$original_post_name = $ece->post_name;
+
+		// Trash the post
+		wp_trash_post( $ece_id );
+
+		// Verify it's in trash
+		$trashed_post = get_post( $ece_id );
+		$this->assertEquals( 'trash', $trashed_post->post_status );
+
+		// Restore the post from trash
+		wp_untrash_post( $ece_id );
+
+		// Get the restored post
+		$restored_post = get_post( $ece_id );
+
+		// Verify it's draft
+		$this->assertEquals( 'draft', $restored_post->post_status );
+
+		// Assert that the post_name has not changed
+		$this->assertEquals( $original_post_name, $restored_post->post_name );
+
+		// Publish the post
+		wp_publish_post( $ece_id );
+
+		// Get the published post
+		$published_post = get_post( $ece_id );
+
+		// Assert that the post_name has not changed
+		$this->assertEquals( $original_post_name, $published_post->post_name );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

Issue 19 from [gsheet](https://docs.google.com/spreadsheets/d/1NzXAjMpzE7Cum9rOix2ctIjEsdpR_YgFLLMKvnGtzkk/edit?gid=439778935#gid=439778935)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Makes sure that the trash-untrash process does not change the ECE's slug.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

The test case is an artifact in this case.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
