### PR TITLE
Category Color - Fix Month View Regression

### DIFF
--- a/src/resources/js/views/category-color-selector.js
+++ b/src/resources/js/views/category-color-selector.js
@@ -43,7 +43,7 @@ tribe.events.categoryColors.categoryPicker = ( function () {
 			},
 			{
 				child: '.tribe-events-calendar-month__calendar-event',
-				parent: '.tribe-events-calendar-month__calendar-event-wrapper',
+				parent: '.tribe-events-calendar-month__calendar-event',
 			},
 			{
 				child: '.tribe-events-pro-summary__event',
@@ -374,16 +374,21 @@ tribe.events.categoryColors.categoryPicker = ( function () {
 	 */
 	const updateEventVisibility = () => {
 		const selectedArray = [ ...selectedCategories ];
+		console.log("Selected ARray",selectedArray);
 
 		getEventParentElements().forEach( ( eventContainer ) => {
 			let categoryElement = eventContainer;
+			console.log("Category Element",categoryElement);
 
 			// If the parent doesn't have a category class, check children
 			if ( ! [ ...categoryElement.classList ].some( ( cls ) => cls.startsWith( 'tribe_events_cat-' ) ) ) {
 				categoryElement = eventContainer.querySelector( '[class*="tribe_events_cat-"]' );
 			}
 
+			console.log("Category Element",categoryElement);
+
 			const hasMatch = categoryElement ? eventHasMatchingCategory( categoryElement, selectedArray ) : false;
+			console.log("Has MAtch",hasMatch);
 
 			eventContainer.classList.toggle( SELECTORS.filteredHide, selectedArray.length > 0 && ! hasMatch );
 		} );


### PR DESCRIPTION

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

There was a small regression for the Month View. When an event was single day the category color filter wasn't working properly because the wrong parent class was being used.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://github.com/user-attachments/assets/81a457b2-fd9e-4957-b089-550f222e8431


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
