### PR TITLE
Prevent specific fatal during upgrade

### DIFF
--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -17,6 +17,7 @@ use TEC\Events\Custom_Tables\V1\Models\Formatters\Formatter;
 use TEC\Events\Custom_Tables\V1\Models\Validators\ValidatorInterface;
 use Tribe__Cache_Listener;
 use TEC\Common\Monolog\Logger;
+use TEC\Common\Monolog\Handler\Handler;
 
 /**
  * Class Model
@@ -282,7 +283,7 @@ abstract class Model implements Serializable {
 
 		if ( ! empty( $this->errors() ) ) {
 			// If here too early, bail instead. Can happen in the upgrade process.
-			if ( ! tribe()->isBound( Logger::class ) ) {
+			if ( ! class_exists( Handler::class ) || ! tribe()->isBound( Logger::class ) ) {
 				return false;
 			}
 

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -280,6 +280,11 @@ abstract class Model implements Serializable {
 		}
 
 		if ( ! empty( $this->errors() ) ) {
+			// If here too early, bail instead. Can happen in the upgrade process.
+			if ( ! did_action( 'tribe_common_loaded' ) ) {
+				return false;
+			}
+
 			// For debug purposes, log validation errors.
 			// These will fail update/insertions on the database.
 			do_action( 'tribe_log',

--- a/src/Events/Custom_Tables/V1/Models/Model.php
+++ b/src/Events/Custom_Tables/V1/Models/Model.php
@@ -16,6 +16,7 @@ use TEC\Common\Contracts\Container;
 use TEC\Events\Custom_Tables\V1\Models\Formatters\Formatter;
 use TEC\Events\Custom_Tables\V1\Models\Validators\ValidatorInterface;
 use Tribe__Cache_Listener;
+use TEC\Common\Monolog\Logger;
 
 /**
  * Class Model
@@ -281,7 +282,7 @@ abstract class Model implements Serializable {
 
 		if ( ! empty( $this->errors() ) ) {
 			// If here too early, bail instead. Can happen in the upgrade process.
-			if ( ! did_action( 'tribe_common_loaded' ) ) {
+			if ( ! tribe()->isBound( Logger::class ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5445]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Makes sure that the specific do_action( 'tribe_log' ) is NOT fired during the upgrade request.

What is happening is quite complex => The Logger is already bound using old plugins codebase. Not initiated though

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5445]: https://stellarwp.atlassian.net/browse/TEC-5445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ