### PR TITLE
TECTRIA-709 Dont trash Series on maintenance

### DIFF
--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -3,7 +3,7 @@ name: Check changelog
 on:
   pull_request:
     branches:
-      - master
+      - main
       - 'release/**'
     paths-ignore:
       - '.github/**'

--- a/.github/workflows/release-merge-forward.yml
+++ b/.github/workflows/release-merge-forward.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       forward-branch:
-        description: 'Name of the branch to merge into (e.g. release/T25.adamwarlock, master)'
+        description: 'Name of the branch to merge into (e.g. release/T25.adamwarlock, main)'
         default: release/T25.name
         required: true
 

--- a/.github/workflows/tests-integrations.yml
+++ b/.github/workflows/tests-integrations.yml
@@ -104,9 +104,9 @@ jobs:
       - name: Set TEC with base branch
         if: steps.skip.outputs.value != 1 && steps.fetch-tec-head-branch.outcome != 'success' && steps.fetch-tec-base-branch.outcome == 'success'
         run: echo "TEC_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
-      - name: Set TEC with master branch
+      - name: Set TEC with main branch
         if: steps.skip.outputs.value != 1 && steps.fetch-tec-head-branch.outcome != 'success' && steps.fetch-tec-base-branch.outcome != 'success'
-        run: echo "TEC_BRANCH=master" >> $GITHUB_ENV
+        run: echo "TEC_BRANCH=main" >> $GITHUB_ENV
       # ------------------------------------------------------------------------------
       # Clone and init TEC
       # ------------------------------------------------------------------------------

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -12,7 +12,7 @@ on:
         required: false
       ref:
         description: 'Git Commit Ref (branch, tag, or hash)'
-        default: 'master'
+        default: 'main'
         required: true
         type: string
       production:

--- a/bin/check-changelog.sh
+++ b/bin/check-changelog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-BASE=${1-origin/master}
+BASE=${1-origin/main}
 HEAD=${2-HEAD}
 
 # Get only added files from git diff.

--- a/changelog/fix-TECTRIA-709-dont-trash-series-on-maintenance
+++ b/changelog/fix-TECTRIA-709-dont-trash-series-on-maintenance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that the Series post status is not changed during maintenance. [TECTRIA-709]

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ We do have some guidelines that you should keep in mind while working with this 
 
 3. **We do not accept or handle support issues or bug reports here.** You may notice that we have disabled the Issues tab on this GitHub project. Please submit bug reports at [WordPress.org](http://wordpress.org/support/plugin/the-events-calendar). If you have purchased any of our premium add-ons, you may create an account and submit support requests at our [Premium Support Forums](http://evnt.is/kj).
 
-4. **Please fork `master` and submit your pull requests against that branch.** This is the branch with the latest code we are working on. Pull requests will be re-targeted against the branch for the next appropriate release before merged.
+4. **Please fork `main` and submit your pull requests against that branch.** This is the branch with the latest code we are working on. Pull requests will be re-targeted against the branch for the next appropriate release before merged.
 
 5. **When developing apply `define('SCRIPT_DEBUG', true)` in your wp-config.php**. This will load unminified versions of our js assets and give you some debugging information in your dev console.
 
@@ -27,7 +27,7 @@ That's all! please have fun and code responsibly :)
 ## Further Information
 
 * **Official Release**: https://wordpress.org/plugins/the-events-calendar/
-* **Readme**: https://github.com/the-events-calendar/the-events-calendar/blob/master/readme.txt
+* **Readme**: https://github.com/the-events-calendar/the-events-calendar/blob/main/readme.txt
 * **Website**: https://theeventscalendar.com/product/wordpress-events-calendar/
 * **Support**: https://theeventscalendar.com/support
 * **Documentation**: https://theeventscalendar.com/functions/

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ That's all! please have fun and code responsibly :)
 ## Further Information
 
 * **Official Release**: https://wordpress.org/plugins/the-events-calendar/
-* **Readme**: https://github.com/moderntribe/the-events-calendar/blob/master/readme.txt
+* **Readme**: https://github.com/the-events-calendar/the-events-calendar/blob/master/readme.txt
 * **Website**: https://theeventscalendar.com/product/wordpress-events-calendar/
 * **Support**: https://theeventscalendar.com/support
 * **Documentation**: https://theeventscalendar.com/functions/

--- a/readme.txt
+++ b/readme.txt
@@ -790,4 +790,4 @@ Remember to always make a backup of your database and files before updating!
 
 * Tweak - Updated hook for showing Event name in the event tickets order report pages. [ET-1810]
 
-### For all versions, please see the full [changelog](https://github.com/the-events-calendar/the-events-calendar/blob/master/changelog.md) in our documentation.
+### For all versions, please see the full [changelog](https://github.com/the-events-calendar/the-events-calendar/blob/main/changelog.md) in our documentation.

--- a/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
+++ b/src/Events/Custom_Tables/V1/Integrations/ACF/Query_Modifier.php
@@ -3,7 +3,7 @@
  * An extension of the Events-only modifier to redirect Event queries to the custom tables
  * while rendering ACF fields.
  *
- * @since   6.0.11
+ * @since 6.0.11
  *
  * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
  */
@@ -18,13 +18,13 @@ use Tribe__Events__Main as TEC;
 /**
  * Class Query_Modifier.
  *
- * @since   6.0.11
+ * @since 6.0.11
  *
  * @package TEC\Events\Custom_Tables\V1\Integrations\ACF;
  */
 class Query_Modifier extends Events_Only_Modifier {
 	/**
-	 * ${CARET}
+	 * Whether this query modifier should handle the query or not.
 	 *
 	 * @since 6.0.11
 	 *

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/RSVP.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/RSVP.php
@@ -25,7 +25,7 @@ use Tribe__Utils__Array as Arr;
  */
 class RSVP {
 	/**
-	 * The option key for the Event calendar links.
+	 * The option key for The Events Calendar links.
 	 *
 	 * @see Email_Abstract::get_option_key() for option key format.
 	 *
@@ -36,7 +36,7 @@ class RSVP {
 	public static string $option_add_event_links = 'tec-tickets-emails-rsvp-add-event-links';
 
 	/**
-	 * The option key for the Event calendar invite.
+	 * The option key for The Events Calendar invite.
 	 *
 	 * @see Email_Abstract::get_option_key() for option key format.
 	 *

--- a/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Ticket.php
+++ b/src/Events/Integrations/Plugins/Event_Tickets/Emails/Email/Ticket.php
@@ -25,7 +25,7 @@ use TEC\Events\Integrations\Plugins\Event_Tickets\Emails\Template;
  */
 class Ticket {
 	/**
-	 * The option key for the Event calendar links.
+	 * The option key for The Events Calendar links.
 	 *
 	 * @see   Email_Abstract::get_option_key() for option key format.
 	 *
@@ -36,7 +36,7 @@ class Ticket {
 	public static string $option_add_event_links = 'tec-tickets-emails-ticket-add-event-links';
 
 	/**
-	 * The option key for the Event calendar invite.
+	 * The option key for The Events Calendar invite.
 	 *
 	 * @see   Email_Abstract::get_option_key() for option key format.
 	 *

--- a/src/Events/Integrations/Plugins/WordPress_SEO/Events_Schema.php
+++ b/src/Events/Integrations/Plugins/WordPress_SEO/Events_Schema.php
@@ -245,7 +245,7 @@ class Events_Schema extends Abstract_Schema_Piece {
 			/*
 			 * PERFORMER
 			 * Unset the performer, as it is currently unused.
-			 * @see: https://github.com/moderntribe/the-events-calendar/blob/5e737eb820c59bb9639d9ee9f4b88931a51c8554/src/Tribe/JSON_LD/Event.php#L151
+			 * @see: https://github.com/the-events-calendar/the-events-calendar/blob/5e737eb820c59bb9639d9ee9f4b88931a51c8554/src/Tribe/JSON_LD/Event.php#L151
 			 */
 			unset( $d->performer );
 

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -643,7 +643,7 @@ class Tribe__Events__Editor extends Tribe__Editor {
 	 *
 	 * This is something should be addressed on TEC as is affecting any new user installing the plugin.
 	 *
-	 * Code is located at: https://github.com/moderntribe/the-events-calendar/blob/f8af49bc41048e8632372fc8da77202d9cb98d86/src/Tribe/Admin/Event_Meta_Box.php#L345
+	 * Code is located at: https://github.com/the-events-calendar/the-events-calendar/blob/f8af49bc41048e8632372fc8da77202d9cb98d86/src/Tribe/Admin/Event_Meta_Box.php#L345
 	 *
 	 * @since 4.7
 	 * @deprecated 0.3.2-alpha

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -127,7 +127,7 @@ class Tribe__Events__Editor extends Tribe__Editor {
 	 * When Gutenberg is active, we do not care about custom-fields as a metabox, but as part of the Rest API
 	 *
 	 * Code is located at:
-	 * https://github.com/moderntribe/the-events-calendar/blob/f8af49bc41048e8632372fc8da77202d9cb98d86/src/Tribe/Admin/Event_Meta_Box.php#L345
+	 * https://github.com/the-events-calendar/the-events-calendar/blob/f8af49bc41048e8632372fc8da77202d9cb98d86/src/Tribe/Admin/Event_Meta_Box.php#L345
 	 *
 	 * @todo  Block that option once the user has Gutenberg active
 	 *

--- a/src/Tribe/Event_Cleaner_Scheduler.php
+++ b/src/Tribe/Event_Cleaner_Scheduler.php
@@ -225,11 +225,15 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 	 * Moves to trash events that ended before a date specified by user
 	 *
 	 * @since 4.6.13
-	 * @since 6.0.13 Added a return value, and suspends Tribe__Events__Dates__Known_Range::rebuild_known_range() until batch is complete.
+	 * @since 6.0.13 Added a return value and suspend Tribe__Events__Dates__Known_Range::rebuild_known_range() until the batch is complete.
+	 * @since TBD Added a filter to skip updating the series post status when cleaning old events.
 	 *
 	 * @return array<string,WP_Post|false|null> An associative array of ID to the result of wp_trash_post().
 	 */
 	public function move_old_events_to_trash(): array {
+		// When running maintenance, we want to keep the Series post unchanged.
+		add_filter( 'tec_events_skip_updating_series_status', '__return_true' );
+
 		$month    = $this->trash_new_date;
 		$post_ids = $this->select_events_to_purge( $month );
 		$results  = [];
@@ -245,6 +249,8 @@ class Tribe__Events__Event_Cleaner_Scheduler {
 		}
 		Tribe__Events__Dates__Known_Range::instance()->rebuild_known_range();
 		$this->hook_rebuild_known_range();
+
+		remove_filter( 'tec_events_skip_updating_series_status', '__return_true' );
 
 		return $results;
 	}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -374,7 +374,7 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		 *
 		 * In the past we used to parse `common/src/Tribe/Main.php` for the Common Lib version.
 		 *
-		 * @link https://github.com/moderntribe/tribe-common
+		 * @link https://github.com/the-events-calendar/tribe-common
 		 * @see  self::init_autoloading
 		 *
 		 * @return void

--- a/src/deprecated/Tribe__Events__Integrations__Freemius.php
+++ b/src/deprecated/Tribe__Events__Integrations__Freemius.php
@@ -230,8 +230,6 @@ class Tribe__Events__Integrations__Freemius {
 	 * For some reason Freemius is redirecting some customers to a page that doesnt exist. So we catch that page and
 	 * redirect them back to the actual page that we are using to setup the plugins integration.
 	 *
-	 * @link        https://moderntribe.atlassian.net/browse/TEC-3218
-	 *
 	 * @deprecated 6.1.0
 	 * @since       5.0.2
 	 *

--- a/src/resources/js/views/README.md
+++ b/src/resources/js/views/README.md
@@ -20,7 +20,7 @@ The second method is to manually initialize the accordion via the `tribe.events.
 
 ## Breakpoints
 
-The Breakpoints JavaScript is responsible for applying the correct container query classes to the container. See the [PostCSS README.md from The Events Calendar](https://github.com/moderntribe/the-events-calendar/blob/master/src/resources/postcss/README.md) on container queries for more information on the classes. The breakpoint values can also be filtered to customize the breakpoints.
+The Breakpoints JavaScript is responsible for applying the correct container query classes to the container. See the [PostCSS README.md from The Events Calendar](https://github.com/the-events-calendar/the-events-calendar/blob/master/src/resources/postcss/README.md) on container queries for more information on the classes. The breakpoint values can also be filtered to customize the breakpoints.
 
 This script is loaded in the header rather than the footer to prevent flash of unstyled content.
 

--- a/src/resources/js/views/README.md
+++ b/src/resources/js/views/README.md
@@ -20,7 +20,7 @@ The second method is to manually initialize the accordion via the `tribe.events.
 
 ## Breakpoints
 
-The Breakpoints JavaScript is responsible for applying the correct container query classes to the container. See the [PostCSS README.md from The Events Calendar](https://github.com/the-events-calendar/the-events-calendar/blob/master/src/resources/postcss/README.md) on container queries for more information on the classes. The breakpoint values can also be filtered to customize the breakpoints.
+The Breakpoints JavaScript is responsible for applying the correct container query classes to the container. See the [PostCSS README.md from The Events Calendar](https://github.com/the-events-calendar/the-events-calendar/blob/main/src/resources/postcss/README.md) on container queries for more information on the classes. The breakpoint values can also be filtered to customize the breakpoints.
 
 This script is loaded in the header rather than the footer to prevent flash of unstyled content.
 

--- a/src/resources/postcss/README.md
+++ b/src/resources/postcss/README.md
@@ -113,7 +113,7 @@ The Events Calendar styles are broken into 4 main sections: utilities, base, com
 
 ### Utilities
 
-The utilities are a set of common PostCSS variables, icons, and mixins used throughout the plugins. These come from the Tribe Common Styles repository. See [Tribe Common Styles](https://github.com/moderntribe/tribe-common-styles) for more details.
+The utilities are a set of common PostCSS variables, icons, and mixins used throughout the plugins. These come from the Tribe Common Styles repository. See [Tribe Common Styles](https://github.com/the-events-calendar/tribe-common-styles) for more details.
 
 ### Base
 
@@ -159,7 +159,7 @@ The specificity to override the styles are matched to those applied to the theme
 
 ## How to contribute
 
-You want to [contribute](https://github.com/moderntribe/the-events-calendar/blob/master/CONTRIBUTING.md) to these styles? Great! There are a few things to consider when making changes:
+You want to [contribute](https://github.com/the-events-calendar/the-events-calendar/blob/master/CONTRIBUTING.md) to these styles? Great! There are a few things to consider when making changes:
 
 ### Additions
 

--- a/src/resources/postcss/README.md
+++ b/src/resources/postcss/README.md
@@ -159,7 +159,7 @@ The specificity to override the styles are matched to those applied to the theme
 
 ## How to contribute
 
-You want to [contribute](https://github.com/the-events-calendar/the-events-calendar/blob/master/CONTRIBUTING.md) to these styles? Great! There are a few things to consider when making changes:
+You want to [contribute](https://github.com/the-events-calendar/the-events-calendar/blob/main/CONTRIBUTING.md) to these styles? Great! There are a few things to consider when making changes:
 
 ### Additions
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Repository/Event_Period_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Repository/Event_Period_Test.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * ${CARET}
+ * This class is used to test the Event_Period repository.
  *
- * @since   4.9.13
+ * @since 4.9.13
  *
  * @package Tribe\Events\Views\V2\Repository
  */


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-709]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

When doing the maintenance (trash past event after x months), and a recurring event occurrence is trashed, the Series post type would be trashed as well. This PR introduces a filter to allow skipping the post status update of the Series.
The PR goes hand-in-hand with an [ECP PR](https://github.com/the-events-calendar/events-pro/pull/2798).

### 🎥 Artifacts <!-- if applicable-->
[Screencast](https://docs.google.com/videos/d/1F9nBS4R86c56CMml1posX6KJTjG06BqS898XMoR0pVs/edit?usp=sharing)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TECTRIA-709]: https://stellarwp.atlassian.net/browse/TECTRIA-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ