### PR TITLE
Fix too strict ECE callbacks

### DIFF
--- a/changelog/fix-make-ece-callbacks-not-strict
+++ b/changelog/fix-make-ece-callbacks-not-strict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Amend various callbacks of the External Calendar Embeds feature to not be so strict on the expected arguments, as a result fixing fatal errors when the arguments are not of the expected type. [TEC-5484]

--- a/src/Events/Calendar_Embeds/Admin/List_Page.php
+++ b/src/Events/Calendar_Embeds/Admin/List_Page.php
@@ -196,12 +196,13 @@ class List_Page extends Controller_Contract {
 	 * Keep parent menu open when adding and editing calendar embeds.
 	 *
 	 * @since 6.11.0
+	 * @since TBD Made the parameters non-strict.
 	 *
-	 * @param string $submenu_file The current submenu file.
+	 * @param ?string $submenu_file The current submenu file.
 	 *
 	 * @return ?string
 	 */
-	public function keep_parent_menu_open( ?string $submenu_file ): ?string {
+	public function keep_parent_menu_open( $submenu_file ): ?string {
 		global $parent_file;
 
 		if ( 'edit.php?post_type=' . Calendar_Embeds::POSTTYPE !== $parent_file ) {

--- a/src/Events/Calendar_Embeds/Admin/Singular_Page.php
+++ b/src/Events/Calendar_Embeds/Admin/Singular_Page.php
@@ -85,12 +85,17 @@ class Singular_Page extends Controller_Contract {
 	 * Modifies the post updated messages for the calendar embed post type.
 	 *
 	 * @since 6.11.0
+	 * @since TBD Made the parameters non-strict.
 	 *
 	 * @param array $messages The post updated messages.
 	 *
 	 * @return array
 	 */
-	public function modify_post_updated_messages( array $messages ): array {
+	public function modify_post_updated_messages( $messages ): array {
+		if ( ! is_array( $messages ) ) {
+			return $messages;
+		}
+
 		if ( ! self::is_on_page() ) {
 			return $messages;
 		}
@@ -249,12 +254,13 @@ class Singular_Page extends Controller_Contract {
 	 * Keep parent menu open when adding and editing calendar embeds.
 	 *
 	 * @since 6.11.0
+	 * @since TBD Made the parameters non-strict.
 	 *
-	 * @param string $submenu_file The current submenu file.
+	 * @param ?string $submenu_file The current submenu file.
 	 *
 	 * @return ?string
 	 */
-	public function keep_parent_menu_open( ?string $submenu_file ): ?string {
+	public function keep_parent_menu_open( $submenu_file ): ?string {
 		global $parent_file;
 
 		if ( 'edit.php?post_type=' . Calendar_Embeds::POSTTYPE !== $parent_file ) {

--- a/src/Events/Calendar_Embeds/Calendar_Embeds.php
+++ b/src/Events/Calendar_Embeds/Calendar_Embeds.php
@@ -96,16 +96,20 @@ class Calendar_Embeds extends Controller_Contract {
 	 *
 	 * @since 6.11.0
 	 * @since 6.11.0.1 Added check to ensure ABSPATH/wp-admin/includes/screen.php is loaded before running.
+	 * @since TBD Made the parameters non-strict.
 	 *
 	 * @param array  $terms      The terms.
 	 * @param ?array $taxonomies The taxonomies.
 	 *
 	 * @return array
 	 */
-	public function modify_term_count_on_term_list_table( array $terms, ?array $taxonomies = null ): array {
+	public function modify_term_count_on_term_list_table( $terms, $taxonomies = null ): array {
 		if ( null === $taxonomies ) {
 			return $terms;
 		}
+
+		$terms      = (array) $terms;
+		$taxonomies = (array) $taxonomies;
 
 		if ( ! in_array( TEC_Plugin::TAXONOMY, $taxonomies, true ) && ! in_array( 'post_tag', $taxonomies, true ) ) {
 			return $terms;
@@ -152,6 +156,7 @@ class Calendar_Embeds extends Controller_Contract {
 	 * Disables slug changes for the calendar embed post type.
 	 *
 	 * @since 6.11.0
+	 * @since TBD Made the parameters non-strict.
 	 *
 	 * @param array $data              The post data.
 	 * @param array $post_array        The post array.
@@ -160,10 +165,14 @@ class Calendar_Embeds extends Controller_Contract {
 	 *
 	 * @return array
 	 */
-	public function disable_slug_changes( array $data, array $post_array, array $unsafe_post_array, bool $update ): array {
+	public function disable_slug_changes( $data, $post_array, $unsafe_post_array, $update ): array {
 		if ( static::POSTTYPE !== $data['post_type'] ) {
 			return $data;
 		}
+
+		$update     = (bool) $update;
+		$data       = (array) $data;
+		$post_array = (array) $post_array;
 
 		if ( $update ) {
 			// Ensure the post name is not updated.
@@ -393,7 +402,10 @@ class Calendar_Embeds extends Controller_Contract {
 	 *
 	 * @return bool
 	 */
-	public function do_not_add_trashed_suffix_to_trashed_calendar_embeds( bool $add_trashed_suffix, string $post_name, int $post_id ): bool {
+	public function do_not_add_trashed_suffix_to_trashed_calendar_embeds( $add_trashed_suffix, $post_name, $post_id ): bool {
+		$add_trashed_suffix = (bool) $add_trashed_suffix;
+		$post_id            = (int) $post_id;
+
 		if ( static::POSTTYPE !== get_post_type( $post_id ) ) {
 			return $add_trashed_suffix;
 		}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5484]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Making callbacks hooked tp WP-core hooks, in the ECE feature less strict on the expected arguments.
As a result fixing possible fatal errors when the arguments are not of the expected type.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5484]: https://stellarwp.atlassian.net/browse/TEC-5484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ