### PR TITLE
Hide telemetry modal on wizard page.

### DIFF
--- a/changelog/fix-no-telemetry-modal-on-wizard-page
+++ b/changelog/fix-no-telemetry-modal-on-wizard-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Alter Telemetry to allow classes to hook in and supress the modal for specific pages.

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -62,6 +62,7 @@ class Controller extends Controller_Contract {
 		add_filter( 'tec_events_onboarding_wizard_handle', [ Organizer::class, 'handle' ], 12, 2 );
 		add_filter( 'tec_events_onboarding_wizard_handle', [ Venue::class, 'handle' ], 13, 2 );
 		add_filter( 'tec_events_onboarding_wizard_handle', [ Tickets::class, 'handle' ], 14, 2 );
+		add_filter( 'tec_telemetry_is_tec_admin_page', [ $this, 'hide_telemetry_on_onboarding_page' ] );
 	}
 
 	/**
@@ -76,7 +77,37 @@ class Controller extends Controller_Contract {
 		add_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
 		add_action( 'admin_post_' . Landing_Page::DISMISS_ONBOARDING_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		add_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
-		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] ); }
+		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
+	}
+
+	/**
+	 * Remove the filter hooks.
+	 *
+	 * @since 6.8.4
+	 */
+	public function remove_filters(): void {
+		// Remove the step handlers.
+		remove_filter( 'tec_events_onboarding_wizard_handle', [ Optin::class, 'handle' ], 10 );
+		remove_filter( 'tec_events_onboarding_wizard_handle', [ Settings::class, 'handle' ], 11 );
+		remove_filter( 'tec_events_onboarding_wizard_handle', [ Organizer::class, 'handle' ], 12 );
+		remove_filter( 'tec_events_onboarding_wizard_handle', [ Venue::class, 'handle' ], 13 );
+		remove_filter( 'tec_events_onboarding_wizard_handle', [ Tickets::class, 'handle' ], 14 );
+		remove_filter( 'tec_telemetry_is_tec_admin_page', [ $this, 'hide_telemetry_on_onboarding_page' ] );
+	}
+
+	/**
+	 * Remove the action hooks.
+	 *
+	 * @since 6.8.4
+	 * @since 6.11.0 Changed the priority of `admin_menu`.
+	 */
+	public function remove_actions(): void {
+		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
+		remove_action( 'admin_init', [ $this, 'enqueue_scripts' ] );
+		remove_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
+		remove_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
+		remove_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
+	}
 
 	/**
 	 * Handle the onboarding page dismiss.
@@ -97,6 +128,8 @@ class Controller extends Controller_Contract {
 	 * @return void
 	 */
 	public function redirect_tec_pages_to_guided_setup(): void {
+		$force = apply_filters( 'tec_events_onboarding_force_redirect_to_guided_setup', false );
+
 		// Do not redirect if they are already on the Guided Setup page.
 		$page = tec_get_request_var( 'page' );
 		if ( Landing_Page::$slug === $page ) {
@@ -119,20 +152,22 @@ class Controller extends Controller_Contract {
 			return;
 		}
 
-		// Do not redirect if they have been to the Guided Setup page already.
-		if ( (bool) tribe_get_option( 'tec_onboarding_wizard_visited_guided_setup', false ) ) {
-			return;
-		}
+		if ( ! $force ) {
+			// Do not redirect if they have been to the Guided Setup page already.
+			if ( (bool) tribe_get_option( 'tec_onboarding_wizard_visited_guided_setup', false ) ) {
+				return;
+			}
 
-		// Do not redirect if they dismissed the Guided Setup page.
-		if ( Landing_Page::is_dismissed() ) {
-			return;
-		}
+			// Do not redirect if they dismissed the Guided Setup page.
+			if ( Landing_Page::is_dismissed() ) {
+				return;
+			}
 
-		// Do not redirect if they have older versions and are probably already set up.
-		$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
-		if ( count( $tec_versions ) > 1 ) {
-			return;
+			// Do not redirect if they have older versions and are probably already set up.
+			$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
+			if ( count( $tec_versions ) > 1 ) {
+				return;
+			}
 		}
 
 		// If we're still here, redirect to the Guided Setup page.
@@ -147,34 +182,6 @@ class Controller extends Controller_Contract {
 		// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit, StellarWP.CodeAnalysis.RedirectAndDie.Error
 		wp_safe_redirect( $setup_url );
 		tribe_exit();
-	}
-
-	/**
-	 * Remove the filter hooks.
-	 *
-	 * @since 6.8.4
-	 */
-	public function remove_filters(): void {
-		// Remove the step handlers.
-		remove_filter( 'tec_events_onboarding_wizard_handle', [ Optin::class, 'handle' ], 10 );
-		remove_filter( 'tec_events_onboarding_wizard_handle', [ Settings::class, 'handle' ], 11 );
-		remove_filter( 'tec_events_onboarding_wizard_handle', [ Organizer::class, 'handle' ], 12 );
-		remove_filter( 'tec_events_onboarding_wizard_handle', [ Venue::class, 'handle' ], 13 );
-		remove_filter( 'tec_events_onboarding_wizard_handle', [ Tickets::class, 'handle' ], 14 );
-	}
-
-	/**
-	 * Remove the action hooks.
-	 *
-	 * @since 6.8.4
-	 * @since 6.11.0 Changed the priority of `admin_menu`.
-	 */
-	public function remove_actions(): void {
-		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
-		remove_action( 'admin_init', [ $this, 'enqueue_scripts' ] );
-		remove_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
-		remove_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
-		remove_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
 	}
 
 	/**
@@ -215,5 +222,18 @@ class Controller extends Controller_Contract {
 	 */
 	public function register_rest_endpoints(): void {
 		$this->container->make( API::class )->register();
+	}
+
+	/**
+	 * Hide telemetry on the onboarding page.
+	 *
+	 * @since TBD
+	 */
+	public function hide_telemetry_on_onboarding_page( $is_tec_admin_page ): bool {
+		if ( $this->container->make( Landing_Page::class )->is_on_page() ) {
+			return false;
+		}
+
+		return $is_tec_admin_page;
 	}
 }

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -76,7 +76,7 @@ class Controller extends Controller_Contract {
 		add_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
 		add_action( 'admin_init', [ $this, 'enqueue_assets' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
-		add_action( 'admin_post_' . Landing_Page::DISMISS_ONBOARDING_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
+		add_action( 'admin_post_' . Landing_Page::DISMISS_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		add_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
 		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
 	}
@@ -106,6 +106,7 @@ class Controller extends Controller_Contract {
 		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
 		remove_action( 'admin_init', [ $this, 'enqueue_scripts' ] );
 		remove_action( 'rest_api_init', [ $this, 'register_rest_endpoints' ] );
+		remove_action( 'admin_post_' . Landing_Page::DISMISS_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		remove_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
 		remove_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
 	}

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -33,7 +33,16 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @var string
 	 */
-	const DISMISS_ONBOARDING_PAGE_ACTION = 'tec_dismiss_onboarding_page';
+	const DISMISS_PAGE_ACTION = 'tec_dismiss_onboarding_page';
+
+	/**
+	 * The option to dismiss the onboarding page.
+	 *
+	 * @since 6.8.4
+	 *
+	 * @var string
+	 */
+	const DISMISS_PAGE_OPTION = 'tec_events_onboarding_page_dismissed';
 
 	/**
 	 * The slug for the admin menu.
@@ -103,17 +112,6 @@ class Landing_Page extends Abstract_Admin_Page {
 	}
 
 	/**
-	 * Has the page been dismissed?
-	 *
-	 * @since 6.8.4
-	 *
-	 * @return bool
-	 */
-	public static function is_dismissed(): bool {
-		return (bool) tribe_get_option( 'tec_events_onboarding_page_dismissed', false );
-	}
-
-	/**
 	 * Get the admin menu title.
 	 *
 	 * @since 6.8.4
@@ -153,7 +151,7 @@ class Landing_Page extends Abstract_Admin_Page {
 
 		$action_url = add_query_arg(
 			// We do not need a nonce. This page can be seen only by admins. see `required_capability` method.
-			[ 'action' => self::DISMISS_ONBOARDING_PAGE_ACTION ],
+			[ 'action' => self::DISMISS_PAGE_ACTION ],
 			admin_url( '/admin-post.php' )
 		);
 		?>

--- a/src/Events/Telemetry/Telemetry.php
+++ b/src/Events/Telemetry/Telemetry.php
@@ -190,22 +190,30 @@ class Telemetry {
 		$current_screen = get_current_screen();
 		$helper = \Tribe__Admin__Helpers::instance();
 
-		// Are we on a tec post-type admin screen?
+		// If we are not on a tec post-type admin screen, bail.
 		if ( ! $helper->is_post_type_screen( TEC::POSTTYPE ) ) {
 			return false;
 		}
 
-		// Are we on a post edit screen?
+		// If we are on a post edit screen, bail.
 		if ( $current_screen instanceof \WP_Screen && tribe_get_request_var( 'action' ) === 'edit' ) {
 			return false;
 		}
 
-		// Are we on a new post screen?
+		// If we are on a new post screen, bail.
 		if ( $current_screen instanceof \WP_Screen && $current_screen->action === 'add' ) {
 			return false;
 		}
 
-		return true;
+		/**
+		 * Filter to determine if we are on a TEC admin page.
+		 * Allows other classes to hook in and modify the return value.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $is_tec_admin_page Whether we are on a TEC admin page.
+		 */
+		return (bool) apply_filters( 'tec_telemetry_is_tec_admin_page', true );
 	}
 
 	/**

--- a/src/resources/packages/wizard/index.tsx
+++ b/src/resources/packages/wizard/index.tsx
@@ -89,6 +89,7 @@ domReady(() => {
     }
 
     // Render the modal once in the container.
-    ReactDOM.render(<OnboardingModal bootData={parsedBootData} />, rootContainer);
+    const root = ReactDOM.createRoot(rootContainer!);
+    root.render(<OnboardingModal bootData={parsedBootData} />);
     isModalRendered = true;
 });


### PR DESCRIPTION
### 🎫 Ticket

[ET-2380]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This stops the Telemetry modal from showing on the Onboarding page - any opt-in here should be handled by the wizard.

Also:
 - Switch to React 18 render method.
 - Change constant we're using to dismiss the page. (the value doesn't change, just the constant name)

### 🎥 Artifacts <!-- if applicable-->
Not adding a screenshot because can't prove this negative that way.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2380]: https://stellarwp.atlassian.net/browse/ET-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ