### PR TITLE
Prevents fatal during update while ECP is also active

### DIFF
--- a/changelog/fix-prevent-fatal-during-upgrade
+++ b/changelog/fix-prevent-fatal-during-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Makes sure that Custom Tables are loaded after our Common library is loaded. [TEC-5445]

--- a/src/Events/Custom_Tables/V1/Models/Builder.php
+++ b/src/Events/Custom_Tables/V1/Models/Builder.php
@@ -206,7 +206,7 @@ class Builder {
 	 */
 	public function __construct( Model $model ) {
 		$this->model      = $model;
-		$this->batch_size = tec_query_batch_size( __METHOD__ );
+		$this->batch_size = function_exists( 'tec_query_batch_size' ) ? tec_query_batch_size( __METHOD__ ) : 50;
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -280,6 +280,11 @@ abstract class Model implements Serializable {
 		}
 
 		if ( ! empty( $this->errors() ) ) {
+			// If here too early, bail instead. Can happen in the upgrade process.
+			if ( ! did_action( 'tribe_common_loaded' ) ) {
+				return false;
+			}
+
 			// For debug purposes, log validation errors.
 			// These will fail update/insertions on the database.
 			do_action( 'tribe_log',

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -280,11 +280,6 @@ abstract class Model implements Serializable {
 		}
 
 		if ( ! empty( $this->errors() ) ) {
-			// If here too early, bail instead. Can happen in the upgrade process.
-			if ( ! did_action( 'tribe_common_loaded' ) ) {
-				return false;
-			}
-
 			// For debug purposes, log validation errors.
 			// These will fail update/insertions on the database.
 			do_action( 'tribe_log',

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -675,7 +675,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 
 			// Custom tables v1 implementation.
 			if ( class_exists( '\\TEC\\Events\\Custom_Tables\\V1\\Provider' ) ) {
-				tribe_register_provider( '\\TEC\\Events\\Custom_Tables\\V1\\Provider' );
+				tribe()->register_on_action( 'tribe_common_loaded', '\\TEC\\Events\\Custom_Tables\\V1\\Provider' );
 			}
 
 			// Blocks.


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5445]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Prevents fatal during update to dartkhawk.

The register_on_action will not prevent the fatal now - but it is used as a safeguard for the future.

What is happening during an upgrade request is that CT1 hooks are registered without the common having loaded yet. As a result functions or singleton bound during common's loading are not available.

The hooks are registered by rpevious version of TEC during upgrade.
But during upgrade all the classes that are being called by the hooks down the road are not in memory - so they are being loaded by the new TEC's zip... aka 💥 

This PR amends to make those hooks fired not fatal out for that single problematic request.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5445]: https://stellarwp.atlassian.net/browse/TEC-5445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ