### PR TITLE
Update to properly use svg-inline in our build process

### DIFF
--- a/changelog/fix-build
+++ b/changelog/fix-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Utilize the newer version of our build process to ensure inline svgs are being handled properly. [TCMN-188]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "the-events-calendar",
-  "version": "6.11.1",
+  "version": "6.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-events-calendar",
-      "version": "6.11.1",
+      "version": "6.13.2",
       "dependencies": {
         "@babel/plugin-proposal-optional-chaining": "^7.21.0",
         "@babel/runtime": "^7.15.3",
@@ -4346,9 +4346,9 @@
       }
     },
     "node_modules/@stellarwp/tyson": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@stellarwp/tyson/-/tyson-0.0.6.tgz",
-      "integrity": "sha512-muzljJDuZalyGHR0lJliUPDIfiUvCS+Ch4Y8uO8xtP0TDIrltFXIt5itckILixHpQUlk8DLcScKzQTXMUPiJpg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@stellarwp/tyson/-/tyson-0.0.10.tgz",
+      "integrity": "sha512-ecYvPP++DwLU293HjzYVe4JEPQQcT6BoFP9K8JuFAmw+vmMDGSpMDV4lAydWWs5AxJJOcSZ2jarDyqQx+vF0WQ==",
       "dev": true,
       "dependencies": {
         "@types/webpack": "^5.28.5"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,12 @@ const customEntryPoints = compileCustomEntryPoints({
    * Handling this correctly requires adding a PostCSS processor specific to the PostCSS files that
    * will handle the nesting correctly.
    */
-  '/src/resources/postcss': createTECPostCss('tec.events'),
+  '/src/resources/postcss': createTECPostCss(
+    'tec.events',
+    [
+      'postcss-inline-svg',
+    ],
+  ),
 
   /**
    * This deals with existing Blocks frontend styles being compiled separately.


### PR DESCRIPTION
Ticket: [TCMN-188]

Requires: https://github.com/the-events-calendar/tribe-common/pull/2619

Before:
<img width="1591" alt="Screenshot 2025-06-04 at 10 39 43 AM" src="https://github.com/user-attachments/assets/9f9ba2ab-b188-46cb-baa6-2527d5c9f277" />

After:
<img width="1407" alt="Screenshot 2025-06-04 at 2 37 21 PM" src="https://github.com/user-attachments/assets/9308462f-463c-4c43-96d7-c01c669fb0d2" />

[TCMN-188]: https://stellarwp.atlassian.net/browse/TCMN-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ