### PR TITLE
Ensure ajax complete is fired after ajax

### DIFF
--- a/changelog/fix-ensure-ajax-complete-is-fired-after-ajax
+++ b/changelog/fix-ensure-ajax-complete-is-fired-after-ajax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures the ajaxComplete callback is fired after AJAX has actually completed. [FBAR-344]

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -528,6 +528,9 @@ tribe.events.views.manager = {};
       $.extend(settings, overwriteSettings)
     );
 
+		// Since we await the ajax request, we need to call the complete event manually.
+		obj.ajaxComplete( $container );
+
     /**
      * Trigger the afterRequest event.
      *
@@ -592,7 +595,6 @@ tribe.events.views.manager = {};
       method: $container.data("view-rest-method") || "POST",
       async: true, // async is keyword
       beforeSend: obj.ajaxBeforeSend,
-      complete: obj.ajaxComplete,
       success: obj.ajaxSuccess,
       error: obj.ajaxError,
       context: $container
@@ -639,23 +641,22 @@ tribe.events.views.manager = {};
    * Context with the View container used to fire this AJAX call
    *
    * @since 4.9.2
-   *
-   * @param  {jqXHR}  qXHR       Request object
-   * @param  {String} textStatus Status for the request
+	 * @since TBD Remove not needed parameters. Hook into the success event instead for those.
+	 *
+	 * @param {Element|jQuery} $container The container we are dealing with
    *
    * @return {void}
    */
-  obj.ajaxComplete = function(jqXHR, textStatus) {
-    var $container = this;
+  obj.ajaxComplete = function( $container ) {
     var $loader = $container.find(obj.selectors.loader);
 
-    $container.trigger("beforeAjaxComplete.tribeEvents", [jqXHR, textStatus]);
+    $container.trigger("beforeAjaxComplete.tribeEvents", []);
 
     if ($loader.length) {
       $loader.addClass(obj.selectors.hiddenElement.className());
     }
 
-    $container.trigger("afterAjaxComplete.tribeEvents", [jqXHR, textStatus]);
+    $container.trigger("afterAjaxComplete.tribeEvents", []);
 
     // Flag that we are done with popstate if that was the case.
     if (obj.doingPopstate) {

--- a/src/resources/js/views/manager.js
+++ b/src/resources/js/views/manager.js
@@ -641,9 +641,9 @@ tribe.events.views.manager = {};
    * Context with the View container used to fire this AJAX call
    *
    * @since 4.9.2
-	 * @since TBD Remove not needed parameters. Hook into the success event instead for those.
-	 *
-	 * @param {Element|jQuery} $container The container we are dealing with
+   * @since TBD Remove not needed parameters. Hook into the success event instead for those.
+   *
+   * @param {Element|jQuery} $container The container we are dealing with
    *
    * @return {void}
    */


### PR DESCRIPTION
### 🎫 Ticket

[FBAR-344]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Ensures ajax complete is fired after AJAX has actually completed. Watch the loom, the issue is being explained there.

### 🎥 Artifacts <!-- if applicable-->

https://www.loom.com/share/5ed8a4fec1254746a4b3312c517c407f

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[FBAR-344]: https://stellarwp.atlassian.net/browse/FBAR-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ