### PR TITLE
Category Colors - Legend Superpowers logic

### DIFF
--- a/src/resources/js/views/category-color-selector.js
+++ b/src/resources/js/views/category-color-selector.js
@@ -210,10 +210,10 @@ tribe.events.categoryColors.categoryPicker = ( function() {
 
 			// Get the first 5 checkboxes from the dropdown
 			const labels = qsa(SELECTORS.dropdownLabel);
-			const firstFiveCheckboxes = Array.from(labels).slice(0, DEFAULT_BUBBLE_COUNT);
+			const firstFiveLabels = Array.from(labels).slice(0, DEFAULT_BUBBLE_COUNT);
 
 			// Render category bubbles from labels.
-			firstFiveCheckboxes.forEach(checkbox => {
+			firstFiveLabels.forEach(checkbox => {
 				const categorySlug = checkbox.dataset.category;
 				if (categorySlug) {
 					const span = document.createElement('span');

--- a/src/resources/js/views/category-color-selector.js
+++ b/src/resources/js/views/category-color-selector.js
@@ -23,6 +23,7 @@ tribe.events.categoryColors.categoryPicker = ( function() {
 	const SELECTORS = {
 		picker: '.tec-events-category-color-filter',
 		dropdown: '.tec-events-category-color-filter__dropdown',
+		dropdownLabel: '.tec-events-category-color-filter__dropdown-item label',
 		checkbox: '.tec-events-category-color-filter__checkbox',
 		dropdownIcon: '.tec-events-category-color-filter__dropdown-icon',
 		dropdownVisible: 'tec-events-category-color-filter__dropdown--visible',
@@ -208,10 +209,10 @@ tribe.events.categoryColors.categoryPicker = ( function() {
 		} else {
 
 			// Get the first 5 checkboxes from the dropdown
-			const checkboxes = qsa(SELECTORS.checkbox);
-			const firstFiveCheckboxes = Array.from(checkboxes).slice(0, DEFAULT_BUBBLE_COUNT);
+			const labels = qsa(SELECTORS.dropdownLabel);
+			const firstFiveCheckboxes = Array.from(labels).slice(0, DEFAULT_BUBBLE_COUNT);
 
-			// Render category bubbles from checkboxes
+			// Render category bubbles from labels.
 			firstFiveCheckboxes.forEach(checkbox => {
 				const categorySlug = checkbox.dataset.category;
 				if (categorySlug) {

--- a/src/views/v2/components/top-bar/category-color-picker.php
+++ b/src/views/v2/components/top-bar/category-color-picker.php
@@ -53,11 +53,10 @@ $category_slug = Tribe__Events__Main::instance()->get_category_slug();
 		<ul class="tec-events-category-color-filter__dropdown-list">
 			<?php foreach ( $category_colors_category_dropdown as $category ) : ?>
 				<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="<?php echo esc_attr( $category['slug'] ); ?>" >
 						<?php if ( $category_colors_super_power ) : ?>
 							<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="<?php echo esc_attr( $category['slug'] ); ?>"
 								aria-label="
 								<?php
 								echo /* translators: %s is the category name. */

--- a/src/views/v2/components/top-bar/category-color-picker.php
+++ b/src/views/v2/components/top-bar/category-color-picker.php
@@ -47,7 +47,7 @@ $category_slug = Tribe__Events__Main::instance()->get_category_slug();
 	</span>
 	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="<?php esc_attr_e( 'Category selection', 'the-events-calendar' ); ?>">
 		<div class="tec-events-category-color-filter__dropdown-header">
-			<span><?php esc_html_e( 'Highlight a category', 'the-events-calendar' ); ?></span>
+			<span><?php echo $category_colors_super_power ? esc_html__( 'Highlight a category', 'the-events-calendar' ) : esc_html__( 'Browse by category', 'the-events-calendar' ); ?></span>
 			<button class="tec-events-category-color-filter__dropdown-close" aria-label="<?php esc_attr_e( 'Close category selection', 'the-events-calendar' ); ?>">✕</button>
 		</div>
 		<ul class="tec-events-category-color-filter__dropdown-list">

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/Category_Color_PickerTest.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/Category_Color_PickerTest.php
@@ -22,9 +22,9 @@ class Category_Color_PickerTest extends HtmlPartialTestCase {
 	}
 
 	/**
-	 * Test render with category colors enabled in Month view
+	 * Test render with category colors enabled in Month view with superpowers enabled
 	 */
-	public function test_render_with_category_colors_enabled_month_view() {
+	public function test_render_with_category_colors_enabled_month_view_superpowers_enabled() {
 		$this->assertMatchesSnapshot( $this->get_partial_html( [
 			'category_colors_enabled'           => true,
 			'category_colors_category_dropdown' => [
@@ -49,9 +49,36 @@ class Category_Color_PickerTest extends HtmlPartialTestCase {
 	}
 
 	/**
-	 * Test render with category colors enabled in List view
+	 * Test render with category colors enabled in Month view with superpowers disabled
 	 */
-	public function test_render_with_category_colors_enabled_list_view() {
+	public function test_render_with_category_colors_enabled_month_view_superpowers_disabled() {
+		$this->assertMatchesSnapshot( $this->get_partial_html( [
+			'category_colors_enabled'           => true,
+			'category_colors_category_dropdown' => [
+				[
+					'slug'     => 'test-category-1',
+					'name'     => 'Test Category 1',
+					'priority' => 1,
+					'primary'  => '#ff0000',
+					'hidden'   => false,
+				],
+				[
+					'slug'     => 'test-category-2',
+					'name'     => 'Test Category 2',
+					'priority' => 2,
+					'primary'  => '#00ff00',
+					'hidden'   => false,
+				],
+			],
+			'category_colors_super_power'       => false,
+			'category_colors_show_reset_button' => false,
+		] ) );
+	}
+
+	/**
+	 * Test render with category colors enabled in List view with superpowers enabled
+	 */
+	public function test_render_with_category_colors_enabled_list_view_superpowers_enabled() {
 		$this->assertMatchesSnapshot( $this->get_partial_html( [
 			'category_colors_enabled'           => true,
 			'category_colors_category_dropdown' => [
@@ -76,9 +103,36 @@ class Category_Color_PickerTest extends HtmlPartialTestCase {
 	}
 
 	/**
-	 * Test render with category colors enabled in Day view
+	 * Test render with category colors enabled in List view with superpowers disabled
 	 */
-	public function test_render_with_category_colors_enabled_day_view() {
+	public function test_render_with_category_colors_enabled_list_view_superpowers_disabled() {
+		$this->assertMatchesSnapshot( $this->get_partial_html( [
+			'category_colors_enabled'           => true,
+			'category_colors_category_dropdown' => [
+				[
+					'slug'     => 'test-category-1',
+					'name'     => 'Test Category 1',
+					'priority' => 1,
+					'primary'  => '#ff0000',
+					'hidden'   => false,
+				],
+				[
+					'slug'     => 'test-category-2',
+					'name'     => 'Test Category 2',
+					'priority' => 2,
+					'primary'  => '#00ff00',
+					'hidden'   => false,
+				],
+			],
+			'category_colors_super_power'       => false,
+			'category_colors_show_reset_button' => false,
+		] ) );
+	}
+
+	/**
+	 * Test render with category colors enabled in Day view with superpowers enabled
+	 */
+	public function test_render_with_category_colors_enabled_day_view_superpowers_enabled() {
 		$this->assertMatchesSnapshot( $this->get_partial_html( [
 			'category_colors_enabled'           => true,
 			'category_colors_category_dropdown' => [
@@ -99,6 +153,33 @@ class Category_Color_PickerTest extends HtmlPartialTestCase {
 			],
 			'category_colors_super_power'       => true,
 			'category_colors_show_reset_button' => true,
+		] ) );
+	}
+
+	/**
+	 * Test render with category colors enabled in Day view with superpowers disabled
+	 */
+	public function test_render_with_category_colors_enabled_day_view_superpowers_disabled() {
+		$this->assertMatchesSnapshot( $this->get_partial_html( [
+			'category_colors_enabled'           => true,
+			'category_colors_category_dropdown' => [
+				[
+					'slug'     => 'test-category-1',
+					'name'     => 'Test Category 1',
+					'priority' => 1,
+					'primary'  => '#ff0000',
+					'hidden'   => false,
+				],
+				[
+					'slug'     => 'test-category-2',
+					'name'     => 'Test Category 2',
+					'priority' => 2,
+					'primary'  => '#00ff00',
+					'hidden'   => false,
+				],
+			],
+			'category_colors_super_power'       => false,
+			'category_colors_show_reset_button' => false,
 		] ) );
 	}
 

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view__1.php
@@ -17,10 +17,9 @@
 		</div>
 		<ul class="tec-events-category-color-filter__dropdown-list">
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-1" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-1"
 								aria-label="
 								Highlight events in Test Category 1">
 							<span class="tec-events-category-color-filter__label">Test Category 1</span>
@@ -29,10 +28,9 @@
 					</label>
 				</li>
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-2" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-2"
 								aria-label="
 								Highlight events in Test Category 2">
 							<span class="tec-events-category-color-filter__label">Test Category 2</span>

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view_superpowers_disabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view_superpowers_disabled__1.php
@@ -1,0 +1,41 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Browse by category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+																				<a href="http://test.tri.be/events/category/test-category-1/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-1" 								aria-label="View events in Test Category 1">
+								Test Category 1							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+																				<a href="http://test.tri.be/events/category/test-category-2/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-2" 								aria-label="View events in Test Category 2">
+								Test Category 2							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+			</div>
+</div>
+';

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view_superpowers_enabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_day_view_superpowers_enabled__1.php
@@ -1,0 +1,50 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Highlight a category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 1">
+							<span class="tec-events-category-color-filter__label">Test Category 1</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 2">
+							<span class="tec-events-category-color-filter__label">Test Category 2</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+					<div class="tec-events-category-color-filter__reset-wrapper">
+				<button type="button" class="tec-events-category-color-filter__reset tribe-common-c-btn-border-small"
+					aria-label="Reset category selection">
+					Reset				</button>
+			</div>
+			</div>
+</div>
+';

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view__1.php
@@ -17,10 +17,9 @@
 		</div>
 		<ul class="tec-events-category-color-filter__dropdown-list">
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-1" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-1"
 								aria-label="
 								Highlight events in Test Category 1">
 							<span class="tec-events-category-color-filter__label">Test Category 1</span>
@@ -29,10 +28,9 @@
 					</label>
 				</li>
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-2" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-2"
 								aria-label="
 								Highlight events in Test Category 2">
 							<span class="tec-events-category-color-filter__label">Test Category 2</span>

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view_superpowers_disabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view_superpowers_disabled__1.php
@@ -1,0 +1,41 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Browse by category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+																				<a href="http://test.tri.be/events/category/test-category-1/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-1" 								aria-label="View events in Test Category 1">
+								Test Category 1							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+																				<a href="http://test.tri.be/events/category/test-category-2/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-2" 								aria-label="View events in Test Category 2">
+								Test Category 2							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+			</div>
+</div>
+';

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view_superpowers_enabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_list_view_superpowers_enabled__1.php
@@ -1,0 +1,50 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Highlight a category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 1">
+							<span class="tec-events-category-color-filter__label">Test Category 1</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 2">
+							<span class="tec-events-category-color-filter__label">Test Category 2</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+					<div class="tec-events-category-color-filter__reset-wrapper">
+				<button type="button" class="tec-events-category-color-filter__reset tribe-common-c-btn-border-small"
+					aria-label="Reset category selection">
+					Reset				</button>
+			</div>
+			</div>
+</div>
+';

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view__1.php
@@ -17,10 +17,9 @@
 		</div>
 		<ul class="tec-events-category-color-filter__dropdown-list">
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-1" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-1"
 								aria-label="
 								Highlight events in Test Category 1">
 							<span class="tec-events-category-color-filter__label">Test Category 1</span>
@@ -29,10 +28,9 @@
 					</label>
 				</li>
 							<li class="tec-events-category-color-filter__dropdown-item" role="option">
-					<label>
+					<label data-category="test-category-2" >
 													<input type="checkbox"
 								class="tec-events-category-color-filter__checkbox"
-								data-category="test-category-2"
 								aria-label="
 								Highlight events in Test Category 2">
 							<span class="tec-events-category-color-filter__label">Test Category 2</span>

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view_superpowers_disabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view_superpowers_disabled__1.php
@@ -1,0 +1,41 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Browse by category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+																				<a href="http://test.tri.be/events/category/test-category-1/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-1" 								aria-label="View events in Test Category 1">
+								Test Category 1							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+																				<a href="http://test.tri.be/events/category/test-category-2/"
+								 class="tec-events-category-color-filter__label tec-events-category-color-filter__color-circle tribe_events_cat-test-category-2" 								aria-label="View events in Test Category 2">
+								Test Category 2							</a>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+			</div>
+</div>
+';

--- a/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view_superpowers_enabled__1.php
+++ b/tests/integration_category_colors/Frontend/Views/V2/Partials/Components/__snapshots__/Category_Color_PickerTest__test_render_with_category_colors_enabled_month_view_superpowers_enabled__1.php
@@ -1,0 +1,50 @@
+<?php return '<div class="tec-events-category-color-filter"
+	role="button"
+	tabindex="0"
+	aria-haspopup="listbox"
+	aria-expanded="false"
+	aria-label="Select categories to highlight">
+
+	<div class="tec-events-category-color-filter__colors" id="tec-category-color-legend"></div>
+
+	<span class="tec-events-category-color-filter__dropdown-icon">
+		<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--caret-down tec-events-category-color-filter__dropdown-icon-svg"  viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.008.609L5 4.6 8.992.61l.958.958L5 6.517.05 1.566l.958-.958z" class="tribe-common-c-svgicon__svg-fill"/></svg>
+	</span>
+	<div class="tec-events-category-color-filter__dropdown" role="listbox" aria-label="Category selection">
+		<div class="tec-events-category-color-filter__dropdown-header">
+			<span>Highlight a category</span>
+			<button class="tec-events-category-color-filter__dropdown-close" aria-label="Close category selection">✕</button>
+		</div>
+		<ul class="tec-events-category-color-filter__dropdown-list">
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-1" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 1">
+							<span class="tec-events-category-color-filter__label">Test Category 1</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-1" 						></span>
+					</label>
+				</li>
+							<li class="tec-events-category-color-filter__dropdown-item" role="option">
+					<label data-category="test-category-2" >
+													<input type="checkbox"
+								class="tec-events-category-color-filter__checkbox"
+								aria-label="
+								Highlight events in Test Category 2">
+							<span class="tec-events-category-color-filter__label">Test Category 2</span>
+												<span
+							 class="tec-events-category-color-filter__color-dot tribe_events_cat-test-category-2" 						></span>
+					</label>
+				</li>
+					</ul>
+
+					<div class="tec-events-category-color-filter__reset-wrapper">
+				<button type="button" class="tec-events-category-color-filter__reset tribe-common-c-btn-border-small"
+					aria-label="Reset category selection">
+					Reset				</button>
+			</div>
+			</div>
+</div>
+';


### PR DESCRIPTION
### 🎫 Ticket

<!-- Ticket ID, if there's any put it between brackets -->

DQA - 
- 52 - When superpowers are disabled the category colors legend isn't populated.
- 53 - When superpowers are disabled the label for the dropdown doesn't make sense.

### 🗒️ Description

To fix this issue I moved the data-category attribute to the label since that is always rendered. I updated the JS accordingly.

For the label, when the superpowers are disabled we show different text.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
![image](https://github.com/user-attachments/assets/04843982-13e0-4a4d-9955-90e23a054868)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
