### PR TITLE
FBAR-332 Move focus to results after filtering

### DIFF
--- a/changelog/fix-FBAR-332-focus-on-results-of-filter
+++ b/changelog/fix-FBAR-332-focus-on-results-of-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: accessibility
 
-Change focus to results after filtering events/ [FBAR-332]
+Change focus to results after filtering `events/`. [FBAR-332]

--- a/changelog/fix-FBAR-332-focus-on-results-of-filter
+++ b/changelog/fix-FBAR-332-focus-on-results-of-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Change focus to results after filtering events/ [FBAR-332]

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -594,6 +594,7 @@ tribe.events.views.manager = {};
 	 * Context with the View container used to fire this AJAX call
 	 *
 	 * @since 4.9.2
+	 * @since TBD Add focus on events list or no results message for improved accessibility.
 	 *
 	 * @param  {String} html       HTML sent from the REST API
 	 * @param  {String} textStatus Status for the request
@@ -654,7 +655,10 @@ tribe.events.views.manager = {};
 		var $noResults = $container.find('.tribe-events-c-messages__message--notice');
 				
 		if ($eventsList.length && $eventsList.find('.tribe-events-calendar-list__event-row').length) {
-			$eventsList.attr('tabindex', '-1').trigger('focus');
+			$eventsList
+				.attr('tabindex', '-1')
+				.attr('aria-label', tribe_events_views_strings.listOfEvents || 'List of Events')
+				.trigger('focus');
 		} else if ($noResults.length) {
 			$noResults.attr('tabindex', '-1').trigger('focus');
 		}

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -200,7 +200,6 @@ tribe.events.views.manager = {};
 			) {
 				$eventsList
 					.attr( 'tabindex', '-1' )
-					.attr( 'aria-label', $container.data( 'events-list-aria-label' ) )
 					.trigger( 'focus' );
 			} else if ( $noResults.length ) {
 				$noResults

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -646,8 +646,18 @@ tribe.events.views.manager = {};
 		// Update the global set of containers with all of the manager object.
 		obj.selectContainers();
 
-		// Trigger the browser pushState
+		// Trigger the browser pushState.
 		obj.updateUrl( $container );
+
+		// Focus on either the events list or the no results message for improved accessibility.
+		var $eventsList = $container.find('.tribe-events-calendar-list');
+		var $noResults = $container.find('.tribe-events-c-messages__message--notice');
+				
+		if ($eventsList.length && $eventsList.find('.tribe-events-calendar-list__event-row').length) {
+			$eventsList.attr('tabindex', '-1').trigger('focus');
+		} else if ($noResults.length) {
+			$noResults.attr('tabindex', '-1').trigger('focus');
+		}
 
 		$container.trigger( 'afterAjaxSuccess.tribeEvents', [ data, textStatus, jqXHR ] );
 

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -145,6 +145,7 @@ tribe.events.views.manager = {};
 	 * Setup the container for views management
 	 *
 	 * @since 4.9.2
+	 * @since TBD Add focus on events list or no results message for improved accessibility.
 	 *
 	 * @todo  Requirement to setup other JS modules after hijacking Click and Submit
 	 *
@@ -175,10 +176,43 @@ tribe.events.views.manager = {};
 		$container.trigger( 'beforeSetup.tribeEvents', [ index, $container, data ] );
 		$container.find( obj.selectors.link ).on( 'click.tribeEvents', obj.onLinkClick );
 
-		// Only catch the submit if properly setup on a form
+		// Only catch the submit if properly setup on a form.
 		if ( $form.length ) {
 			$form.on( 'submit.tribeEvents', obj.onSubmit );
 		}
+
+		/**
+		 * Sets focus on either the events list or no results message for accessibility.
+		 *
+		 * @since TBD
+		 *
+		 * @param {jQuery} $container The container element.
+		 *
+		 * @return {void}
+		 */
+		const setResultsFocus = function( $container ) {
+			const $eventsList = $container.find( '.tribe-events-calendar-list' );
+			const $noResults = $container.find( '.tribe-events-c-messages__message--notice' );
+			
+			if ( 
+				$eventsList.length 
+				&& $eventsList.find( '.tribe-events-calendar-list__event-row' ).length 
+			) {
+				$eventsList
+					.attr( 'tabindex', '-1' )
+					.attr( 'aria-label', $container.data( 'events-list-aria-label' ) )
+					.trigger( 'focus' );
+			} else if ( $noResults.length ) {
+				$noResults
+					.attr( 'tabindex', '-1' )
+					.trigger( 'focus' );
+			}
+		};
+
+		// Handle focus after AJAX success.
+		$container.on( 'afterAjaxSuccess.tribeEvents', function( event, html ) {
+			setResultsFocus( $container );
+		} );
 
 		$container.trigger( 'afterSetup.tribeEvents', [ index, $container, data ] );
 	};
@@ -594,7 +628,6 @@ tribe.events.views.manager = {};
 	 * Context with the View container used to fire this AJAX call
 	 *
 	 * @since 4.9.2
-	 * @since TBD Add focus on events list or no results message for improved accessibility.
 	 *
 	 * @param  {String} html       HTML sent from the REST API
 	 * @param  {String} textStatus Status for the request
@@ -649,19 +682,6 @@ tribe.events.views.manager = {};
 
 		// Trigger the browser pushState.
 		obj.updateUrl( $container );
-
-		// Focus on either the events list or the no results message for improved accessibility.
-		var $eventsList = $container.find('.tribe-events-calendar-list');
-		var $noResults = $container.find('.tribe-events-c-messages__message--notice');
-				
-		if ($eventsList.length && $eventsList.find('.tribe-events-calendar-list__event-row').length) {
-			$eventsList
-				.attr('tabindex', '-1')
-				.attr('aria-label', tribe_events_views_strings.listOfEvents || 'List of Events')
-				.trigger('focus');
-		} else if ($noResults.length) {
-			$noResults.attr('tabindex', '-1').trigger('focus');
-		}
 
 		$container.trigger( 'afterAjaxSuccess.tribeEvents', [ data, textStatus, jqXHR ] );
 

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -56,7 +56,10 @@ if ( empty( $disable_event_search ) ) {
 
 		<?php $this->template( 'components/filter-bar' ); ?>
 
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="<?php echo esc_attr( sprintf( __( 'List of %s', 'the-events-calendar' ), tribe_get_event_label_plural() ) ); ?>"
+		>
 
 			<?php foreach ( $events as $event ) : ?>
 				<?php $this->setup_postdata( $event ); ?>

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -59,7 +59,10 @@ if ( empty( $disable_event_search ) ) {
 
 		<div 
 			class="tribe-events-calendar-list"
-			aria-label="<?php echo esc_attr( sprintf( __( 'List of %s', 'the-events-calendar' ), tribe_get_event_label_plural() ) ); ?>"
+			aria-label="<?php 
+				/* translators: %s: Events (plural) */
+				echo esc_attr( sprintf( __( 'List of %s', 'the-events-calendar' ), tribe_get_event_label_plural() ) ); 
+			?>"
 		>
 
 			<?php foreach ( $events as $event ) : ?>

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -59,10 +59,12 @@ if ( empty( $disable_event_search ) ) {
 
 		<div 
 			class="tribe-events-calendar-list"
-			aria-label="<?php 
+			aria-label="
+			<?php 
 				/* translators: %s: Events (plural) */
 				echo esc_attr( sprintf( __( 'List of %s', 'the-events-calendar' ), tribe_get_event_label_plural() ) ); 
-			?>"
+			?>
+			"
 		>
 
 			<?php foreach ( $events as $event ) : ?>

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -10,6 +10,7 @@
  * @link    http://evnt.is/1aiy
  *
  * @since   6.1.4 Changing our nonce verification structures.
+ * @since   TBD Add aria-label to events list for improved accessibility.
  *
  * @version 6.2.0
  * @since 6.2.0 Moved the header information into a new components/header.php template.

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - cats__0.snapshot.html
@@ -2978,12 +2978,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -2997,12 +2997,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3016,12 +3016,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3035,12 +3035,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3054,12 +3054,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3451,12 +3451,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3470,12 +3470,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3489,12 +3489,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3508,12 +3508,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3527,12 +3527,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3546,12 +3546,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3565,12 +3565,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3584,12 +3584,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3603,12 +3603,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3622,12 +3622,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3641,12 +3641,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3660,12 +3660,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3679,12 +3679,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3698,12 +3698,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3717,12 +3717,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3736,12 +3736,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3755,12 +3755,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3774,12 +3774,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3793,12 +3793,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3812,12 +3812,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3831,12 +3831,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3850,12 +3850,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3869,12 +3869,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3888,12 +3888,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3907,12 +3907,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3926,12 +3926,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3945,12 +3945,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3964,12 +3964,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - no cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - no cats__0.snapshot.html
@@ -2978,12 +2978,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -2997,12 +2997,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3016,12 +3016,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3035,12 +3035,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3054,12 +3054,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3451,12 +3451,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3470,12 +3470,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3489,12 +3489,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3508,12 +3508,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3527,12 +3527,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3546,12 +3546,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3565,12 +3565,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3584,12 +3584,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3603,12 +3603,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3622,12 +3622,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3641,12 +3641,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3660,12 +3660,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3679,12 +3679,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3698,12 +3698,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3717,12 +3717,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3736,12 +3736,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3755,12 +3755,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3774,12 +3774,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3793,12 +3793,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3812,12 +3812,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3831,12 +3831,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3850,12 +3850,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3869,12 +3869,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3888,12 +3888,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3907,12 +3907,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3926,12 +3926,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3945,12 +3945,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3964,12 +3964,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags - no cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags - no cats__0.snapshot.html
@@ -2978,12 +2978,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -2997,12 +2997,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3016,12 +3016,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3035,12 +3035,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3054,12 +3054,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3451,12 +3451,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3470,12 +3470,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3489,12 +3489,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3508,12 +3508,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3527,12 +3527,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3546,12 +3546,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3565,12 +3565,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3584,12 +3584,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3603,12 +3603,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3622,12 +3622,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3641,12 +3641,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3660,12 +3660,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3679,12 +3679,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3698,12 +3698,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3717,12 +3717,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3736,12 +3736,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3755,12 +3755,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3774,12 +3774,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3793,12 +3793,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3812,12 +3812,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3831,12 +3831,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3850,12 +3850,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3869,12 +3869,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3888,12 +3888,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3907,12 +3907,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3926,12 +3926,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3945,12 +3945,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3964,12 +3964,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags and cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags and cats__0.snapshot.html
@@ -2978,12 +2978,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -2997,12 +2997,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3016,12 +3016,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3035,12 +3035,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3054,12 +3054,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3451,12 +3451,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3470,12 +3470,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3489,12 +3489,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3508,12 +3508,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3527,12 +3527,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3546,12 +3546,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3565,12 +3565,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3584,12 +3584,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3603,12 +3603,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3622,12 +3622,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3641,12 +3641,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3660,12 +3660,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3679,12 +3679,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3698,12 +3698,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3717,12 +3717,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3736,12 +3736,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3755,12 +3755,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3774,12 +3774,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3793,12 +3793,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3812,12 +3812,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3831,12 +3831,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3850,12 +3850,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3869,12 +3869,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3888,12 +3888,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3907,12 +3907,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3926,12 +3926,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3945,12 +3945,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 
@@ -3964,12 +3964,12 @@
 		<div  class="tribe-events-header__messages tribe-events-c-messages tribe-common-b2 tribe-events-header__messages--mobile tribe-events-header__messages--day"  >
 			<div class="tribe-events-c-messages__message tribe-events-c-messages__message--notice" role="alert">
 			<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found tribe-events-c-messages__message-icon-svg"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
-			<ul class="tribe-events-c-messages__message-list" role="alert" aria-live="polite">
-									<li
+			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+									<div
 						class="tribe-events-c-messages__message-list-item"
 						 data-key="no-events-in-day" 					>
-					There are no events on this day.					</li>
-							</ul>
+						There are no events on this day.					</div>
+							</div>
 		</div>
 	</div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
@@ -273,7 +273,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 			
 		</div>

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
@@ -274,7 +274,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 			
 		</div>

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -255,7 +255,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 							
 				<h2 class="tribe-events-calendar-list__month-separator">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
@@ -254,7 +254,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 							
 				<h2 class="tribe-events-calendar-list__month-separator">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
@@ -282,7 +282,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 							
 				<h2 class="tribe-events-calendar-list__month-separator">

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
@@ -262,7 +262,11 @@
 </header>
 
 		
-		<div class="tribe-events-calendar-list">
+		<div 
+			class="tribe-events-calendar-list"
+			aria-label="
+			List of Events			"
+		>
 
 			
 		</div>


### PR DESCRIPTION
### 🎫 Ticket

[FBAR-332]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

When a user selects a filter option, the page refreshes and displays the search results. However, the focus is directed to the top of the filters rather than to the number of results or the first event in the list, which may be confusing for users. 

This change should immediately set the focus to the results of the filtering or the 'No events found' message. 

### 🎥 Artifacts 

https://drive.google.com/file/d/1WV_x7bZk3yGn-2nezoY0hfg-LJR50Fov/view?usp=drive_link

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[FBAR-332]: https://stellarwp.atlassian.net/browse/FBAR-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ