### PR TITLE
classy/component integration testing

### DIFF
--- a/src/resources/packages/classy/store/selectors.ts
+++ b/src/resources/packages/classy/store/selectors.ts
@@ -1,11 +1,11 @@
-import { select } from '@wordpress/data';
-import { EventDateTimeDetails } from '../types/EventDateTimeDetails';
+import { select } from '@tec/common/classy/store';
 import { EventMeta } from '../types/EventMeta';
 import { Settings } from '@tec/common/classy/types/LocalizedData';
 import { getDate } from '@wordpress/date';
 import { METADATA_EVENT_ORGANIZER_ID, METADATA_EVENT_VENUE_ID } from '../constants';
 import { StoreState } from '../types/StoreState';
 import { TECSettings } from '../types/Settings';
+import { EventDateTimeDetails } from '../types/EventDateTimeDetails';
 
 /**
  * Retrieves the post meta from the editor.
@@ -15,7 +15,6 @@ import { TECSettings } from '../types/Settings';
  * @returns {EventMeta} The event meta or an empty object if not available.
  */
 export function getPostMeta(): EventMeta {
-	// @ts-ignore
 	return select( 'core/editor' )?.getEditedPostAttribute( 'meta' ) ?? {};
 }
 
@@ -27,7 +26,6 @@ export function getPostMeta(): EventMeta {
  * @returns {Settings} The settings or an empty object if not available.
  */
 export function getSettings(): Settings {
-	// @ts-ignore
 	return select( 'tec/classy' ).getSettings() ?? {};
 }
 

--- a/tests/classy_jest/fields/EventLocation.spec.tsx
+++ b/tests/classy_jest/fields/EventLocation.spec.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Provider as ClassyProvider } from '@tec/common/classy/components/Provider.tsx';
+// import { EventLocation } from '../../../src/resources/packages/classy/fields';
+
+// @todo the apiFetch will have to be mocked since this component makes requests to the backed to get Venues.
+// jest.mock('@wordpress/api-fetch');
+
+// @todo the store is already registered, but not correctly -- fix
+
+describe( 'EventLocation component', () => {
+	beforeEach( async () => {
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		jest.resetModules();
+	} );
+
+	it( 'renders correctly with default props', async () => {
+		const user = userEvent.setup();
+
+		// @todo after the above issues are fixed, re-enable this test.
+		// const { findByText } = render(
+		// 	<ClassyProvider>
+		// 		<EventLocation title="Event Location TEST"/>
+		// 	</ClassyProvider>
+		// );
+
+		const { container } = render(
+			<ClassyProvider>
+				<p>Hello from Event Location</p>
+			</ClassyProvider>
+		);
+	} );
+} );

--- a/tests/classy_jest/jest.config.js
+++ b/tests/classy_jest/jest.config.js
@@ -1,4 +1,5 @@
 const { defaults: tsjPreset } = require( 'ts-jest/presets' );
+const path = require( 'path' );
 
 module.exports = {
 	verbose: true,
@@ -28,6 +29,8 @@ module.exports = {
 	preset: 'ts-jest',
 	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'jsx' ],
 	snapshotSerializers: [ '@emotion/jest/serializer' ],
+	// Load modules only from TEC, override defaut resolution that could lead Comon loading from its own `nonode_modules`.
+	moduleDirectories: [ path.resolve( __dirname, '../../node_modules' ) ],
 	moduleNameMapper: {
 		'@tec/common/(.*)$': '<rootDir>/../../common/src/resources/packages/$1',
 		'@tec/common/classy/(.*)$': '<rootDir>/../../common/src/resources/packages/classy/$1',


### PR DESCRIPTION
Based on the [Common PR](https://github.com/the-events-calendar/tribe-common/pull/2640).

This PR is a first step toward use of the Classy application outside of the Block Editor context.

Following the refactoring of the Classy code in Common, being able to set up and run a simple test (see the `EventLocation.spec.tsx` file) using the `Provider` of the Classy application means being able to run code relying on the presence anc correct set up of the WordPress default store regsitry **outside** of the Block Editor (i.e. in the tests context for now).

The effort and logic used to make things work in tests brings with itself two benefits:
1. Simpler integration testing, where as little as possible (ideally only API requests) is mocked and components are tested with a fast and realistic usage approach.
2. Preparation and discover for the use of the Classy application outside of the Block Editor context.

