### PR TITLE
Disabled Event Views should redirect to default view

### DIFF
--- a/changelog/fix-disabled-views-redirect
+++ b/changelog/fix-disabled-views-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disabled Event Views should redirect to default view [TEC-5427]

--- a/src/Tribe/Views/V2/Template_Bootstrap.php
+++ b/src/Tribe/Views/V2/Template_Bootstrap.php
@@ -443,6 +443,28 @@ class Template_Bootstrap {
 			return $this->get_v1_embed_template_path();
 		}
 
+		// Check if the current view is enabled.
+		$view_slug = $context->get( 'event_display' );
+		if ( ! empty( $view_slug ) && 'default' !== $view_slug ) {
+			$public_views = $this->manager->get_publicly_visible_views();
+
+			// If current view is not publicly visible, redirect to default.
+			if ( ! isset( $public_views[ $view_slug ] ) ) {
+				$default = tribe_events_get_url(
+					[
+						'eventDisplay'     => 'default',
+						'tribe_redirected' => 1,
+					]
+				);
+
+				add_filter( 'tribe_events_views_v2_redirected', '__return_true' );
+
+				// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect, StellarWP.CodeAnalysis.RedirectAndDie
+				wp_safe_redirect( $default, 301 );
+				tribe_exit();
+			}
+		}
+
 		return $this->get_template_object()->get_path();
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5427]

### 🗒️ Description

Disabling views at `At Events > Settings > Display > Calendar` tab would still allow accessing them at `/events/view/` . Solution is to redirect disabled views to the default.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
