### PR TITLE
Add wp-hooks to manager's dependencies

### DIFF
--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -207,6 +207,7 @@ class Assets extends Service_Provider {
 				'tribe-common',
 				'tribe-query-string',
 				'underscore',
+				'wp-hooks',
 			],
 			'wp_print_footer_scripts',
 			[


### PR DESCRIPTION
Fixes an introduced issue during ECE where we would use wp.hooks into the manager.js without adding it to manager's dependencies though.