### PR TITLE
Remove back-compat classes upon Classy unregistration

### DIFF
--- a/src/Events/Classy/Controller.php
+++ b/src/Events/Classy/Controller.php
@@ -223,6 +223,18 @@ class Controller extends ControllerContract {
 	 * @return void The hooked actions and filters are removed.
 	 */
 	public function unregister(): void {
+		// Unregister the back-compat editor and utils.
+		if ( $this->container->has( 'editor' ) && $this->container->get( 'editor' ) instanceof Editor ) {
+			unset( $this->container['editor'] );
+			unset( $this->container['events.editor'] );
+			unset( $this->container['events.editor.compatibility'] );
+		}
+
+		if ( $this->container->has( 'editor.utils' ) && $this->container->get( 'editor.utils' ) instanceof Editor_Utils ) {
+			unset( $this->container['editor.utils'] );
+		}
+
+		// Remove filters and actions.
 		remove_filter( 'tribe_editor_should_load_blocks', [ self::class, 'return_false' ] );
 		remove_filter( 'tec_using_classy_editor', [ self::class, 'return_true' ] );
 		remove_filter( 'block_editor_settings_all', [ $this, 'filter_block_editor_settings' ], 100 );


### PR DESCRIPTION
### 🎫 Ticket

Related to [TEC-5416]

### 🗒️ Description

Updates `Classy\Controller::unregister()` to also remove the back-compat registrations from the container.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5416]: https://stellarwp.atlassian.net/browse/TEC-5416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ