### PR TITLE
type cast it instead

### DIFF
--- a/src/Events/Calendar_Embeds/Admin/Singular_Page.php
+++ b/src/Events/Calendar_Embeds/Admin/Singular_Page.php
@@ -92,9 +92,7 @@ class Singular_Page extends Controller_Contract {
 	 * @return array
 	 */
 	public function modify_post_updated_messages( $messages ): array {
-		if ( ! is_array( $messages ) ) {
-			return $messages;
-		}
+		$messages = (array) $messages;
 
 		if ( ! self::is_on_page() ) {
 			return $messages;


### PR DESCRIPTION
Type cast it instead of bailing to ensure proper return type