### PR TITLE
Prevents redirect on non-events archive pages

### DIFF
--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -322,6 +322,10 @@ class Hooks extends Service_Provider {
 	public function disabled_views_redirect() {
 		$context = tribe_context();
 
+		if ( ! ( $context->get( 'event_post_type' ) && is_archive( TEC::POSTTYPE ) ) ) {
+			return;
+		}
+
 		$view_slug = $context->get( 'event_display' );
 		if ( ! empty( $view_slug ) && 'default' !== $view_slug ) {
 			$public_views = $this->container->make( Manager::class )->get_publicly_visible_views();
@@ -337,7 +341,7 @@ class Hooks extends Service_Provider {
 				add_filter( 'tribe_events_views_v2_redirected', '__return_true' );
 
 				// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect, StellarWP.CodeAnalysis.RedirectAndDie
-				wp_safe_redirect( $default, 301 );
+				wp_safe_redirect( $default );
 				tribe_exit();
 			}
 		}


### PR DESCRIPTION
### 🗒️ Description

- Prevents unintended redirects from non-event archive pages when a specific view is selected.
- Checks if the current page is an event post type archive before attempting to redirect.
- Removes unnecessary 301 redirect code

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.