### PR TITLE
Exclude bin/source-updater files from PHPCS

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -22,6 +22,7 @@
 		</properties>
 	</rule>
 
+	<exclude-pattern>*/bin/source-updater/*</exclude-pattern>
 	<exclude-pattern>*/common/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fix PHPCS errors for the `bin/source-updater/` directory by excluding that directory from PHPCS entirely.

[skip-changelog]

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
