### PR TITLE
Only shows category colors when in use

### DIFF
--- a/src/Events/Category_Colors/Controller.php
+++ b/src/Events/Category_Colors/Controller.php
@@ -19,6 +19,7 @@ use TEC\Events\Category_Colors\Repositories\Category_Color_Dropdown_Provider;
 use TEC\Events\Category_Colors\Repositories\Category_Color_Priority_Category_Provider;
 use TEC\Events\Category_Colors\Settings\Settings;
 use TEC\Events\Category_Colors\Migration\Controller as Migration_Controller;
+use TEC\Events\Category_Colors\CSS\Generator;
 use Tribe\Events\Views\V2\View;
 use Tribe__Events__Main;
 
@@ -193,6 +194,17 @@ class Controller extends Controller_Contract {
 		 *
 		 * @param bool $show_frontend_ui Whether the frontend UI should be displayed.
 		 */
-		return (bool) apply_filters( 'tec_events_category_colors_show_frontend_ui', true );
+		return (bool) apply_filters( 'tec_events_category_colors_show_frontend_ui', $this->is_in_use() );
+	}
+
+	/**
+	 * Checks if the Category Colors feature is in use.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True if the Category Colors feature is in use, false otherwise.
+	 */
+	public function is_in_use(): bool {
+		return (bool) get_option( $this->container->get( Generator::class )->get_option_key(), '' );
 	}
 }

--- a/src/Events/Category_Colors/Event_Category_Meta.php
+++ b/src/Events/Category_Colors/Event_Category_Meta.php
@@ -142,7 +142,7 @@ class Event_Category_Meta {
 			$all_meta = get_term_meta( $this->term_id );
 
 			foreach ( $all_meta as $meta_key => &$value ) {
-				$value = $this->normalize_meta( $meta_key, $value );
+				$value = $this->normalize_meta( $value );
 			}
 
 			return $all_meta;
@@ -151,7 +151,7 @@ class Event_Category_Meta {
 		$key = $this->sanitize_and_validate_key( $key );
 
 		return metadata_exists( 'term', $this->term_id, $key )
-			? $this->normalize_meta( $key, get_term_meta( $this->term_id, $key, true ) )
+			? $this->normalize_meta( get_term_meta( $this->term_id, $key, true ) )
 			: '';
 	}
 
@@ -243,12 +243,11 @@ class Event_Category_Meta {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $key   The meta key.
-	 * @param mixed  $value The raw value retrieved from get_term_meta().
+	 * @param mixed $value The raw value retrieved from get_term_meta().
 	 *
 	 * @return mixed The normalized meta value.
 	 */
-	protected function normalize_meta( string $key, $value ) {
+	protected function normalize_meta( $value ) {
 		if ( null === $value ) {
 			return '';
 		}


### PR DESCRIPTION
### 🗒️ Description

- Ensures category colors are only displayed if the feature is actively being used.
- Introduces an `is_in_use` method to determine feature usage based on a stored option.
- Modifies the `show_frontend_ui` filter to depend on the `is_in_use` method's return value.
- Simplifies meta retrieval by directly normalizing the value instead of passing the key.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.