### PR TITLE
refactor(Classy) scaffold dedicated registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/react-dom": "^19.0.4",
         "@wordpress/block-editor": "^14.15.0",
         "@wordpress/components": "^29.6.0",
+        "@wordpress/compose": "^7.21.0",
         "@wordpress/data": "^10.19.0",
         "@wordpress/editor": "^14.19.0",
         "@wordpress/element": "^6.19.0",
@@ -82,10 +83,6 @@
         "redux-mock-store": "^1.5.3",
         "ts-jest": "^29.2.6",
         "webpack-merge": "^4.1.4"
-      },
-      "engines": {
-        "node": "18.17.0",
-        "npm": "9.6.7"
       }
     },
     "common/src/modules": {
@@ -7240,20 +7237,20 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.20.0.tgz",
-      "integrity": "sha512-L84QUGXbXPdCAgNDNmmH+4tJuAl1MwH5an6CaQ+NaSXk4kM4xAc42znHo0n5LfsRmWxOPrtlGikxMXCaejvoyw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.21.0.tgz",
+      "integrity": "sha512-Q7asGsoJL4mPJPU9xvI5vHQnfRlYhsRPy6bKSBXVC6RR/Yc5FLRgmd/th6pIXWz+pdCmlsMcwn8j18jk3PaaKw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.20.0",
-        "@wordpress/dom": "^4.20.0",
-        "@wordpress/element": "^6.20.0",
-        "@wordpress/is-shallow-equal": "^5.20.0",
-        "@wordpress/keycodes": "^4.20.0",
-        "@wordpress/priority-queue": "^3.20.0",
-        "@wordpress/undo-manager": "^1.20.0",
+        "@wordpress/deprecated": "^4.21.0",
+        "@wordpress/dom": "^4.21.0",
+        "@wordpress/element": "^6.21.0",
+        "@wordpress/is-shallow-equal": "^5.21.0",
+        "@wordpress/keycodes": "^4.21.0",
+        "@wordpress/priority-queue": "^3.21.0",
+        "@wordpress/undo-manager": "^1.21.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -7471,13 +7468,13 @@
       "dev": true
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.20.0.tgz",
-      "integrity": "sha512-36JbtGUSQ49SM33fvfSAvN8ZGDqCxCPAj2PByAney4WhoVbznxGWnao8qKwWrNNG5xec1reQvXFxOsD7qab4rg==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.21.0.tgz",
+      "integrity": "sha512-0C73fJ26gr1LfiCr2DOTZaIl/QnXGKHpQLghecNecv+3gFaYeuz0kUkFJ2FNG+uQQqI+tojYczt9M6o+/arBqg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.20.0"
+        "@wordpress/hooks": "^4.21.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7497,9 +7494,9 @@
       }
     },
     "node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.20.0.tgz",
-      "integrity": "sha512-nn6RbAER5EitMJVr+jpOg5HDIUEEOEv6jC/P1s5C0HvsOaldBeJ80A73Gsd/NFGlUqCc7o51uoZO36wGoPjIpg==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.21.0.tgz",
+      "integrity": "sha512-P5EH6GJyJpPHZpZC7vPcMgJP1u3u8RSqDpoLn/DC3u58FSFD5eh7wn8u2hZsT+erxVaatYRUosrfh/Qr8mwazQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -7510,13 +7507,13 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.20.0.tgz",
-      "integrity": "sha512-uLYH7hKfJDUHkooAy0uoFJXMCkraTP3gdybblAJT9a/dqAOVcsMODH9gTGI99IoFhsvJwWo5Vk94/kgqeOdarA==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.21.0.tgz",
+      "integrity": "sha512-6VNQnoVZW3ETYR80CmB5mney2YMuTOfOwh2x8tjayLHWM9ZOmgN4BfUoLAorhjak45uNA/GymzfnWrbsy96m3A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/deprecated": "^4.20.0"
+        "@wordpress/deprecated": "^4.21.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7677,15 +7674,15 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.20.0.tgz",
-      "integrity": "sha512-JsM1Cy283BusHOb1uyD3tG9GAb5hp/ycgPnBS/ScKT/8VD8yGzsX6Pz910GWo5udXP03d2+UI/BQ68KPqPQKqQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.21.0.tgz",
+      "integrity": "sha512-qp/beSJMd7a0RSkxDiwOX56AYxXPR4p/MJoNVq+hUe/SiF0GD5hvdK3q/VDJI/jWBoVEkCcRAtMq1102AJHQ8w==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.20.0",
+        "@wordpress/escape-html": "^3.21.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7728,9 +7725,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.20.0.tgz",
-      "integrity": "sha512-Jrm+RdTZo8cj1JUo4Vqx92/yw7B+XS6aClEyQ/xlHoQU0WIZ+xByWZHOPgDFBcKczuO34UkFTWmDFFHMSy1uyw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.21.0.tgz",
+      "integrity": "sha512-X0Xj4sZaBh1HL2QwxtXkfr93vXX3TFmtzcKM6ub3Bk/hbFwTp0U8yALZQe7sBl3rL6ouaKGXnOyQSPWwqqs53Q==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7"
@@ -7941,12 +7938,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.20.0.tgz",
-      "integrity": "sha512-JrgVe5QT+nDHFbujeD0lJifDpdgmOt1SSnEK631jIISjfGjriYwphoOEAzBGRh9S9ThqOOfW4mLOOeXPYmJR7w==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.21.0.tgz",
+      "integrity": "sha512-yeEXkaQfUkeBFj/9oJMkTuLZK6TbI21mslZczvvcN/iSFaByaoXl/ilgE3YMLxTNwoEpRz5W5Y0CfclJcvjgHQ==",
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/hooks": "^4.20.0",
+        "@wordpress/hooks": "^4.21.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -7972,9 +7969,9 @@
       }
     },
     "node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.20.0.tgz",
-      "integrity": "sha512-nn6RbAER5EitMJVr+jpOg5HDIUEEOEv6jC/P1s5C0HvsOaldBeJ80A73Gsd/NFGlUqCc7o51uoZO36wGoPjIpg==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.21.0.tgz",
+      "integrity": "sha512-P5EH6GJyJpPHZpZC7vPcMgJP1u3u8RSqDpoLn/DC3u58FSFD5eh7wn8u2hZsT+erxVaatYRUosrfh/Qr8mwazQ==",
       "dependencies": {
         "@babel/runtime": "7.25.7"
       },
@@ -8061,9 +8058,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.20.0.tgz",
-      "integrity": "sha512-/m8P/6AQgZchMbeDhne5z8Wzde07mv8+l7qsYK6VhChEWonrYN7Sfig9uGPtWijkWwOkxYjWE6ggcJ5xn8KVlg==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.21.0.tgz",
+      "integrity": "sha512-acbSqAjPX5h5I/MNSgeBY2C88fvspzwPJYfhR/pUXG7vkLa786Jfo/CB6Rjq7JfRoRwItnSVE+a0hDwh7jAZIA==",
       "dependencies": {
         "@babel/runtime": "7.25.7"
       },
@@ -8162,13 +8159,13 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.20.0.tgz",
-      "integrity": "sha512-GLzp9uTSNOPvX378FInwvLj4riqq1N/By1kd40iAr1hXfRAjy0H//vktJ70r+AkwK0R07txtCPiLnDcW53hLmg==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.21.0.tgz",
+      "integrity": "sha512-uSbo8Me3TVS9CyXrYAG9EMhJDMu670WMNpHxZG8NlgQ4tqeoO6twCVnfSE202Ouee18dkJli1yteKxhRk6QdaA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/i18n": "^5.20.0"
+        "@wordpress/i18n": "^5.21.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8453,9 +8450,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.20.0.tgz",
-      "integrity": "sha512-2gOa8LQaTLPgk1GDkkXWALA9yH47yhDZKHKBHy8YH61c+m8ai8RctWegzXA6pSInPW77nbBUNHSOzxWTsDN1Sw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.21.0.tgz",
+      "integrity": "sha512-cKcM0/Qf4lILl+rCA7dG3S5x0wMgH5sPo/8IitX/JOOesnWCPULGyuk5KmH0Tw38xDuVMlL4POU3hgWFrC1q4A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
@@ -8924,13 +8921,13 @@
       }
     },
     "node_modules/@wordpress/undo-manager": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.20.0.tgz",
-      "integrity": "sha512-IG3/u0uR0nfZ/kXRfC6DVFK52hbbNx4aMB/c5DAMQgKtJElE7Mz1Mf5zgU1XNlpBOdguQp6oo/nMpyJUIasipQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.21.0.tgz",
+      "integrity": "sha512-mTtVH0//rC1dgm09ux+BB2aKxaI8K1KAKV8igKb14I7qFpdk1jcTlRU5ce/pI0czbrAFrk5xYwyVrOl1sZrAjQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.25.7",
-        "@wordpress/is-shallow-equal": "^5.20.0"
+        "@wordpress/is-shallow-equal": "^5.21.0"
       },
       "engines": {
         "node": ">=18.12.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/react-dom": "^19.0.4",
     "@wordpress/block-editor": "^14.15.0",
     "@wordpress/components": "^29.6.0",
+    "@wordpress/compose": "^7.21.0",
     "@wordpress/data": "^10.19.0",
     "@wordpress/editor": "^14.19.0",
     "@wordpress/element": "^6.19.0",

--- a/src/resources/packages/classy/elements/Classy.tsx
+++ b/src/resources/packages/classy/elements/Classy.tsx
@@ -3,8 +3,8 @@ import { Slot, SlotFillProvider } from '@wordpress/components';
 import { doAction } from '@wordpress/hooks';
 import { _x } from '@wordpress/i18n';
 import { EventDetails, EventTitle } from './fields';
-import { RegistryProvider } from '@wordpress/data';
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
+import {default as Provider} from './components/Provider';
 
 function ClassyApplication() {
 	return (
@@ -46,12 +46,9 @@ function ClassyApplication() {
 }
 
 export function Classy( { registry }: { registry: WPDataRegistry } ) {
-	{
-		/* @ts-ignore */
-	}
 	return (
-		<RegistryProvider value={ registry }>
+		<Provider value={ registry }>
 			<ClassyApplication />
-		</RegistryProvider>
+		</Provider>
 	);
 }

--- a/src/resources/packages/classy/elements/Classy.tsx
+++ b/src/resources/packages/classy/elements/Classy.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { Slot, SlotFillProvider } from '@wordpress/components';
 import { doAction } from '@wordpress/hooks';
 import { _x } from '@wordpress/i18n';
-import { EventTitle, EventDetails } from './fields';
+import { EventDetails, EventTitle } from './fields';
+import { RegistryProvider } from '@wordpress/data';
+import { WPDataRegistry } from '@wordpress/data/build-types/registry';
 
-export function Classy() {
+function ClassyApplication() {
 	return (
 		<SlotFillProvider>
 			{
@@ -40,5 +42,16 @@ export function Classy() {
 				<Slot name="classy.fields" />
 			</div>
 		</SlotFillProvider>
+	);
+}
+
+export function Classy( { registry }: { registry: WPDataRegistry } ) {
+	{
+		/* @ts-ignore */
+	}
+	return (
+		<RegistryProvider value={ registry }>
+			<ClassyApplication />
+		</RegistryProvider>
 	);
 }

--- a/src/resources/packages/classy/elements/components/Provider.tsx
+++ b/src/resources/packages/classy/elements/components/Provider.tsx
@@ -1,0 +1,60 @@
+import {compose } from '@wordpress/compose';
+import {withRegistryProvider} from "../../store";
+import {Component} from '@wordpress/element';
+import {ReactNode} from 'react';
+import { WPDataRegistry } from '@wordpress/data/build-types/registry';
+
+class Provider extends Component<{registry: WPDataRegistry, children?: ReactNode}> {
+	private unsubscribe: Function|null;
+
+	attachChangeObserver(registry:WPDataRegistry){
+		console.log('Provider.attachChangeObserver called');
+
+		if(this.unsubscribe)	{
+			this.unsubscribe();
+		}
+
+		// @todo here run some logic that should run when the fields change.
+		// const {getFields}:{getFields: Function} = registry.select('tec/classy');
+		// let fields = getFields();
+
+		this.unsubscribe = registry.subscribe(()=>{
+			console.log('Provider.attachChangeObserver.listener called');
+			// @todo here fetch the fields and update the state.
+		});
+	}
+
+	componentDidMount(){
+		console.log('Provider.componentDidMount called');
+		this.attachChangeObserver(this.props.registry)
+	}
+
+	componentWillUnmount(){
+		console.log('Provider.componentWillUnmount called');
+		if(this.unsubscribe){
+			this.unsubscribe();
+		}
+	}
+
+	componentDidUpdate(prevProps){
+		console.log('Provider.componentDidUpdate called');
+		const {registry} = this.props;
+
+		if(registry!== prevProps.registry){
+			this.attachChangeObserver(registry);
+		}
+
+		// @todo deal with in-flight requests here
+	}
+
+	render(){
+		console.log('Provider.render called');
+		const {children} = this.props;
+
+		return children;
+	}
+}
+
+export default compose([
+	withRegistryProvider
+])(Provider);

--- a/src/resources/packages/classy/elements/fields/EventTitle.tsx
+++ b/src/resources/packages/classy/elements/fields/EventTitle.tsx
@@ -1,11 +1,14 @@
 import { EventTitleProps } from '../../types/FieldProps';
 import { __experimentalInputControl as InputControl } from '@wordpress/components';
 import { useState, useEffect } from 'react';
-import { usePostEdits } from '../../hooks';
-import { UsePostEditsReturn } from '../../types/UsePostEditsReturn';
+import {useSelect, useDispatch} from '@wordpress/data';
 
 export function EventTitle( props: EventTitleProps ) {
-	const { postTitle, editPost } = usePostEdits() as UsePostEditsReturn;
+	const postTitle = useSelect((select)=>{
+		const {getEditedPostAttribute}: { getEditedPostAttribute: Function } = select('tec/classy');
+		return getEditedPostAttribute('title');
+	},[]);
+	const {editPost}:{editPost: Function}  = useDispatch('tec/classy');
 
 	const [ value, setValue ] = useState< string >( postTitle || '' );
 

--- a/src/resources/packages/classy/functions/classy.ts
+++ b/src/resources/packages/classy/functions/classy.ts
@@ -4,6 +4,7 @@ import {
 	getElement as getVisualEditorElement,
 	toggleVisibility as toggleVisualEditorVisibility,
 } from './visualEditor';
+import { createRegistry as createClassyRegistry } from '../store';
 
 /**
  * Cached instance of the classy element.
@@ -112,5 +113,6 @@ export function toggleElementVisibility(
 export function initApp( document: Document | null = null ): void {
 	document = document ?? window.document;
 	const classyRoot = createRoot( getOrCreateElement( document ) );
-	classyRoot.render( Classy() );
+	const registry = createClassyRegistry();
+	classyRoot.render( Classy( { registry } ) );
 }

--- a/src/resources/packages/classy/index.ts
+++ b/src/resources/packages/classy/index.ts
@@ -9,11 +9,7 @@ import {
 	insertElement as insertClassyElement,
 	toggleElementVisibility as toggleClassyElementVisibility,
 } from './functions/classy';
-import { store } from './store';
 import './style.pcss';
-import { register } from '@wordpress/data';
-
-register( store );
 
 whenEditorIsReady().then( () => {
 	hideZoomOutButton();

--- a/src/resources/packages/classy/store/index.ts
+++ b/src/resources/packages/classy/store/index.ts
@@ -1,12 +1,2 @@
-import { createReduxStore } from '@wordpress/data';
-import { reducer } from './reducer';
-import * as actions from './actions';
-import * as selectors from './selectors';
-
-export const STORE_NAME = 'tec/classy';
-
-export const store = createReduxStore( STORE_NAME, {
-	reducer,
-	actions,
-	selectors,
-} );
+export * from './store';
+export * from './registry';

--- a/src/resources/packages/classy/store/registry.ts
+++ b/src/resources/packages/classy/store/registry.ts
@@ -1,0 +1,143 @@
+import { STORE_NAME, storeConfig } from './store';
+import { createRegistry as wpDataCreateRegistry } from '@wordpress/data';
+import {
+	StoreDescriptor,
+	WPDataRegistry,
+} from '@wordpress/data/build-types/registry';
+
+/**
+ * Extend the global to let TypeScript know about the global window object.
+ */
+declare global {
+	interface Window {
+		wp?: {
+			data?: {
+				select: Function;
+				dispatch: Function;
+			};
+		};
+	}
+}
+
+/**
+ * The original select function.
+ *
+ * @since TBD
+ *
+ * @type {Function}
+ */
+let originalSelect: Function | null = null;
+
+/**
+ * The original dispatch function.
+ *
+ * @since TBD
+ *
+ * @type {Function}
+ */
+let originalDispatch: Function | null = null;
+
+/**
+ * An adapter that will route data selections to the appropriate source.
+ *
+ * @since TBD
+ *
+ * @param {string|StoreDescriptor} storeSelector The name of the store to select from, or a StoreDescriptor.
+ *
+ * @returns {any} The selected data.
+ */
+function classyRegistrySelectAdapter(
+	storeSelector: string | StoreDescriptor
+): any {
+	const storeName =
+		typeof storeSelector === 'string' ? storeSelector : storeSelector.name;
+
+	console.log(
+		'classyRegistrySelectAdapter selecting store with name ',
+		storeName
+	);
+
+	if ( storeName === STORE_NAME ) {
+		return originalSelect( STORE_NAME );
+	}
+
+	/**
+	 * If the store exists on the `window.wp.data` object, then select from it.
+	 */
+	const wpDataSelect = window?.wp?.data.select( storeName );
+	if ( wpDataSelect ) {
+		return wpDataSelect;
+	}
+
+	console.error(
+		`Classy select adapter: store ${ storeName } does not exist on window.wp.data or in Classy registry.`
+	);
+
+	return {}; // Return an empty object if the store cannot be selected.
+}
+
+/**
+ * An adapter that will route data dispatches to the appropriate source.
+ *
+ * @since TBD
+ *
+ * @param {string|StoreDescriptor} storeSelector The name of the store to select from, or a StoreDescriptor.
+ *
+ * @returns {any} The selected data.
+ */
+function classyRegistryDispatchAdapter(
+	storeSelector: string | StoreDescriptor
+): any {
+	const storeName =
+		typeof storeSelector === 'string' ? storeSelector : storeSelector.name;
+
+	console.log(
+		'classyRegistryDispatchAdapter dispatching action to store with name ',
+		storeName
+	);
+
+	if ( storeName === STORE_NAME ) {
+		return originalDispatch( STORE_NAME );
+	}
+
+	/**
+	 * If the store exists on the `window.wp.data` object, then dispatch from it.
+	 */
+	// @ts-ignore
+	const wpDataDispatch = window?.wp?.data.dispatch( storeName );
+
+	if ( wpDataDispatch ) {
+		return wpDataDispatch;
+	}
+
+	console.error(
+		`Classy dispatch adapter: store ${ storeName } does not exist on window.wp.data or in Classy registry.`
+	);
+
+	return {}; // Return an empty object if the store cannot be selected.
+}
+
+/**
+ * Creates a registry, separated from the default WordPress one,
+ * that will act as a router to handle requests coming from the Classy application components.
+ * Requests for the Core stores will be handled by the WordPress registry if available.
+ *
+ * @since 1.0.0
+ *
+ * @return {WPDataRegistry} The created Classy registry.
+ */
+export function createRegistry(): WPDataRegistry {
+	const classyRegistry: WPDataRegistry = wpDataCreateRegistry( {
+		[ STORE_NAME ]: storeConfig,
+	} );
+
+	// Save a reference to the original `select` and `dispatch` functions.
+	originalSelect = classyRegistry.select;
+	originalDispatch = classyRegistry.dispatch;
+
+	// Replace the default WordPress registry's select and dispatch functions with the adapters.
+	classyRegistry.select = classyRegistrySelectAdapter;
+	classyRegistry.dispatch = classyRegistryDispatchAdapter;
+
+	return classyRegistry;
+}

--- a/src/resources/packages/classy/store/registry/index.ts
+++ b/src/resources/packages/classy/store/registry/index.ts
@@ -1,0 +1,2 @@
+export * from './registry';
+export {default as withRegistryProvider} from './with-registry-provider';

--- a/src/resources/packages/classy/store/registry/registry.ts
+++ b/src/resources/packages/classy/store/registry/registry.ts
@@ -1,4 +1,4 @@
-import { STORE_NAME, storeConfig } from './store';
+import { STORE_NAME, storeConfig } from '../store';
 import { createRegistry as wpDataCreateRegistry } from '@wordpress/data';
 import {
 	StoreDescriptor,
@@ -66,6 +66,7 @@ function classyRegistrySelectAdapter(
 	 */
 	const wpDataSelect = window?.wp?.data.select( storeName );
 	if ( wpDataSelect ) {
+		// @todo reroute requests to the Classy store
 		return wpDataSelect;
 	}
 
@@ -107,6 +108,7 @@ function classyRegistryDispatchAdapter(
 	const wpDataDispatch = window?.wp?.data.dispatch( storeName );
 
 	if ( wpDataDispatch ) {
+		// @todo reroute requests to the Classy store.
 		return wpDataDispatch;
 	}
 
@@ -141,3 +143,4 @@ export function createRegistry(): WPDataRegistry {
 
 	return classyRegistry;
 }
+

--- a/src/resources/packages/classy/store/registry/with-registry-provider.tsx
+++ b/src/resources/packages/classy/store/registry/with-registry-provider.tsx
@@ -1,0 +1,22 @@
+import {createHigherOrderComponent} from '@wordpress/compose';
+import {withRegistry} from '@wordpress/data';
+import {STORE_NAME, storeConfig} from "../store";
+import { WPDataRegistry } from '@wordpress/data/build-types/registry';
+
+const withRegistryProvider =createHigherOrderComponent(
+	(WrappedComponent)=>{
+		return withRegistry(
+			({registry, ...props}: {registry: WPDataRegistry, props: any[]}) => {
+				// Register the Classy store.
+				registry.registerStore(STORE_NAME, storeConfig);
+
+				return (
+					<WrappedComponent registry={registry} {...props} />
+				);
+			}
+		)
+	},
+	'witRegistryProvider'
+)
+
+export default withRegistryProvider;

--- a/src/resources/packages/classy/store/store.ts
+++ b/src/resources/packages/classy/store/store.ts
@@ -1,0 +1,12 @@
+import { reducer } from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+export { createRegistry } from './registry';
+
+export const STORE_NAME = 'tec/classy';
+
+export const storeConfig = {
+	reducer,
+	actions,
+	selectors,
+};


### PR DESCRIPTION
This work starts the update of the Classy application to use a
dedicated registry, separate from the WordPress Block Editor one.

Why?

Since the application must work in the Block Editor context, and outside
of it, it cannot rely on the WordPress Core stores being present and
initialized on the page.

The app is using components (e.g. the `PostFeaturedImage` one) that have
hard-codeded dependencies on the Core stores (e.g. the `core` and the
`core/editor` stores); to intercept those dependencies, the only option
I could find is to create a new registry and, in that, re-route the
request to the correct core store in the core registry, if available.

At this stage the components render without crashing, but the featured
image one will not update correctly.

Tests will need update too to use a dedicated registry in place of store
mocks.
