### PR TITLE
tweak(CT1) introduce query caching in the Model builder.

### DIFF
--- a/changelog/fix-ECP-1898-builder-cache
+++ b/changelog/fix-ECP-1898-builder-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Avoid duplicate queries by caching model queries results. [ECP-1898]

--- a/src/Events/Custom_Tables/V1/Models/Builder.php
+++ b/src/Events/Custom_Tables/V1/Models/Builder.php
@@ -368,17 +368,17 @@ class Builder {
 
 		$columns = implode( ',', array_keys( $formatted_data ) );
 
-		$SQL = "INSERT INTO {$wpdb->prefix}{$this->model->table_name()} ($columns) VALUES($placeholder_values) ON DUPLICATE KEY update {$update_assignment_list}";
-		$SQL = $wpdb->prepare( $SQL, ...$this->create_replacements_values( $formatted_data ) );
+		$sql = "INSERT INTO {$wpdb->prefix}{$this->model->table_name()} ($columns) VALUES($placeholder_values) ON DUPLICATE KEY update {$update_assignment_list}";
+		$sql = $wpdb->prepare( $sql, ...$this->create_replacements_values( $formatted_data ) );
 
-		$this->queries[] = $SQL;
+		$this->queries[] = $sql;
 
 		if ( $this->execute_queries && self::$class_execute_queries ) {
 			/*
 			 * Depending on the db implementation, it could not run updates and return `0`.
 			 * We need to make sure it does not return exactly boolean `false`.
 			 */
-			$result = $wpdb->query( $SQL );
+			$result = $wpdb->query( $sql );
 			if ( $result === false ) {
 				do_action(
 					'tribe_log',
@@ -567,15 +567,15 @@ class Builder {
 		$this->operation = 'DELETE';
 
 		global $wpdb;
-		$SQL = $this->get_sql();
+		$sql = $this->get_sql();
 
 		// If the query is invalid, don't delete anything.
 		if ( $this->invalid ) {
 			return 0;
 		}
 
-		$this->queries[] = $SQL;
-		$result          = $this->execute_queries ? $this->query( $SQL ) : false;
+		$this->queries[] = $sql;
+		$result          = $this->execute_queries ? $this->query( $sql ) : false;
 
 		// If an error happen or no row was updated by the query above.
 		if ( $result === false || (int) $result === 0 ) {
@@ -851,10 +851,10 @@ class Builder {
 		$order_by = $this->get_order_by_clause();
 
 		global $wpdb;
-		$SQL = "SELECT * FROM {$wpdb->prefix}{$this->model->table_name()} WHERE `{$column}` {$operator} ({$compare}) {$order_by} LIMIT %d";
+		$sql = "SELECT * FROM {$wpdb->prefix}{$this->model->table_name()} WHERE `{$column}` {$operator} ({$compare}) {$order_by} LIMIT %d";
 
 		$batch_size    = min( absint( $this->batch_size ), 5000 );
-		$semi_prepared = $wpdb->prepare( $SQL, array_merge( (array) $data, [ $batch_size ] ) );
+		$semi_prepared = $wpdb->prepare( $sql, array_merge( (array) $data, [ $batch_size ] ) );
 		$model_class   = get_class( $this->model );
 		// Start with no results.
 		$results = [];
@@ -1025,11 +1025,11 @@ class Builder {
 
 		$subquery = $this->get_sql();
 
-		$SQL             = "SELECT * FROM `{$wpdb->prefix}{$this->model->table_name()}` WHERE EXISTS ($subquery)";
-		$this->queries[] = $SQL;
+		$sql             = "SELECT * FROM `{$wpdb->prefix}{$this->model->table_name()}` WHERE EXISTS ($subquery)";
+		$this->queries[] = $sql;
 
 		if ( $this->execute_queries ) {
-			return (bool) $wpdb->get_var( $SQL );
+			return (bool) $wpdb->get_var( $sql );
 		}
 
 		return false;
@@ -1079,23 +1079,23 @@ class Builder {
 			return [];
 		}
 
-		$SQL             = $this->get_sql();
-		$this->queries[] = $SQL;
+		$sql             = $this->get_sql();
+		$this->queries[] = $sql;
 		$results         = [];
 
 		if ( $this->execute_queries ) {
 			$results = self::$use_query_cache ?
-				tribe_cache()->get( $SQL, Cache_Triggers::TRIGGER_SAVE_POST, null, Cache::NON_PERSISTENT )
+				tribe_cache()->get( $sql, Cache_Triggers::TRIGGER_SAVE_POST, null, Cache::NON_PERSISTENT )
 				: null;
 
 			if ( null === $results ) {
-				$results       = $wpdb->get_results(
-					$SQL,
+				$results = $wpdb->get_results(
+					$sql,
 					ARRAY_A
 				);
 
 				if ( self::$use_query_cache ) {
-					tribe_cache()->set( $SQL, $results, Cache::NON_PERSISTENT, Cache_Triggers::TRIGGER_SAVE_POST );
+					tribe_cache()->set( $sql, $results, Cache::NON_PERSISTENT, Cache_Triggers::TRIGGER_SAVE_POST );
 				}
 			}
 
@@ -1632,14 +1632,14 @@ class Builder {
 		$found_results = $found_rows - $query_offset;
 
 		do {
-			$this->limit    = min( $this->batch_size, $running_limit );
-			$this->offset   = $running_offset;
+			$this->limit     = min( $this->batch_size, $running_limit );
+			$this->offset    = $running_offset;
 			$running_limit  -= $this->batch_size;
 			$running_offset += $this->batch_size;
-			$batch_results  = $this->get();
+			$batch_results   = $this->get();
 			foreach ( $batch_results as $batch_result ) {
 				// Yields with a set key to avoid calls to `iterator_to_array` overriding the values on each pass.
-				yield $running_tally ++ => $batch_result;
+				yield $running_tally++ => $batch_result;
 			}
 		} while ( $running_tally < $found_results && $running_tally < $query_limit );
 	}
@@ -1811,7 +1811,7 @@ class Builder {
 	 *
 	 * @param bool $use_query_cache Whether the Builder class should use the query cache in the fetch methods or not.
 	 */
-	public static function use_query_cache( bool $use_query_cache ): void {
+	public static function use_query_cache( bool $use_query_cache ) {
 		self::$use_query_cache = $use_query_cache;
 	}
 }

--- a/src/Events/Custom_Tables/V1/Models/Builder.php
+++ b/src/Events/Custom_Tables/V1/Models/Builder.php
@@ -10,8 +10,8 @@ namespace TEC\Events\Custom_Tables\V1\Models;
 use Generator;
 use InvalidArgumentException;
 use TEC\Common\Configuration\Configuration;
-use Tribe__Cache;
-use Tribe__Cache_Listener;
+use Tribe__Cache as Cache;
+use Tribe__Cache_Listener as Cache_Triggers;
 
 /**
  * Class Builder
@@ -49,6 +49,16 @@ class Builder {
 	 * @var bool
 	 */
 	private static $class_execute_queries = true;
+
+	/**
+	 * Whether the results of fetch methods should be cached for the duration of the request or not.
+	 * When active results will be memoized using the SQL query as key in the non-persistent cache (i.e. memoized).
+	 *
+	 * @since TBD
+	 *
+	 * @var bool
+	 */
+	private static bool $use_query_cache = true;
 
 	/**
 	 * The size of the batch the Builder should use to fetch
@@ -389,7 +399,11 @@ class Builder {
 				foreach ( $unique_by as $field ) {
 					$value = $data[ $field ] ?? null;
 					$key   = self::generate_cache_key( $model, $field, $value );
-					tribe_cache()->delete( $key, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+
+					// Invalidate the caches.
+					$cache = tribe_cache();
+					$cache->delete( $key, Cache_Triggers::TRIGGER_SAVE_POST );
+					$cache->set_last_occurrence( Cache_Triggers::TRIGGER_SAVE_POST );
 				}
 			} else {
 				$model->flush_cache();
@@ -568,6 +582,10 @@ class Builder {
 			return 0;
 		}
 
+		// Invalidate the query cache.
+		$cache = tribe_cache();
+		$cache->set_last_occurrence( Cache_Triggers::TRIGGER_SAVE_POST );
+
 		foreach ( $this->where_args as $args ) {
 			$field = $args['field'] ?? null;
 			$value = $args['value'] ?? null;
@@ -576,7 +594,9 @@ class Builder {
 				continue;
 			}
 			$key = self::generate_cache_key( $this->model, $field, $value );
-			tribe_cache()->delete( $key, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+
+			// Invalidate the caches.
+			$cache->delete( $key, Cache_Triggers::TRIGGER_SAVE_POST );
 		}
 		$this->model->reset();
 
@@ -606,7 +626,7 @@ class Builder {
 
 		// Check if we memoized this instance.
 		$key  = self::generate_cache_key( $this->model, $column, $value );
-		$data = tribe_cache()->get( $key, Tribe__Cache_Listener::TRIGGER_SAVE_POST, null, Tribe__Cache::NON_PERSISTENT );
+		$data = tribe_cache()->get( $key, Cache_Triggers::TRIGGER_SAVE_POST, null, Cache::NON_PERSISTENT );
 
 		if ( $data ) {
 			$model_class       = get_class( $this->model );
@@ -622,7 +642,7 @@ class Builder {
 			// Store on model so we can use it to cache bust later.
 			$result->cache_key = $key;
 
-			tribe_cache()->set( $key, $result->to_array(), Tribe__Cache::NON_PERSISTENT, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
+			tribe_cache()->set( $key, $result->to_array(), Cache::NON_PERSISTENT, Cache_Triggers::TRIGGER_SAVE_POST );
 		}
 
 		return $result;
@@ -1064,10 +1084,20 @@ class Builder {
 		$results         = [];
 
 		if ( $this->execute_queries ) {
-			$results = $wpdb->get_results(
-				$SQL,
-				ARRAY_A
-			);
+			$results = self::$use_query_cache ?
+				tribe_cache()->get( $SQL, Cache_Triggers::TRIGGER_SAVE_POST, null, Cache::NON_PERSISTENT )
+				: null;
+
+			if ( null === $results ) {
+				$results       = $wpdb->get_results(
+					$SQL,
+					ARRAY_A
+				);
+
+				if ( self::$use_query_cache ) {
+					tribe_cache()->set( $SQL, $results, Cache::NON_PERSISTENT, Cache_Triggers::TRIGGER_SAVE_POST );
+				}
+			}
 
 			if ( $results === false || $wpdb->last_error ) {
 				do_action(
@@ -1772,5 +1802,16 @@ class Builder {
 		}
 
 		return implode( "\n", $pieces );
+	}
+
+	/**
+	 * Controls whether the Builder class should use the query cache in the fetch methods or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $use_query_cache Whether the Builder class should use the query cache in the fetch methods or not.
+	 */
+	public static function use_query_cache( bool $use_query_cache ): void {
+		self::$use_query_cache = $use_query_cache;
 	}
 }

--- a/src/Events/Custom_Tables/V1/Models/Builder.php
+++ b/src/Events/Custom_Tables/V1/Models/Builder.php
@@ -548,6 +548,9 @@ class Builder {
 
 		$this->queries[] = $sql;
 
+		// Trigger the save post cache invalidation.
+		tribe_cache()->set_last_occurrence( Cache_Triggers::TRIGGER_SAVE_POST );
+
 		// If we have a cache, let's clear it.
 		$model->flush_cache();
 

--- a/src/Events/Custom_Tables/V1/Models/Occurrence.php
+++ b/src/Events/Custom_Tables/V1/Models/Occurrence.php
@@ -29,6 +29,7 @@ use TEC\Events\Custom_Tables\V1\Models\Validators\Start_Date_UTC;
 use TEC\Events\Custom_Tables\V1\Models\Validators\String_Validator;
 use TEC\Events\Custom_Tables\V1\Models\Validators\Valid_Date;
 use TEC\Events\Custom_Tables\V1\Models\Validators\Valid_Event;
+use Tribe__Cache_Listener as Cache_Listener;
 use Tribe__Date_Utils as Dates;
 use Tribe__Events__Main as TEC;
 use Tribe__Timezones as Timezones;
@@ -154,6 +155,7 @@ class Occurrence extends Model {
 	 */
 	public function save_occurrences( ...$args ) {
 		$insertions = $this->get_occurrences( ...$args );
+		$post_id = $this->event->post_id;
 
 		if ( count( $insertions ) ) {
 			self::insert( $insertions );
@@ -166,7 +168,7 @@ class Occurrence extends Model {
 			 * @param int   $post_id    The ID of the Event post the Occurrences are being saved for.
 			 * @param array $insertions The inserted Occurrences.
 			 */
-			do_action( 'tec_events_custom_tables_v1_after_insert_occurrences', $this->event->post_id, $insertions );
+			do_action( 'tec_events_custom_tables_v1_after_insert_occurrences', $post_id, $insertions );
 		}
 
 		/**
@@ -177,7 +179,10 @@ class Occurrence extends Model {
 		 *
 		 * @param int $post_id The ID of the Event post the Occurrences are being saved for.
 		 */
-		do_action( 'tec_events_custom_tables_v1_after_save_occurrences', $this->event->post_id );
+		do_action( 'tec_events_custom_tables_v1_after_save_occurrences', $post_id );
+
+		// After saving occurrences invalidate caches for this post.
+		Cache_Listener::instance()->save_post( $post_id, get_post( $post_id ) );
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Models/Occurrence.php
+++ b/src/Events/Custom_Tables/V1/Models/Occurrence.php
@@ -155,7 +155,7 @@ class Occurrence extends Model {
 	 */
 	public function save_occurrences( ...$args ) {
 		$insertions = $this->get_occurrences( ...$args );
-		$post_id = $this->event->post_id;
+		$post_id    = $this->event->post_id;
 
 		if ( count( $insertions ) ) {
 			self::insert( $insertions );

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Models/ModelTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Models/ModelTest.php
@@ -8,6 +8,15 @@ use TEC\Events\Custom_Tables\V1\Tables\Events;
 use WP_Post;
 
 class ModelTest extends WPTestCase {
+	protected function _before() {
+		parent::_before();
+		/**
+		 * For the purpose of this test, we do not want to use the cache query.
+		 * Other tests are covering correct and timely cache invalidation on update and insert of rows.
+		 */
+		Builder::use_query_cache( false );
+	}
+
 	/**
 	 * It should allow using raw WHERE clauses for filtering
 	 *

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Models/ModelTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Models/ModelTest.php
@@ -17,6 +17,12 @@ class ModelTest extends WPTestCase {
 		Builder::use_query_cache( false );
 	}
 
+	protected function _after() {
+		parent::_after();
+		// Restore the use of cache in the builder.
+		Builder::use_query_cache( true );
+	}
+
 	/**
 	 * It should allow using raw WHERE clauses for filtering
 	 *


### PR DESCRIPTION
Ticket: [ECP-1898](https://stellarwp.atlassian.net/browse/ECP-1898)

This introduces query caching in the model builder to cache the results of duplicated queries at the builder level without running them twice.

[Demo](https://share.cleanshot.com/QHLG0szn)

Proper cache invalidation was already directly (`ct1_integration/BuilderTest.php`) and indirectly covered in existing tests.

I had to modify a single test that was insisting on the batched fetching functionality since the whole point of the test is to assert on the number of queries made.


[ECP-1898]: https://stellarwp.atlassian.net/browse/ECP-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ