### PR TITLE
Ensures delete custom tables is called only for events

### DIFF
--- a/changelog/fix-delete-custom-tables-only-for-events
+++ b/changelog/fix-delete-custom-tables-only-for-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensures `delete_custom_tables_data` method is called only for events. [TEC-5445]

--- a/src/Events/Custom_Tables/V1/Updates/Controller.php
+++ b/src/Events/Custom_Tables/V1/Updates/Controller.php
@@ -305,6 +305,7 @@ class Controller {
 	 * Deletes an Event custom tables information.
 	 *
 	 * @since 6.0.0
+	 * @since TBD - Ensures this is only called for Events.
 	 *
 	 * @param int                  $post_id The deleted Event post ID.
 	 * @param WP_REST_Request|null $request A reference to the request object triggering the deletion, if any.
@@ -312,6 +313,10 @@ class Controller {
 	 * @return int|false Either the number of affected rows, or `false` on failure.
 	 */
 	public function delete_custom_tables_data( int $post_id, WP_REST_Request $request = null ) {
+		if ( ! tribe_is_event( $post_id ) ) {
+			return false;
+		}
+
 		if ( null === $request ) {
 			$request = $this->requests->from_http_request();
 		}

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/ControllerTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/ControllerTest.php
@@ -117,4 +117,20 @@ class ControllerTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( 2, $affected );
 	}
+
+	/**
+	 * It should report deletions when Events does
+	 *
+	 * @test
+	 */
+	public function should_report_no_deletions_when_posts_are_deleted() {
+		$post_id = self::factory()->post->create();
+		$requests = new Requests();
+		$events   = new Events();
+
+		$controller = new Controller( new Meta_Watcher(), $requests, $events );
+		$affected   = $controller->delete_custom_tables_data( $post_id, $requests->from_http_request() );
+
+		$this->assertEquals( 0, $affected );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5445]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

`delete_custom_tables_data` should be called only for events! During darkhawk work it ended up being called for attachment deletion during plugin update causing a fatal.

### 🎥 Artifacts <!-- if applicable-->

Test case is artifact enough to serve as artifact here.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5445]: https://stellarwp.atlassian.net/browse/TEC-5445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ