### PR TITLE
!DO NOT MERGE! - test slic 1.10.0

### DIFF
--- a/.github/workflows/tests-integrations.yml
+++ b/.github/workflows/tests-integrations.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
-          ref: main
+          ref: 1.10.0
           path: slic
           fetch-depth: 1
       # ------------------------------------------------------------------------------

--- a/.github/workflows/tests-php-seo-plugin.yml
+++ b/.github/workflows/tests-php-seo-plugin.yml
@@ -46,7 +46,7 @@ jobs:
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
-          ref: main
+          ref: 1.10.0
           path: slic
           fetch-depth: 1
       # ------------------------------------------------------------------------------

--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
-          ref: main
+          ref: 1.10.0
           path: slic
           fetch-depth: 1
       # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR purpose is to test the plugin build using `slic` version `1.10.0` that introduced the use of MySQL `5.5.5` for builds on PHP `7.4`.

[Related slic PR](https://github.com/stellarwp/slic/pull/218)