### PR TITLE
Harden ajax endpoints

### DIFF
--- a/src/Events/Traits/Can_Edit_Events.php
+++ b/src/Events/Traits/Can_Edit_Events.php
@@ -18,7 +18,7 @@ use WP_User;
  *
  * @since TBD
  */
-trait Edit_Events {
+trait Can_Edit_Events {
 
 	/**
 	 * Check if the current user can edit events.

--- a/src/Events/Traits/Can_Edit_Events.php
+++ b/src/Events/Traits/Can_Edit_Events.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Edit_Events trait.
+ * Can_Edit_Events trait.
  *
  * @since TBD
  */
@@ -14,7 +14,7 @@ use WP_Post_Type;
 use WP_User;
 
 /**
- * Trait Edit_Events
+ * Trait Can_Edit_Events
  *
  * @since TBD
  */

--- a/src/Events/Traits/Edit_Events.php
+++ b/src/Events/Traits/Edit_Events.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Edit_Events trait.
+ *
+ * @since TBD
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Events\Traits;
+
+use Tribe__Events__Main as Events;
+use WP_Post_Type;
+use WP_User;
+
+/**
+ * Trait Edit_Events
+ *
+ * @since TBD
+ */
+trait Edit_Events {
+
+	/**
+	 * Check if the current user can edit events.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	protected function current_user_can_edit_events(): bool {
+		$current_user = wp_get_current_user();
+		if ( ! $current_user instanceof WP_User ) {
+			return false;
+		}
+
+		return $this->user_can_edit_events( $current_user );
+	}
+
+	/**
+	 * Check if the user can edit events.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user to check.
+	 *
+	 * @return bool
+	 */
+	protected function user_can_edit_events( WP_User $user ): bool {
+		$event_post_type = get_post_type_object( Events::POSTTYPE );
+		if ( ! $event_post_type instanceof WP_Post_Type ) {
+			return false;
+		}
+
+		return user_can( $user, $event_post_type->cap->edit_posts );
+	}
+}

--- a/src/Events/Traits/Edit_Events.php
+++ b/src/Events/Traits/Edit_Events.php
@@ -33,7 +33,7 @@ trait Edit_Events {
 			return false;
 		}
 
-		return $this->user_can_edit_events( $current_user );
+		return $this->user_can_edit_events( $current_user->ID );
 	}
 
 	/**
@@ -41,16 +41,16 @@ trait Edit_Events {
 	 *
 	 * @since TBD
 	 *
-	 * @param WP_User $user The user to check.
+	 * @param int $user_id The user to check.
 	 *
 	 * @return bool
 	 */
-	protected function user_can_edit_events( WP_User $user ): bool {
+	protected function user_can_edit_events( int $user_id ): bool {
 		$event_post_type = get_post_type_object( Events::POSTTYPE );
 		if ( ! $event_post_type instanceof WP_Post_Type ) {
 			return false;
 		}
 
-		return user_can( $user, $event_post_type->cap->edit_posts );
+		return user_can( $user_id, $event_post_type->cap->edit_posts );
 	}
 }

--- a/src/Tribe/Aggregator/Migrate.php
+++ b/src/Tribe/Aggregator/Migrate.php
@@ -175,6 +175,17 @@ class Tribe__Events__Aggregator__Migrate {
 	 * @return void
 	 */
 	public function ajax_convert_ical_settings() {
+		$nonce = tec_get_request_var( 'tribe_aggregator_nonce' );
+		if ( ! wp_verify_nonce( $nonce, 'tribe-aggregator-ajax-nonce' ) ) {
+			wp_send_json_error(
+				[
+					'status' => false,
+					'text'   => esc_html__( 'Error: Nonce verification failed. Please try again.', 'the-events-calendar' ),
+				],
+				400
+			);
+		}
+
 		$response = (object) array(
 			'status' => false,
 			'text' => esc_html__( 'Error: we were not able to migrate your iCal Importer settings to Event Aggregator. Please try again later.', 'the-events-calendar' ),

--- a/src/Tribe/Aggregator/Page.php
+++ b/src/Tribe/Aggregator/Page.php
@@ -135,6 +135,7 @@ class Tribe__Events__Aggregator__Page {
 				],
 				'default_settings'     => tribe( 'events-aggregator.settings' )->get_all_default_settings(),
 				'source_origin_regexp' => tribe( 'events-aggregator.settings' )->get_source_origin_regexp(),
+				'nonce'                => wp_create_nonce( 'tribe-aggregator-ajax-nonce' ),
 			];
 
 			/**

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -735,19 +735,11 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 	 *                               limit.
 	 */
 	public function queue_import( $args = [] ) {
-		$aggregator = tribe( 'events-aggregator.main' );
-
-		$is_previewing = (
-			! empty( $_GET['action'] )
-			&& (
-				'tribe_aggregator_create_import' === $_GET['action']
-				|| 'tribe_aggregator_preview_import' === $_GET['action']
-			)
-		);
-
-		$error = null;
-
-		$defaults = [
+		/** @var Tribe__Events__Aggregator $aggregator */
+		$aggregator    = tribe( 'events-aggregator.main' );
+		$is_previewing = $this->is_previewing();
+		$error         = null;
+		$defaults      = [
 			'type'                => $this->meta['type'],
 			'origin'              => $this->meta['origin'],
 			'source'              => $this->meta['source'] ?? '',
@@ -2623,7 +2615,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 				'fields'     => 'ID',
 			]
 		);
-		
+
 		if ( ! empty( $authors ) ) {
 			return reset( $authors );
 		}

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -1533,9 +1533,6 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 		 */
 		do_action( 'tribe_aggregator_before_insert_posts', $items, $this->meta );
 
-		// sets the default user ID to that of the first user that can edit events.
-		$default_user_id = $this->get_default_user_id();
-
 		// Creates an Activity to log what Happened.
 		$activity                = new Tribe__Events__Aggregator__Record__Activity();
 		$initial_created_events  = $activity->count( Tribe__Events__Main::POSTTYPE );
@@ -2123,7 +2120,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 
 				// during cron runs the user will be set to 0; we assign the event to the first user that can edit events.
 				if ( ! isset( $event['post_author'] ) ) {
-					$event['post_author'] = $default_user_id;
+					$event['post_author'] = $this->get_default_user_id();
 				}
 
 				/**

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -3028,7 +3028,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 	 * @return bool Whether the record is being previewed or not.
 	 */
 	protected function is_previewing(): bool {
-		$action = $_GET['action'] ?? null;
+		$action = tec_get_request_var( 'action' );
 
 		return 'tribe_aggregator_create_import' === $action || 'tribe_aggregator_preview_import' === $action;
 	}

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -2604,7 +2604,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 		// try the current user.
 		$current_user_id = get_current_user_id();
 
-		if ( ! empty( $current_user_id ) && $this->current_user_can_edit_events() ) {
+		if ( $this->user_can_edit_events( $current_user_id ) ) {
 			return $current_user_id;
 		}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -5,6 +5,7 @@
  * Abstract for EA records.
  */
 
+use TEC\Events\Traits\Edit_Events;
 use Tribe\Events\Aggregator\Record\Batch_Queue;
 
 // Don't load directly.
@@ -19,6 +20,8 @@ use Tribe__Languages__Locations as Locations;
  * Abstract for EA records.
  */
 abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.Classes.ValidClassName.NotSnakeCase, PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
+
+	use Edit_Events;
 
 	/**
 	 * Meta key prefix for ea-record data
@@ -2601,7 +2604,7 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 		// try the current user.
 		$current_user_id = get_current_user_id();
 
-		if ( ! empty( $current_user_id ) && current_user_can( $post_type_object->cap->edit_posts ) ) {
+		if ( ! empty( $current_user_id ) && $this->current_user_can_edit_events() ) {
 			return $current_user_id;
 		}
 

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -3027,4 +3027,17 @@ abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.
 	public function generate_next_batch_hash() {
 		return md5( uniqid( '', true ) );
 	}
+
+	/**
+	 * Whether the record is being previewed or not.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the record is being previewed or not.
+	 */
+	protected function is_previewing(): bool {
+		$action = $_GET['action'] ?? null;
+
+		return 'tribe_aggregator_create_import' === $action || 'tribe_aggregator_preview_import' === $action;
+	}
 }

--- a/src/Tribe/Aggregator/Record/Abstract.php
+++ b/src/Tribe/Aggregator/Record/Abstract.php
@@ -5,7 +5,7 @@
  * Abstract for EA records.
  */
 
-use TEC\Events\Traits\Edit_Events;
+use TEC\Events\Traits\Can_Edit_Events;
 use Tribe\Events\Aggregator\Record\Batch_Queue;
 
 // Don't load directly.
@@ -21,7 +21,7 @@ use Tribe__Languages__Locations as Locations;
  */
 abstract class Tribe__Events__Aggregator__Record__Abstract { //phpcs:ignore TEC.Classes.ValidClassName.NotSnakeCase, PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
 
-	use Edit_Events;
+	use Can_Edit_Events;
 
 	/**
 	 * Meta key prefix for ea-record data

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -34,24 +34,15 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 	}
 
 	public function queue_import( $args = array() ) {
-		$is_previewing = (
-			! empty( $_GET['action'] )
-			&& (
-				'tribe_aggregator_create_import' === $_GET['action']
-				|| 'tribe_aggregator_preview_import' === $_GET['action']
-			)
-		);
-
-		$data = $this->get_csv_data();
-
-		$result = array(
+		$data   = $this->get_csv_data();
+		$result = [
 			'status'       => 'success',
 			'message_code' => 'success',
-			'data'         => array(
+			'data'         => [
 				'import_id' => $this->id,
 				'items'     => $data,
-			),
-		);
+			],
+		];
 
 		$first_row = reset( $data );
 		$columns   = array_keys( $first_row );
@@ -61,9 +52,8 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		// store the import id
 		update_post_meta( $this->id, self::$meta_key_prefix . 'import_id', $this->id );
 
-		// only set as pending if we aren't previewing the record
-		if ( ! $is_previewing ) {
-			// if we get here, we're good! Set the status to pending
+		// Only set as pending if we aren't previewing the record.
+		if ( ! $this->is_previewing() ) {
 			$this->set_status_as_pending();
 		}
 

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -55,10 +55,6 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	}
 
 	public function handle_submit() {
-		$data = array(
-			'message' => __( 'There was a problem processing your import. Please try again.', 'the-events-calendar' ),
-		);
-
 		if ( ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) && ! $this->is_active() ) {
 			return;
 		}
@@ -72,9 +68,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		}
 
 		// validate nonce
-		if ( empty( $_POST['tribe_aggregator_nonce'] ) || ! wp_verify_nonce( $_POST['tribe_aggregator_nonce'], 'tribe-aggregator-save-import' ) ) {
-			wp_send_json_error( $data );
-		}
+		$this->validate_nonce();
 
 		$post_data = $_POST['aggregator'];
 
@@ -173,6 +167,21 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		return [
 			'message' => __( 'There was a problem processing your import. Please try again.', 'the-events-calendar' ),
 		];
+	}
+
+	/**
+	 * Validates the nonce for the AJAX request.
+	 *
+	 * If the nonce is invalid, this will send a JSON error response and end the request.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function validate_nonce() {
+		if ( ! wp_verify_nonce( $_POST['tribe_aggregator_nonce'] ?? '', 'tribe-aggregator-save-import' ) ) {
+			wp_send_json_error( $this->get_default_data() );
+		}
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -79,7 +79,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		$post_data = $_POST['aggregator'];
 
 		if ( empty( $post_data['origin'] ) || empty( $post_data[ $post_data['origin'] ] ) ) {
-			wp_send_json_error( $data );
+			wp_send_json_error( $this->get_default_data() );
 		}
 
 		$data = $post_data[ $post_data['origin'] ];
@@ -160,6 +160,19 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 			'post_data' => $post_data,
 			'meta' => $meta,
 		);
+	}
+
+	/**
+	 * Return the default data with an error message.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The default data with an error message.
+	 */
+	protected function get_default_data(): array {
+		return [
+			'message' => __( 'There was a problem processing your import. Please try again.', 'the-events-calendar' ),
+		];
 	}
 
 	/**

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -73,7 +73,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		$post_data = $_POST['aggregator'];
 
 		if ( empty( $post_data['origin'] ) || empty( $post_data[ $post_data['origin'] ] ) ) {
-			wp_send_json_error( $this->get_default_data() );
+			wp_send_json_error( $this->get_failure_data() );
 		}
 
 		$data = $post_data[ $post_data['origin'] ];
@@ -163,7 +163,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	 *
 	 * @return array The default data with an error message.
 	 */
-	protected function get_default_data(): array {
+	protected function get_failure_data(): array {
 		return [
 			'message' => __( 'There was a problem processing your import. Please try again.', 'the-events-calendar' ),
 		];
@@ -180,7 +180,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	 */
 	protected function validate_nonce() {
 		if ( ! wp_verify_nonce( $_POST['tribe_aggregator_nonce'] ?? '', 'tribe-aggregator-save-import' ) ) {
-			wp_send_json_error( $this->get_default_data() );
+			wp_send_json_error( $this->get_failure_data() );
 		}
 	}
 

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -68,7 +68,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		}
 
 		// validate nonce
-		$this->validate_nonce();
+		$this->validate_nonce( 'tribe-aggregator-save-import' );
 
 		$post_data = $_POST['aggregator'];
 
@@ -176,10 +176,13 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	 *
 	 * @since TBD
 	 *
+	 * @param string $action    The action name to verify the nonce against.
+	 * @param string $nonce_var The name of the nonce variable in the request.
+	 *
 	 * @return void
 	 */
-	protected function validate_nonce() {
-		if ( ! wp_verify_nonce( $_POST['tribe_aggregator_nonce'] ?? '', 'tribe-aggregator-save-import' ) ) {
+	protected function validate_nonce( string $action, string $nonce_var = 'tribe_aggregator_nonce' ) {
+		if ( ! wp_verify_nonce( tec_get_request_var( $nonce_var, '' ), $action ) ) {
 			wp_send_json_error( $this->get_failure_data() );
 		}
 	}

--- a/src/Tribe/Aggregator/Tabs/Abstract.php
+++ b/src/Tribe/Aggregator/Tabs/Abstract.php
@@ -73,7 +73,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 		$post_data = $_POST['aggregator'];
 
 		if ( empty( $post_data['origin'] ) || empty( $post_data[ $post_data['origin'] ] ) ) {
-			wp_send_json_error( $this->get_failure_data() );
+			wp_send_json_error( $this->get_failure_data(), 400 );
 		}
 
 		$data = $post_data[ $post_data['origin'] ];
@@ -183,7 +183,7 @@ abstract class Tribe__Events__Aggregator__Tabs__Abstract extends Tribe__Tabbed_V
 	 */
 	protected function validate_nonce( string $action, string $nonce_var = 'tribe_aggregator_nonce' ) {
 		if ( ! wp_verify_nonce( tec_get_request_var( $nonce_var, '' ), $action ) ) {
-			wp_send_json_error( $this->get_failure_data() );
+			wp_send_json_error( $this->get_failure_data(), 400 );
 		}
 	}
 

--- a/src/Tribe/Aggregator/Tabs/Edit.php
+++ b/src/Tribe/Aggregator/Tabs/Edit.php
@@ -1,10 +1,10 @@
 <?php
 
-use TEC\Events\Traits\Edit_Events;
+use TEC\Events\Traits\Can_Edit_Events;
 
 class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__Tabs__Abstract {
 
-	use Edit_Events;
+	use Can_Edit_Events;
 
 	/**
 	 * Static Singleton Holder

--- a/src/Tribe/Aggregator/Tabs/Edit.php
+++ b/src/Tribe/Aggregator/Tabs/Edit.php
@@ -1,6 +1,11 @@
 <?php
 
+use TEC\Events\Traits\Edit_Events;
+
 class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__Tabs__Abstract {
+
+	use Edit_Events;
+
 	/**
 	 * Static Singleton Holder
 	 *
@@ -151,6 +156,18 @@ class Tribe__Events__Aggregator__Tabs__Edit extends Tribe__Events__Aggregator__T
 	 * Handles the previewing of a scheduled import edit
 	 */
 	public function ajax_preview_import() {
+		$this->validate_nonce( 'tribe-aggregator-save-import' );
+
+		if ( ! $this->current_user_can_edit_events() ) {
+			wp_send_json_error(
+				[
+					'message_code' => 'error:create-import-failed',
+					'message'      => __( 'You do not have permission to create an import.', 'the-events-calendar' ),
+				],
+				403
+			);
+		}
+
 		$result = $this->handle_submit();
 
 		if ( is_wp_error( $result ) ) {

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -1,11 +1,15 @@
 <?php
 // Don't load directly
 
+use TEC\Events\Traits\Edit_Events;
 use Tribe\Events\Admin\Settings;
 
 defined( 'WPINC' ) or die;
 
 class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Tabs__Abstract {
+
+	use Edit_Events;
+
 	/**
 	 * Static Singleton Holder
 	 *
@@ -449,6 +453,16 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 	public function ajax_create_import() {
 		$this->validate_nonce();
+
+		if ( ! $this->current_user_can_edit_events() ) {
+			wp_send_json_error(
+				[
+					'message_code' => 'error:create-import-failed',
+					'message'      => __( 'You do not have permission to create an import.', 'the-events-calendar' ),
+				],
+				403
+			);
+		}
 
 		$result = $this->handle_submit();
 

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -452,7 +452,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 	}
 
 	public function ajax_create_import() {
-		$this->validate_nonce();
+		$this->validate_nonce( 'tribe-aggregator-save-import' );
 
 		if ( ! $this->current_user_can_edit_events() ) {
 			wp_send_json_error(

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -1,14 +1,14 @@
 <?php
 // Don't load directly
 
-use TEC\Events\Traits\Edit_Events;
+use TEC\Events\Traits\Can_Edit_Events;
 use Tribe\Events\Admin\Settings;
 
 defined( 'WPINC' ) or die;
 
 class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Tabs__Abstract {
 
-	use Edit_Events;
+	use Can_Edit_Events;
 
 	/**
 	 * Static Singleton Holder

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -445,6 +445,8 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 	}
 
 	public function ajax_create_import() {
+		$this->validate_nonce();
+
 		$result = $this->handle_submit();
 
 		if ( is_wp_error( $result ) ) {

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -408,12 +408,24 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 	}
 
 	public function ajax_save_credentials() {
-		if ( empty( $_POST['tribe_credentials_which'] ) ) {
-			$data = array(
-				'message' => __( 'Invalid credential save request', 'the-events-calendar' ),
-			);
+		$this->validate_nonce( 'tribe-aggregator-ajax-nonce' );
 
-			wp_send_json_error( $data );
+		if ( ! $this->current_user_can_edit_events() ) {
+			wp_send_json_error(
+				[
+					'message_code' => 'error:save-credentials-failed',
+					'message'      => __( 'You do not have permission to save credentials.', 'the-events-calendar' ),
+				],
+				403
+			);
+		}
+
+		if ( empty( $_POST['tribe_credentials_which'] ) ) {
+			wp_send_json_error(
+				[
+					'message' => __( 'Invalid credential save request', 'the-events-calendar' ),
+				]
+			);
 		}
 
 		$which = $_POST['tribe_credentials_which'];
@@ -480,7 +492,19 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 	}
 
 	public function ajax_fetch_import() {
-		$import_id = $_GET['import_id'];
+		$this->validate_nonce( 'tribe-aggregator-ajax-nonce' );
+
+		if ( ! $this->current_user_can_edit_events() ) {
+			wp_send_json_error(
+				[
+					'message_code' => 'error:fetch-import-failed',
+					'message'      => __( 'You do not have permission to fetch an import.', 'the-events-calendar' ),
+				],
+				403
+			);
+		}
+
+		$import_id = tec_get_request_var( 'import_id', 0 );
 
 		$record = Tribe__Events__Aggregator__Records::instance()->get_by_import_id( $import_id );
 

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -84,14 +84,17 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 	}
 
 	public function handle_submit() {
+		// Set up the basic error object.
+		$base_error = new WP_Error( 'error:create-import-failed' );
+
 		if ( empty( $_POST['aggregator']['action'] ) || 'new' !== $_POST['aggregator']['action'] ) {
-			return;
+			return $base_error;
 		}
 
 		$submission = parent::handle_submit();
 
 		if ( empty( $submission['record'] ) || empty( $submission['post_data'] ) || empty( $submission['meta'] ) ) {
-			return;
+			return $base_error;
 		}
 
 		/** @var Tribe__Events__Aggregator__Record__Abstract $record */
@@ -104,7 +107,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 
 		if ( ! empty( $post_data['import_id'] ) ) {
 			$this->handle_import_finalize( $post_data );
-			return;
+			return true;
 		}
 
 		// Prevents Accidents

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -454,7 +454,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 			$service      = tribe( 'events-aggregator.service' );
 			$result       = (object) array(
 				'message_code' => $result->get_error_code(),
-				'message'      => $service->get_service_message( $result->get_error_code(), $result->get_error_data() ),
+				'message'      => $service->get_service_message( $result->get_error_code(), $result->get_error_data() ?? [] ),
 			);
 			wp_send_json_error( $result );
 		}

--- a/src/resources/js/aggregator-admin-legacy-settings.js
+++ b/src/resources/js/aggregator-admin-legacy-settings.js
@@ -24,7 +24,8 @@ var tribe_aggregator = tribe_aggregator || {};
 				dataType: 'json',
 				method: 'POST',
 				data: {
-					action: action
+					action: action,
+					tribe_aggregator_nonce: data.nonce,
 				},
 				success: function ( response, status ) { // eslint-disable-line no-unused-vars
 					if ( response.status ) {

--- a/src/resources/js/aggregator-fields.js
+++ b/src/resources/js/aggregator-fields.js
@@ -469,9 +469,15 @@ tribe_aggregator.fields = {
 	obj.poll_for_results = function() {
 		obj.result_fetch_count++;
 
+		const urlParts = [
+			'action=tribe_aggregator_fetch_import',
+			`import_id=${ obj.import_id }`,
+			`tribe_aggregator_nonce=${ ea.nonce }`
+		];
+
 		var jqxhr = $.ajax( {
 			type: 'GET',
-			url: ajaxurl + '?action=tribe_aggregator_fetch_import&import_id=' + obj.import_id,
+			url: `${ ajaxurl }?` + urlParts.join( '&' ),
 			dataType: 'json'
 		} );
 
@@ -806,6 +812,7 @@ tribe_aggregator.fields = {
 	 */
 	obj.save_credentials = function( $credentials_form ) {
 		var data = $credentials_form.find( '.tribe-fieldset' ).find( 'input' ).serialize();
+		data += `&tribe_aggregator_nonce=${ ea.nonce }`;
 
 		var url = ajaxurl + '?action=tribe_aggregator_save_credentials';
 


### PR DESCRIPTION
- **Create method for default data response**
- **Create method to validate the nonce**
- **Create a method to determine if we are previewing**
- **Use new is_previewing() method**
- **Add nonce validation early in Ajax request**
- **Create trait for editing events cap checks**
- **Add default array if there's no error data.**
- **Add return values to other submission condition checks**
- **Add a check for whether the current user can edit events**
- **Remove redundant $default_user_id variable**
- **Add the edit event capability check**
- **Use tec_get_request_var() instead of direct $_GET**
- **Rename method to get_failure_data()**
- **Add nonce to JS**
- **Add action and variable parameters to validate_nonce() method**
- **Add nonce and capability validation to other ajax actions**
- **Add nonce and capability checks to preview import**
- **Add nonce to the legacy migrate settings**
- **Convert user parameter to user_id**
- **Add 400 status to some failures**
- **Rename Edit_Events trait to Can_Edit_Events**
- **Use correct trait name in docblocks**

### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

[skip-changelog]

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
