### PR TITLE
(Classy) Fix currency position saving

### DIFF
--- a/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
+++ b/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
@@ -115,12 +115,12 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 
 		setEventCurrency( selectedCurrency.currency );
 		setCurrencySymbol( selectedCurrency.symbol );
-		setCurrencyPosition( selectedCurrency.position );
+		setCurrencyPosition( eventCurrencyPosition );
 		editPost( {
 			meta: {
 				[ METADATA_EVENT_CURRENCY ]: selectedCurrency.currency,
 				[ METADATA_EVENT_CURRENCY_SYMBOL ]: selectedCurrency.symbol,
-				[ METADATA_EVENT_CURRENCY_POSITION ]: selectedCurrency.position,
+				[ METADATA_EVENT_CURRENCY_POSITION ]: eventCurrencyPosition,
 			},
 		} );
 	};

--- a/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
+++ b/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
@@ -71,6 +71,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 	// todo: pull the default currency from the store using the settings.
 	const defaultCurrency: string = 'USD';
 	const defaultCurrencySymbol: string = '$';
+	const defaultCurrencyPosition: CurrencyPosition = 'before';
 
 	const eventCurrencyMeta: string = meta[ METADATA_EVENT_CURRENCY ] || defaultCurrency;
 	const [ eventCurrency, setEventCurrency ] = useState< string >( eventCurrencyMeta );
@@ -81,7 +82,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 	const eventCurrencyPosition: CurrencyPosition =
 		meta[ METADATA_EVENT_CURRENCY_POSITION ] ||
 		Currencies.find( ( currency ) => currency.currency === eventCurrency )?.position ||
-		'before';
+		defaultCurrencyPosition;
 	const [ currencyPosition, setCurrencyPosition ] = useState< CurrencyPosition >( eventCurrencyPosition );
 
 	useEffect( () => {
@@ -101,12 +102,12 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 		if ( ! selectedCurrency || nextValue === 'default' ) {
 			setEventCurrency( defaultCurrency );
 			setCurrencySymbol( defaultCurrencySymbol );
-			setCurrencyPosition( 'before' );
+			setCurrencyPosition( defaultCurrencyPosition );
 			editPost( {
 				meta: {
 					[ METADATA_EVENT_CURRENCY ]: defaultCurrency,
 					[ METADATA_EVENT_CURRENCY_SYMBOL ]: defaultCurrencySymbol,
-					[ METADATA_EVENT_CURRENCY_POSITION ]: 'before',
+					[ METADATA_EVENT_CURRENCY_POSITION ]: defaultCurrencyPosition,
 				},
 			} );
 			return;

--- a/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
+++ b/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
@@ -16,10 +16,12 @@ type CurrencySelectorProps = {
 	title?: string;
 };
 
+type CurrencyPosition = 'before' | 'after';
+
 type CurrencyProps = {
 	symbol: string;
 	currency: string;
-	position: 'before' | 'after';
+	position: CurrencyPosition;
 };
 
 // todo: Replace with API call to fetch available currencies.
@@ -76,11 +78,11 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 	const eventCurrencySymbolMeta: string = meta[ METADATA_EVENT_CURRENCY_SYMBOL ] || defaultCurrencySymbol;
 	const [ currencySymbol, setCurrencySymbol ] = useState< string >( eventCurrencySymbolMeta );
 
-	const eventCurrencyPosition: 'before' | 'after' =
+	const eventCurrencyPosition: CurrencyPosition =
 		meta[ METADATA_EVENT_CURRENCY_POSITION ] ||
 		Currencies.find( ( currency ) => currency.currency === eventCurrency )?.position ||
 		'before';
-	const [ currencyPosition, setCurrencyPosition ] = useState< 'before' | 'after' >( eventCurrencyPosition );
+	const [ currencyPosition, setCurrencyPosition ] = useState< CurrencyPosition >( eventCurrencyPosition );
 
 	useEffect( () => {
 		setEventCurrency( eventCurrencyMeta );

--- a/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
+++ b/src/resources/packages/classy/fields/EventCost/CurrencySelector.tsx
@@ -16,7 +16,7 @@ type CurrencySelectorProps = {
 	title?: string;
 };
 
-type CurrencyPosition = 'before' | 'after';
+type CurrencyPosition = 'prefix' | 'postfix';
 
 type CurrencyProps = {
 	symbol: string;
@@ -26,11 +26,11 @@ type CurrencyProps = {
 
 // todo: Replace with API call to fetch available currencies.
 const Currencies: CurrencyProps[] = [
-	{ symbol: '$', currency: 'USD', position: 'before' },
-	{ symbol: '€', currency: 'EUR', position: 'before' },
-	{ symbol: '£', currency: 'GBP', position: 'before' },
-	{ symbol: '¥', currency: 'JPY', position: 'before' },
-	{ symbol: '₹', currency: 'INR', position: 'before' },
+	{ symbol: '$', currency: 'USD', position: 'prefix' },
+	{ symbol: '€', currency: 'EUR', position: 'prefix' },
+	{ symbol: '£', currency: 'GBP', position: 'prefix' },
+	{ symbol: '¥', currency: 'JPY', position: 'prefix' },
+	{ symbol: '₹', currency: 'INR', position: 'prefix' },
 ];
 
 type CurrencySelectOption = {
@@ -71,7 +71,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 	// todo: pull the default currency from the store using the settings.
 	const defaultCurrency: string = 'USD';
 	const defaultCurrencySymbol: string = '$';
-	const defaultCurrencyPosition: CurrencyPosition = 'before';
+	const defaultCurrencyPosition: CurrencyPosition = 'prefix';
 
 	const eventCurrencyMeta: string = meta[ METADATA_EVENT_CURRENCY ] || defaultCurrency;
 	const [ eventCurrency, setEventCurrency ] = useState< string >( eventCurrencyMeta );
@@ -115,12 +115,10 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 
 		setEventCurrency( selectedCurrency.currency );
 		setCurrencySymbol( selectedCurrency.symbol );
-		setCurrencyPosition( eventCurrencyPosition );
 		editPost( {
 			meta: {
 				[ METADATA_EVENT_CURRENCY ]: selectedCurrency.currency,
 				[ METADATA_EVENT_CURRENCY_SYMBOL ]: selectedCurrency.symbol,
-				[ METADATA_EVENT_CURRENCY_POSITION ]: eventCurrencyPosition,
 			},
 		} );
 	};
@@ -130,7 +128,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 	}, [ eventCurrencySymbolMeta ] );
 
 	const onCurrencyPositionChange = ( nextValue: boolean ): void => {
-		const newPosition = nextValue ? 'before' : 'after';
+		const newPosition = nextValue ? 'prefix' : 'postfix';
 		setCurrencyPosition( newPosition );
 		editPost( { meta: { [ METADATA_EVENT_CURRENCY_POSITION ]: newPosition } } );
 	};
@@ -146,7 +144,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 			return '';
 		}
 
-		if ( currencyPosition === 'before' ) {
+		if ( currencyPosition === 'prefix' ) {
 			return `${ currencySymbol }${ eventCurrency }`;
 		}
 
@@ -206,7 +204,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ) {
 								'Event currency position toggle label',
 								'the-events-calendar'
 							) }
-							checked={ currencyPosition === 'before' }
+							checked={ currencyPosition === 'prefix' }
 							onChange={ onCurrencyPositionChange }
 						/>
 					</div>


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This fixes the Currency Position save/display for the Classy editor.

Notable changes:

* Add a `CurrencyPosition` type instead of hardcoding strings
* Update how the currency position is saved to ensure we save the actual set value rather than the default for the currency selected
* Use `prefix` and `postfix` for the settings instead of `before` and `after`.

### 🎥 Artifacts <!-- if applicable-->

**Before:**

The currency symbol always shows after the currency, regardless of the settings in the event.

<img width="821" alt="Screenshot 2025-06-05 at 17 54 05" src="https://github.com/user-attachments/assets/52c3954e-c6b7-4e6f-aa33-db27b092a33f" />

**After:**

The currency symbol is in the correct place based on the event settings.

<img width="821" alt="Screenshot 2025-06-05 at 17 53 03" src="https://github.com/user-attachments/assets/42d08605-5614-4a7b-9110-ebaafd73fc4c" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
