### PR TITLE
TEC-4226 Focus on search results

### DIFF
--- a/changelog/fix-TEC-4226-focus-on-search-results
+++ b/changelog/fix-TEC-4226-focus-on-search-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Move focus to search results for accessibility improvements. [TEC-4226]

--- a/src/Tribe/Views/V2/Assets.php
+++ b/src/Tribe/Views/V2/Assets.php
@@ -102,6 +102,7 @@ class Assets extends Service_Provider {
 	 * Binds and sets up implementations.
 	 *
 	 * @since 4.9.2
+	 * @since TBD Added search focus asset.
 	 */
 	public function register() {
 		$plugin = Plugin::instance();
@@ -390,6 +391,22 @@ class Assets extends Service_Provider {
 			[
 				'jquery',
 				'tribe-common',
+			],
+			'wp_enqueue_scripts',
+			[
+				'priority'     => 10,
+				'conditionals' => [ $this, 'should_enqueue_frontend' ],
+				'groups'       => [ static::$group_key ],
+			]
+		);
+
+		tribe_asset(
+			$plugin,
+			'tribe-events-views-v2-search-focus',
+			'tribe-events-search-focus.js',
+			[
+				'jquery',
+				'tribe-events-views-v2-manager',
 			],
 			'wp_enqueue_scripts',
 			[

--- a/src/resources/js/tribe-events-search-focus.js
+++ b/src/resources/js/tribe-events-search-focus.js
@@ -1,0 +1,54 @@
+/**
+ * Handles focus management for The Events Calendar search results.
+ *
+ * @since TBD
+ */
+(function($) {
+    'use strict';
+
+    /**
+     * Focuses on the appropriate container after search is performed.
+     * Prioritizes the events list container if it has events, otherwise focuses
+     * on the messages container.
+     *
+     * This function runs when the container is replaced after an AJAX request,
+     * which happens after search form submission.
+     * 
+     * @since TBD
+     * 
+     * @param {Event} event The dispatched event.
+     * @param {Object} detail The event details containing the container.
+     */
+    function focusOnSearchResults(event) {
+        const $container = $(event.detail);
+        
+        // Find the events list container if it exists and has events.
+        const $eventsContainer = $container.find('.tribe-events-calendar-list');
+        const hasEvents = $eventsContainer.find('.tribe-events-calendar-list__event-row').length > 0;
+        
+        // Find the messages container if it exists (which appears when no events are found).
+        const $messagesContainer = $container.find('.tribe-events-c-messages__message-list');
+        
+        // Determine which element to focus on.
+        if (hasEvents && $eventsContainer.length) {
+            // Focus on the events list container if it has events.
+            $eventsContainer.get(0).focus();
+        } else if ($messagesContainer.length) {
+            // Otherwise focus on the messages container (no events found).
+            $messagesContainer.get(0).focus();
+        }
+    }
+
+    /**
+     * Setup the event listeners.
+     *
+     * @since TBD
+     */
+    function setup() {
+        // Listen for the event triggered after the container is replaced.
+        document.addEventListener('containerReplaceAfter.tribeEvents', focusOnSearchResults);
+    }
+
+    $(document).ready(setup);
+
+})(jQuery); 

--- a/src/views/v2/components/messages.php
+++ b/src/views/v2/components/messages.php
@@ -35,7 +35,7 @@ $attributes = isset( $attributes ) ? (array) $attributes : [];
 	<?php foreach ( $messages as $message_type => $message_group ) : ?>
 		<div class="tribe-events-c-messages__message tribe-events-c-messages__message--<?php echo esc_attr( $message_type ); ?>" role="alert">
 			<?php $this->template( 'components/messages/' . esc_attr( $message_type ) . '-icon' ); ?>
-			<div class="tribe-events-c-messages__message-list" tabindex="0" role="alert" aria-live="polite">
+			<div class="tribe-events-c-messages__message-list" tabindex="0" aria-live="assertive">
 				<?php foreach ( $message_group as $key => $message ) : ?>
 					<div
 						class="tribe-events-c-messages__message-list-item"

--- a/src/views/v2/list.php
+++ b/src/views/v2/list.php
@@ -14,6 +14,7 @@
  *
  * @version 6.2.0
  * @since 6.2.0 Moved the header information into a new components/header.php template.
+ * @since TBD Add tabindex to events list for improved accessibility.
  *
  * @var array    $events               The array containing the events.
  * @var string   $rest_url             The REST URL.
@@ -59,6 +60,7 @@ if ( empty( $disable_event_search ) ) {
 
 		<div 
 			class="tribe-events-calendar-list"
+			tabindex="-1"
 			aria-label="
 			<?php 
 				/* translators: %s: Events (plural) */


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4226]

### 🗒️ Description

When using either the tribe-bar or filterbar to search for events, the focus should be moved to the results of this search for improved accessibility. Moving the focus directly to the results provides a better user experience because the user immediately gets feedback on their search results and doesn't need to tab through the whole page to learn the results of their search. 

### 🎥 Artifacts 

https://github.com/user-attachments/assets/22583c46-7a87-4a2a-8163-8a9a6404079b



### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
