### PR TITLE
Avoid registering templates when theme provides them

### DIFF
--- a/src/Events/Block_Templates/Controller.php
+++ b/src/Events/Block_Templates/Controller.php
@@ -184,7 +184,7 @@ class Controller extends Controller_Contract {
 			return $query_result;
 		}
 		// Get our block template services for this query.
-		$template_services = $this->get_filtered_block_templates( $template_type );
+		$template_services = $this->get_filtered_block_templates( $template_type, $query_result );
 		foreach ( $template_services as $template ) {
 			if ( empty( $query['slug__in'] ) || in_array( $template->slug(), $query['slug__in'], true ) ) {
 				/**
@@ -231,14 +231,32 @@ class Controller extends Controller_Contract {
 	 * WP_Block_Template instances.
 	 *
 	 * @since 6.2.7
+	 * @since TBD Added $query_result parameter.
 	 *
-	 * @param string $template_type The type of templates we are fetching.
+	 * @param string              $template_type The type of templates we are fetching.
+	 * @param WP_Block_Template[] $query_result  The query result.
 	 *
 	 * @return Block_Template_Contract[] List of filtered Event Calendar templates.
 	 */
-	public function get_filtered_block_templates( $template_type = 'wp_template' ): array {
+	public function get_filtered_block_templates( $template_type = 'wp_template', $query_result = [] ): array {
 		$templates = [];
 		if ( $template_type === 'wp_template' ) {
+			$theme_has_single_event_template  = false;
+			$theme_has_archive_event_template = false;
+			foreach ( $query_result as $template ) {
+				if ( 'theme' !== $template->origin && 'theme' !== $template->source ) {
+					continue;
+				}
+
+				if ( 'single-event' === $template->slug ) {
+					$theme_has_single_event_template = true;
+				}
+
+				if ( 'archive-events' === $template->slug ) {
+					$theme_has_archive_event_template = true;
+				}
+			}
+
 			/**
 			 * Filter whether the event archive block template should be used.
 			 *
@@ -246,8 +264,7 @@ class Controller extends Controller_Contract {
 			 *
 			 * @param bool $allow_archive Whether the event archive block template should be used.
 			 */
-			$allow_archive = apply_filters( 'tec_events_allow_archive_block_template', true );
-
+			$allow_archive = apply_filters( 'tec_events_allow_archive_block_template', ! $theme_has_archive_event_template );
 			if ( $allow_archive ) {
 				$templates[] = tribe( Archive_Block_Template::class );
 			}
@@ -259,7 +276,7 @@ class Controller extends Controller_Contract {
 			 *
 			 * @param bool $allow_single Whether the single block template should be used.
 			 */
-			$allow_single = apply_filters( 'tec_events_allow_single_block_template', true );
+			$allow_single = apply_filters( 'tec_events_allow_single_block_template', ! $theme_has_single_event_template );
 			if ( $allow_single ) {
 				$templates[] = tribe( Single_Block_Template::class );
 			}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5525]

### 🗒️ Description

Prevents registering redundant single event and event archive block templates when the theme already provides them.

- Checks if the theme has `single-event` and `archive-events` templates.
- Respects the `tec_events_allow_archive_block_template` and `tec_events_allow_single_block_template` filters to allow override.

### 🎥 Artifacts <!-- if applicable-->

https://www.loom.com/share/ae7b2d4665844e99b868c188a8ea6c10

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.