### PR TITLE
Add missing Domain Path to the plugin file header.

### DIFF
--- a/changelog/fix-text-domain-path
+++ b/changelog/fix-text-domain-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add Domain Path to the pluigin header to ensure isntalled files get read. [TEC-5520]

--- a/the-events-calendar.php
+++ b/the-events-calendar.php
@@ -8,6 +8,7 @@
  * Author: The Events Calendar
  * Author URI: https://evnt.is/1x
  * Text Domain: the-events-calendar
+ * Domain Path: /lang
  * License: GPLv2 or later
  * Elementor tested up to: 3.23.1
  * Elementor Pro tested up to: 3.23.0


### PR DESCRIPTION
This allows WP JIT translations to find our files in the `plugins/lang` directory.



### 🎫 Ticket

[TEC-5520]

### 🗒️ Description

Languages without language packs (like Suomi/Finnish) don't have language packs. Those need to get the files in `plugin/lang` but the JIT language engine can't find them because it doesn't default to the `/lang` folder for some strange reason. 

### 🎥 Artifacts <!-- if applicable-->
<img width="1300" alt="Screenshot 2025-05-23 at 10 50 19 AM" src="https://github.com/user-attachments/assets/57e46a0e-d54b-47d6-8e58-c0842f100601" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5520]: https://stellarwp.atlassian.net/browse/TEC-5520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ