### PR TITLE
classy/fix date time tz handling

### DIFF
--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -219,11 +219,15 @@ export default function EventDateTime( props: FieldProps ) {
 
 				// Add the start date, end date and timezone information to the payload sent to the backend.
 				edits.meta = edits?.meta || {};
-				edits.meta[ METADATA_EVENT_START_DATE ] =
-					edits[ METADATA_EVENT_START_DATE ] || format( phpDateMysqlFormat, eventStart );
-				edits.meta[ METADATA_EVENT_END_DATE ] =
-					edits[ METADATA_EVENT_END_DATE ] || format( phpDateMysqlFormat, eventEnd );
-				edits.meta[ METADATA_EVENT_TIMEZONE ] = edits[ METADATA_EVENT_TIMEZONE ] || eventTimezone;
+				if ( ! edits.meta[ METADATA_EVENT_START_DATE ] ) {
+					edits[ METADATA_EVENT_START_DATE ] = format( phpDateMysqlFormat, eventStart );
+				}
+				if ( ! edits.meta[ METADATA_EVENT_END_DATE ] ) {
+					edits[ METADATA_EVENT_END_DATE ] = format( phpDateMysqlFormat, eventEnd );
+				}
+				if ( ! edits.meta[ METADATA_EVENT_TIMEZONE ] ) {
+					edits.meta[ METADATA_EVENT_TIMEZONE ] = eventTimezone;
+				}
 
 				return edits;
 			};

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -212,9 +212,9 @@ export default function EventDateTime( props: FieldProps ) {
 
 				// Add the start date, end date and timezone information to the payload sent to the backend.
 				edits.meta = edits?.meta || {};
-				edits.meta[ METADATA_EVENT_START_DATE ] = format( phpDateMysqlFormat, eventStart );
-				edits.meta[ METADATA_EVENT_END_DATE ] = format( phpDateMysqlFormat, eventEnd );
-				edits.meta[ METADATA_EVENT_TIMEZONE ] = eventTimezone;
+				edits.meta[ METADATA_EVENT_START_DATE ] = edits[METADATA_EVENT_START_DATE] || format( phpDateMysqlFormat, eventStart );
+				edits.meta[ METADATA_EVENT_END_DATE ] = edits[METADATA_EVENT_END_DATE] || format( phpDateMysqlFormat, eventEnd );
+				edits.meta[ METADATA_EVENT_TIMEZONE ] = edits[METADATA_EVENT_TIMEZONE] || eventTimezone;
 
 				return edits;
 			};

--- a/src/resources/packages/classy/store/selectors.ts
+++ b/src/resources/packages/classy/store/selectors.ts
@@ -43,20 +43,21 @@ export function getEventDateTimeDetails(): EventDateTimeDetails {
 
 	const eventStartDateString = meta?._EventStartDate ?? '';
 	const eventEndDateString = meta?._EventEndDate ?? '';
+	const eventTimezone = meta?._EventTimezone || settings.timezoneString;
 
 	let eventStart: Date;
 	if ( eventStartDateString ) {
-		eventStart = getDate( eventStartDateString );
+		eventStart = new Date(eventStartDateString);
 	} else {
-		eventStart = getDate( '' );
+		eventStart = new Date();
 		eventStart.setHours( 8, 0, 0 );
 	}
 
 	let eventEnd: Date;
 	if ( eventEndDateString ) {
-		eventEnd = getDate( eventEndDateString );
+		eventEnd = new Date(eventEndDateString);
 	} else {
-		eventEnd = getDate( '' );
+		eventEnd = new Date();
 		eventEnd.setHours( 17, 0, 0 );
 	}
 	const isMultiday =
@@ -65,7 +66,6 @@ export function getEventDateTimeDetails(): EventDateTimeDetails {
 		eventStart.getFullYear() !== eventEnd.getFullYear();
 	const isAllDayStringValue = meta?._EventAllDay ?? '0';
 	const isAllDay = isAllDayStringValue === '1';
-	const eventTimezone = meta?._EventTimezone || settings.timezoneString;
 
 	return {
 		eventStart: eventStart.toISOString(),

--- a/src/resources/packages/classy/store/selectors.ts
+++ b/src/resources/packages/classy/store/selectors.ts
@@ -47,7 +47,7 @@ export function getEventDateTimeDetails(): EventDateTimeDetails {
 
 	let eventStart: Date;
 	if ( eventStartDateString ) {
-		eventStart = new Date(eventStartDateString);
+		eventStart = new Date( eventStartDateString );
 	} else {
 		eventStart = new Date();
 		eventStart.setHours( 8, 0, 0 );
@@ -55,7 +55,7 @@ export function getEventDateTimeDetails(): EventDateTimeDetails {
 
 	let eventEnd: Date;
 	if ( eventEndDateString ) {
-		eventEnd = new Date(eventEndDateString);
+		eventEnd = new Date( eventEndDateString );
 	} else {
 		eventEnd = new Date();
 		eventEnd.setHours( 17, 0, 0 );


### PR DESCRIPTION
The main change of this PR is replacing usages of the `getDate` function from the `@wordpress/date` package with calls to the `new Date( ... )` object.

The `getDate` function will build and return a `Date` object following this process:
* build the date on the string with the UTC timezone (`Z`)
* **then** apply the current WP timezone to it effectively moving the time (and possibly day)

In the UI the dates should not carry timezone information around, they should only move around date information using `Date` objects for the purpose of displaying it.

Together with this, the PR fixes another issue where saving a new Event before it's auto-saved would not save the event start / end dates.

[Demo](https://share.cleanshot.com/4gdrv7Lp)
