### PR TITLE
TEC-3424 Change div to section for TEC views

### DIFF
--- a/changelog/fix-TEC-3424-change-div-to-section
+++ b/changelog/fix-TEC-3424-change-div-to-section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Change wrapper div to a section tag to avoid multiple 'banner' landmarks. [TEC-3424]

--- a/src/views/v2/day.php
+++ b/src/views/v2/day.php
@@ -42,7 +42,7 @@ if ( empty( $disable_event_search ) ) {
 		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
 	<?php endif; ?>
 >
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>
 
 		<?php $this->template( 'components/json-ld-data' ); ?>
@@ -74,7 +74,7 @@ if ( empty( $disable_event_search ) ) {
 
 		<?php $this->template( 'components/after' ); ?>
 
-	</div>
+	</section>
 
 </div>
 

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -44,7 +44,7 @@ if ( empty( $disable_event_search ) ) {
 		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
 	<?php endif; ?>
 >
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>
 
 		<?php $this->template( 'components/json-ld-data' ); ?>
@@ -84,7 +84,7 @@ if ( empty( $disable_event_search ) ) {
 
 		<?php $this->template( 'components/after' ); ?>
 
-	</div>
+	</section>
 </div>
 
 <?php $this->template( 'components/breakpoints' ); ?>

--- a/src/views/v2/month.php
+++ b/src/views/v2/month.php
@@ -40,7 +40,7 @@ if ( empty( $disable_event_search ) ) {
 		data-view-breakpoint-pointer="<?php echo esc_attr( $breakpoint_pointer ); ?>"
 	<?php endif; ?>
 >
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<?php $this->template( 'components/loader', [ 'text' => __( 'Loading...', 'the-events-calendar' ) ] ); ?>
 
 		<?php $this->template( 'components/json-ld-data' ); ?>
@@ -75,7 +75,7 @@ if ( empty( $disable_event_search ) ) {
 
 		<?php $this->template( 'components/after' ); ?>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - cats__0.snapshot.html
@@ -6,7 +6,7 @@
 			data-view-embed="6008fd99"
 				data-view-breakpoint-pointer="breakpoint-pointer"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -4261,7 +4261,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - no cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__no tags - no cats__0.snapshot.html
@@ -6,7 +6,7 @@
 			data-view-embed="6008fd99"
 				data-view-breakpoint-pointer="breakpoint-pointer"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -4261,7 +4261,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags - no cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags - no cats__0.snapshot.html
@@ -6,7 +6,7 @@
 			data-view-embed="6008fd99"
 				data-view-breakpoint-pointer="breakpoint-pointer"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -4261,7 +4261,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags and cats__0.snapshot.html
+++ b/tests/embed_calendar_integration/__snapshots__/Frontend_Test__it_should_overwrite_content__tags and cats__0.snapshot.html
@@ -6,7 +6,7 @@
 			data-view-embed="6008fd99"
 				data-view-breakpoint-pointer="breakpoint-pointer"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -4261,7 +4261,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Integrations/__snapshots__/Restrict_Content_Pro_Test__test_render_unrestricted__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Integrations/__snapshots__/Restrict_Content_Pro_Test__test_render_unrestricted__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3461,7 +3461,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -410,7 +410,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -481,7 +481,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -579,7 +579,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__2.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -607,7 +607,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Day View__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -363,7 +363,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set List View__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -389,7 +389,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Latest_Past_ViewTest__should_correctly_render_in_the_context_of_month_view with data set Month View__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -393,7 +393,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -425,7 +425,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -494,7 +494,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -532,7 +532,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -560,7 +560,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3244,7 +3244,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3461,7 +3461,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_hide_endtime__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_hide_endtime__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3452,7 +3452,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3432,7 +3432,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -3460,7 +3460,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 
 </div>
 

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
@@ -5,7 +5,7 @@
 	data-view-manage-url="1"
 				data-view-breakpoint-pointer="random-id"
 	>
-	<div class="tribe-common-l-container tribe-events-l-container">
+	<section class="tribe-common-l-container tribe-events-l-container">
 		<div
 	class="tribe-events-view-loader tribe-common-a11y-hidden"
 	role="alert"
@@ -413,7 +413,7 @@ http://evnt.is/18wn
 -->
 </div>
 
-	</div>
+	</section>
 </div>
 
 <script class="tribe-events-breakpoints">


### PR DESCRIPTION
### 🎫 Ticket

[TEC-3424]

### 🗒️ Description

This is an alternative solution to [this PR](https://github.com/the-events-calendar/the-events-calendar/pull/5093). 

For better accessibility, the document should not have more than one banner landmark. The banner landmark is implicitly added to `<header>` tags, which is causing this to get flagged in our plugins. 

This PR adjusts the `tribe-common-l-container tribe-events-l-container` wrapper `<div>` to a `<section>` to semantically describe the contents of the page and fix the flag for multiple banner landmarks. 

### 🎥 Artifacts 
https://drive.google.com/file/d/1gy0lk3_1JJQKwfhxQBarhA1cOOxEKpOc/view?usp=sharing 

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-3424]: https://stellarwp.atlassian.net/browse/TEC-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ