### PR TITLE
Fix/calling get current screen too early

### DIFF
--- a/changelog/fix-calling-get_current_screen_too-early
+++ b/changelog/fix-calling-get_current_screen_too-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures `get_current_screen()` function is only called if it exists, avoiding fatal error if called too early. [TEC-5439]

--- a/src/Events/Calendar_Embeds/Calendar_Embeds.php
+++ b/src/Events/Calendar_Embeds/Calendar_Embeds.php
@@ -95,6 +95,7 @@ class Calendar_Embeds extends Controller_Contract {
 	 * Modifies the term count on the term list tables to ignore Calendar embeds from their count.
 	 *
 	 * @since 6.11.0
+	 * @since 6.11.0.1 Added check to ensure ABSPATH/wp-admin/includes/screen.php is loaded before running.
 	 *
 	 * @param array  $terms      The terms.
 	 * @param ?array $taxonomies The taxonomies.
@@ -110,8 +111,8 @@ class Calendar_Embeds extends Controller_Contract {
 			return $terms;
 		}
 
-		if ( ! is_admin() ) {
-			// Should only run on BE.
+		if ( ! is_admin() || ! function_exists( 'get_current_screen' ) ) {
+			// Should only run on BE and after ABSPATH/wp-admin/includes/screen.php is loaded.
 			return $terms;
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5439]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Function get_current_screen is included just before hook `admin_init` - so for possible usage prior we have to make sure it exists before calling it.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

Have written a test case that ensures the function get_current_screen is only being called if it exists.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5439]: https://stellarwp.atlassian.net/browse/TEC-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ