### PR TITLE
Remove ${CARET} from docblocks.

### DIFF
--- a/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
+++ b/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
@@ -3,7 +3,7 @@
  * An extension of the Events-only modifier to redirect Event queries to the custom tables
  * while rendering ACF fields.
  *
- * @since   6.0.11
+ * @since 6.0.11
  *
  * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
  */
@@ -18,13 +18,13 @@ use Tribe__Events__Main as TEC;
 /**
  * Class Query_Modifier.
  *
- * @since   6.0.11
+ * @since 6.0.11
  *
  * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
  */
 class Query_Modifier extends Events_Only_Modifier {
 	/**
-	 * ${CARET}
+	 * Whether this query modifier should handle the query or not.
 	 *
 	 * @since 6.0.11
 	 *

--- a/tests/views_integration/Tribe/Events/Views/V2/Repository/Event_Period_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Repository/Event_Period_Test.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * ${CARET}
+ * This class is used to test the Event_Period repository.
  *
- * @since   4.9.13
+ * @since 4.9.13
  *
  * @package Tribe\Events\Views\V2\Repository
  */


### PR DESCRIPTION
These are from someone's malformed docblock template - they need to go.

Requires: https://github.com/the-events-calendar/tribe-common/pull/2637