### PR TITLE
Add support for manual offset and fix Event cost block.

### DIFF
--- a/src/Events/Classy/Controller.php
+++ b/src/Events/Classy/Controller.php
@@ -2,7 +2,7 @@
 /**
  * The main Classy feature controller for The Events Calendar.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Classy;
  */
@@ -18,7 +18,7 @@ use Tribe__Events__Main as TEC;
 /**
  * Class Controller.
  *
- * @since   TBD
+ * @since TBD
  *
  * @package TEC\Events\Classy;
  */

--- a/src/Events/Classy/Meta.php
+++ b/src/Events/Classy/Meta.php
@@ -430,8 +430,12 @@ class Meta extends Controller_Contract {
 
 		$meta    = $request->get_param( 'meta' ) ?? [];
 		$post_id = $post->ID;
+		
+		if ( ! isset( $meta['EventCost'] ) ) {
+			return;
+		}
 
-		$cost = (array) ( ! empty( $meta['_EventCost'] ) ? $meta['_EventCost'] : tribe_get_cost( $post_id ) );
+		$cost = ! empty( $meta['_EventCost'] ) ? $meta['_EventCost'] : '';
 		API::update_event_cost( $post_id, $cost );
 	}
 }

--- a/src/Events/Classy/Meta.php
+++ b/src/Events/Classy/Meta.php
@@ -57,9 +57,6 @@ class Meta extends Controller_Contract {
 		],
 		'_EventEndDate'            => [],
 		'_EventEndDateUTC'         => [],
-		'_EventIsFree'             => [
-			'type' => 'boolean',
-		],
 		'_EventOrganizerID'        => [
 			'single' => false,
 			'type'   => 'integer',

--- a/src/Events/Classy/Meta.php
+++ b/src/Events/Classy/Meta.php
@@ -351,8 +351,12 @@ class Meta extends Controller_Contract {
 				? $meta['_EventTimezone']
 				: $this->get_timezone_string( $post_id );
 
-			// Attempt to create a DateTimeZone object from the timezone string.
-			$timezone = new DateTimeZone( $timezone_string );
+			// Handle UTC offsets like "UTC+6" using the proper timezone conversion method.
+			if ( Timezones::is_utc_offset( $timezone_string ) ) {
+				$timezone_string = Timezones::timezone_from_utc_offset( $timezone_string )->getName();
+			}
+			
+			$timezone = Timezones::build_timezone_object( $timezone_string );
 			$utc      = new DateTimeZone( 'UTC' );
 		} catch ( \Exception $e ) {
 			do_action(

--- a/src/Events/Classy/Meta.php
+++ b/src/Events/Classy/Meta.php
@@ -12,7 +12,6 @@ namespace TEC\Events\Classy;
 use DateTimeZone;
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use Tribe__Date_Utils as Date;
-use Tribe__Events__API as API;
 use Tribe__Timezones as Timezones;
 use WP_Post as Post;
 use WP_Post_Type;
@@ -121,7 +120,6 @@ class Meta extends Controller_Contract {
 		// Add actions for each supported post type.
 		foreach ( $this->get_supported_post_types() as $post_type ) {
 			add_action( "rest_after_insert_{$post_type}", [ $this, 'add_utc_dates' ], 5, 2 );
-			add_action( "rest_after_insert_{$post_type}", [ $this, 'update_cost' ], 10, 2 );
 		}
 	}
 
@@ -407,35 +405,5 @@ class Meta extends Controller_Contract {
 		}
 
 		return $timezone;
-	}
-
-	/**
-	 * Updates the cost of an event.
-	 *
-	 * This method is called when the cost of an event is updated via the REST API.
-	 * It retrieves the cost from the request and updates the post meta accordingly.
-	 *
-	 * @since TBD
-	 *
-	 * @param Post    $post    The post object being updated.
-	 * @param Request $request The request object containing the new cost data.
-	 *
-	 * @return void
-	 */
-	public function update_cost( $post, $request ): void {
-		// If for some reason we don't have the correct object types, return early.
-		if ( ! $post instanceof Post || ! $request instanceof Request ) {
-			return;
-		}
-
-		$meta    = $request->get_param( 'meta' ) ?? [];
-		$post_id = $post->ID;
-		
-		if ( ! isset( $meta['_EventCost'] ) ) {
-			return;
-		}
-
-		$cost = ! empty( $meta['_EventCost'] ) ? $meta['_EventCost'] : '';
-		API::update_event_cost( $post_id, $cost );
 	}
 }

--- a/src/Events/Classy/Meta.php
+++ b/src/Events/Classy/Meta.php
@@ -431,7 +431,7 @@ class Meta extends Controller_Contract {
 		$meta    = $request->get_param( 'meta' ) ?? [];
 		$post_id = $post->ID;
 		
-		if ( ! isset( $meta['EventCost'] ) ) {
+		if ( ! isset( $meta['_EventCost'] ) ) {
 			return;
 		}
 

--- a/src/resources/packages/classy/constants.tsx
+++ b/src/resources/packages/classy/constants.tsx
@@ -15,7 +15,6 @@ export const METADATA_EVENT_CURRENCY = '_EventCurrencyCode';
 export const METADATA_EVENT_CURRENCY_POSITION = '_EventCurrencyPosition';
 export const METADATA_EVENT_CURRENCY_SYMBOL = '_EventCurrencySymbol';
 export const METADATA_EVENT_END_DATE = '_EventEndDate';
-export const METADATA_EVENT_IS_FREE = '_EventIsFree';
 export const METADATA_EVENT_START_DATE = '_EventStartDate';
 export const METADATA_EVENT_TIMEZONE = '_EventTimezone';
 export const METADATA_EVENT_ORGANIZER_ID = '_EventOrganizerID';

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -100,7 +100,7 @@ export default function EventCost(): JSX.Element {
 	 * Formats the event cost value for display.
 	 *
 	 * This function formats the event cost value based on whether the input has focus or if the event is free.
-	 * It handles multiple prices separated by commas and returns a formatted string.
+	 * It handles multiple prices separated by dashes and returns a formatted string.
 	 *
 	 * @since TBD
 	 *
@@ -114,7 +114,7 @@ export default function EventCost(): JSX.Element {
 		}
 
 		const pieces = value
-			.split( ',' )
+			.split( '-' )
 			.map( ( piece ) => piece.trim() )
 			.filter( ( piece ) => piece !== '' );
 
@@ -182,7 +182,7 @@ export default function EventCost(): JSX.Element {
 
 			<div className="classy-field__input-note">
 				{ _x(
-					'If multiple entry prices are available, list each price separated by commas.',
+					'If multiple entry prices are available, list each price separated by dashes.',
 					'Event cost input note',
 					'the-events-calendar'
 				) }

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -68,6 +68,7 @@ export default function EventCost(): JSX.Element {
 	// Handle changes to the event cost input.
 	const onCostChange = ( nextValue: string | undefined ): void => {
 		setEventCostValue( nextValue ?? '' );
+        setPreviousCostValue( nextValue ?? '' );
 		editPost( { meta: { [ METADATA_EVENT_COST ]: nextValue } } );
 	};
 

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -39,6 +39,7 @@ export default function EventCost(): JSX.Element {
 	const { editPost } = useDispatch( 'core/editor' );
 
 	const eventCostMeta: string = meta?.[ METADATA_EVENT_COST ] || '';
+	const [ isFree, setIsFree ] = useState< boolean >( eventCostMeta === '0' );
 	const [ eventCostValue, setEventCostValue ] = useState< string >( isFree ? freeText : eventCostMeta );
 
 	const eventCurrencySymbolMeta: string = meta?.[ METADATA_EVENT_CURRENCY_SYMBOL ] || defaultCurrency.symbol;
@@ -52,7 +53,7 @@ export default function EventCost(): JSX.Element {
 
 	// Track changes to the post content and update the state accordingly.
 	useEffect( () => {
-		setEventCostValue( eventCostMeta );
+		setEventCostValue( isFree ? freeText : eventCostMeta );
 	}, [ eventCostMeta ] );
 
 	useEffect( () => {

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -9,7 +9,6 @@ import {
 	METADATA_EVENT_CURRENCY,
 	METADATA_EVENT_CURRENCY_POSITION,
 	METADATA_EVENT_CURRENCY_SYMBOL,
-	METADATA_EVENT_IS_FREE,
 } from '../../constants';
 import { Currency } from '@tec/common/classy/types/Currency';
 import { CurrencyPosition } from '@tec/common/classy/types/CurrencyPosition';
@@ -39,9 +38,6 @@ export default function EventCost(): JSX.Element {
 
 	const { editPost } = useDispatch( 'core/editor' );
 
-	const isFreeMeta: boolean = meta?.[ METADATA_EVENT_IS_FREE ] || false;
-	const [ isFree, setIsFree ] = useState< boolean >( isFreeMeta );
-
 	const eventCostMeta: string = meta?.[ METADATA_EVENT_COST ] || '';
 	const [ eventCostValue, setEventCostValue ] = useState< string >( isFree ? freeText : eventCostMeta );
 
@@ -58,10 +54,6 @@ export default function EventCost(): JSX.Element {
 	useEffect( () => {
 		setEventCostValue( eventCostMeta );
 	}, [ eventCostMeta ] );
-
-	useEffect( () => {
-		setIsFree( isFreeMeta );
-	}, [ isFreeMeta ] );
 
 	useEffect( () => {
 		setCurrencySymbol( eventCurrencySymbolMeta );
@@ -82,7 +74,6 @@ export default function EventCost(): JSX.Element {
 		setIsFree( nextValue );
 		setEventCostValue( nextValue ? freeText : eventCostMeta );
 
-		editPost( { meta: { [ METADATA_EVENT_IS_FREE ]: nextValue } } );
 	};
 
 	/**

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -41,6 +41,7 @@ export default function EventCost(): JSX.Element {
 	const eventCostMeta: string = meta?.[ METADATA_EVENT_COST ] || '';
 	const [ isFree, setIsFree ] = useState< boolean >( eventCostMeta === '0' );
 	const [ eventCostValue, setEventCostValue ] = useState< string >( isFree ? freeText : eventCostMeta );
+	const [ previousCostValue, setPreviousCostValue ] = useState< string >( eventCostMeta );
 
 	const eventCurrencySymbolMeta: string = meta?.[ METADATA_EVENT_CURRENCY_SYMBOL ] || defaultCurrency.symbol;
 	const [ currencySymbol, setCurrencySymbol ] = useState< string >( eventCurrencySymbolMeta );
@@ -73,8 +74,11 @@ export default function EventCost(): JSX.Element {
 	// Handle changes to the "is free" toggle.
 	const onFreeChange = ( nextValue: boolean ): void => {
 		setIsFree( nextValue );
-		setEventCostValue( nextValue ? freeText : eventCostMeta );
 
+		const newCostValue = isFree ? '0' : previousCostValue;
+
+		setEventCostValue( isFree ? freeText : newCostValue );
+		editPost( { meta: { [ METADATA_EVENT_COST ]: newCostValue } } );
 	};
 
 	/**

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -75,9 +75,9 @@ export default function EventCost(): JSX.Element {
 	const onFreeChange = ( nextValue: boolean ): void => {
 		setIsFree( nextValue );
 
-		const newCostValue = isFree ? '0' : previousCostValue;
+		const newCostValue = nextValue ? '0' : previousCostValue;
 
-		setEventCostValue( isFree ? freeText : newCostValue );
+		setEventCostValue( nextValue ? freeText : newCostValue );
 		editPost( { meta: { [ METADATA_EVENT_COST ]: newCostValue } } );
 	};
 

--- a/src/resources/packages/classy/fields/EventCost/EventCost.tsx
+++ b/src/resources/packages/classy/fields/EventCost/EventCost.tsx
@@ -68,7 +68,7 @@ export default function EventCost(): JSX.Element {
 	// Handle changes to the event cost input.
 	const onCostChange = ( nextValue: string | undefined ): void => {
 		setEventCostValue( nextValue ?? '' );
-        setPreviousCostValue( nextValue ?? '' );
+		setPreviousCostValue( nextValue ?? '' );
 		editPost( { meta: { [ METADATA_EVENT_COST ]: nextValue } } );
 	};
 

--- a/tests/classy_integration/Meta_Test.php
+++ b/tests/classy_integration/Meta_Test.php
@@ -229,4 +229,48 @@ class Meta_Test extends Controller_Test_Case {
 		// The timezone should be the same as the original.
 		$this->assertEquals( 'UTC', get_post_meta( $event_id, '_EventTimezone', true ) );
 	}
+
+	public function possible_cost_values() {
+		return [
+			''              => [ '' ],
+			'100'           => [ '100' ],
+			'100.00'        => [ '100.00' ],
+			'10.00 - 50.00' => [ '10.00 - 50.00' ],
+			'10-30'         => [ '10-30' ],
+		];
+	}
+
+	/**
+	 * @test
+	 * @covers \TEC\Events\Classy\Meta::update_cost
+	 * @dataProvider possible_cost_values
+	 */
+	public function test_update_cost_should_update_the_cost_meta( $cost ) {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Basic Event',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 00:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$this->make_controller()->register();
+
+		$post = get_post( $event_id );
+
+		do_action(
+			'rest_after_insert_' . TEC::POSTTYPE,
+			$post,
+			$this->create_request(
+				[
+					'meta' => [
+						'_EventCost' => $cost,
+					],
+				]
+			)
+		);
+
+		$this->assertEquals( $cost, get_post_meta( $event_id, '_EventCost', true ) );
+	}
 }

--- a/tests/classy_integration/Meta_Test.php
+++ b/tests/classy_integration/Meta_Test.php
@@ -229,48 +229,4 @@ class Meta_Test extends Controller_Test_Case {
 		// The timezone should be the same as the original.
 		$this->assertEquals( 'UTC', get_post_meta( $event_id, '_EventTimezone', true ) );
 	}
-
-	public function possible_cost_values() {
-		return [
-			''              => [ '' ],
-			'100'           => [ '100' ],
-			'100.00'        => [ '100.00' ],
-			'10.00 - 50.00' => [ '10.00 - 50.00' ],
-			'10-30'         => [ '10-30' ],
-		];
-	}
-
-	/**
-	 * @test
-	 * @covers \TEC\Events\Classy\Meta::update_cost
-	 * @dataProvider possible_cost_values
-	 */
-	public function test_update_cost_should_update_the_cost_meta( $cost ) {
-		$event_id = tribe_events()->set_args(
-			[
-				'title'      => 'Basic Event',
-				'status'     => 'publish',
-				'start_date' => '2020-01-01 00:00:00',
-				'duration'   => 2 * HOUR_IN_SECONDS,
-			]
-		)->create()->ID;
-
-		$this->make_controller()->register();
-
-		$post = get_post( $event_id );
-
-		do_action(
-			'rest_after_insert_' . TEC::POSTTYPE,
-			$post,
-			$this->create_request(
-				[
-					'meta' => [
-						'_EventCost' => $cost,
-					],
-				]
-			)
-		);
-
-		$this->assertEquals( $cost, get_post_meta( $event_id, '_EventCost', true ) );
-	}
 }

--- a/tests/classy_integration/Meta_Test.php
+++ b/tests/classy_integration/Meta_Test.php
@@ -115,7 +115,7 @@ class Meta_Test extends Controller_Test_Case {
 		$this->assertEquals( 'You cannot pass!', get_post_meta( $event->ID, '_EventStartDateUTC', true ) );
 		$this->assertEquals( 'not a UTC time', get_post_meta( $event->ID, '_EventEndDateUTC', true ) );
 	}
-	
+
 	/**
 	 * @test
 	 * @covers \TEC\Events\Classy\Meta::add_utc_dates
@@ -151,5 +151,82 @@ class Meta_Test extends Controller_Test_Case {
 		// default timezone was UTC which now changed to Europe/Paris which is UTC+1. The new UTC dates should be behind now.
 		$this->assertEquals( '2019-12-31 23:00:00', get_post_meta( $event_id, '_EventStartDateUTC', true ) );
 		$this->assertEquals( '2020-01-01 01:00:00', get_post_meta( $event_id, '_EventEndDateUTC', true ) );
+	}
+
+	/**
+	 * @test
+	 * @covers \TEC\Events\Classy\Meta::add_utc_dates
+	 */
+	public function test_add_utc_dates_should_update_properly_for_manual_offset_timezones() {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Basic Event',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 00:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$this->make_controller()->register();
+
+		apply_filters(
+			'rest_after_insert_' . TEC::POSTTYPE,
+			get_post( $event_id ),
+			$this->create_request(
+				[
+					'meta' => [
+						'_EventStartDate' => '2020-01-01 00:00:00',
+						'_EventTimezone'  => 'UTC+6',
+					],
+				]
+			)
+		);
+
+		$this->assertEquals( '2020-01-01 00:00:00', get_post_meta( $event_id, '_EventStartDate', true ) );
+		$this->assertEquals( '2020-01-01 02:00:00', get_post_meta( $event_id, '_EventEndDate', true ) );
+
+		// default timezone was UTC which now changed to UTC+6. The new UTC dates should be behind now.
+		$this->assertEquals( '2019-12-31 18:00:00', get_post_meta( $event_id, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '2019-12-31 20:00:00', get_post_meta( $event_id, '_EventEndDateUTC', true ) );
+	}
+
+	/**
+	 * @test
+	 * @covers \TEC\Events\Classy\Meta::add_utc_dates
+	 */
+	public function test_add_utc_dates_should_not_update_for_invalid_timezones() {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Basic Event',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 00:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$this->make_controller()->register();
+
+		apply_filters(
+			'rest_after_insert_' . TEC::POSTTYPE,
+			get_post( $event_id ),
+			$this->create_request(
+				[
+					'meta' => [
+						'_EventStartDate' => '2020-01-01 00:00:00',
+						'_EventTimezone'  => 'Invalid/Timezone',
+					],
+				]
+			)
+		);
+
+		$this->assertEquals( '2020-01-01 00:00:00', get_post_meta( $event_id, '_EventStartDate', true ) );
+		$this->assertEquals( '2020-01-01 02:00:00', get_post_meta( $event_id, '_EventEndDate', true ) );
+
+		// default timezone was UTC which now changed to Invalid/Timezone. The new UTC dates should be the same as the original.
+		$this->assertEquals( '2020-01-01 00:00:00', get_post_meta( $event_id, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '2020-01-01 02:00:00', get_post_meta( $event_id, '_EventEndDateUTC', true ) );
+
+		// The timezone should be the same as the original.
+		$this->assertEquals( 'UTC', get_post_meta( $event_id, '_EventTimezone', true ) );
 	}
 }

--- a/tests/classy_integration/Meta_Test.php
+++ b/tests/classy_integration/Meta_Test.php
@@ -32,39 +32,39 @@ class Meta_Test extends Controller_Test_Case {
 		return $request;
 	}
 
-	public function test_on_rest_insert_event_does_not_add_meta_to_non_event_post():void{
-		$post = static::factory()->post->create_and_get(  );
+	public function test_on_rest_insert_event_does_not_add_meta_to_non_event_post(): void {
+		$post = static::factory()->post->create_and_get();
 		// Sanity check.
-		$this->assertEquals('', get_post_meta($post->ID, '_EventStartDateUTC',true));
-		$this->assertEquals('', get_post_meta($post->ID, '_EventEndDateUTC',true));
+		$this->assertEquals( '', get_post_meta( $post->ID, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '', get_post_meta( $post->ID, '_EventEndDateUTC', true ) );
 
 		$this->make_controller()->register();
 		apply_filters( 'rest_after_insert_' . TEC::POSTTYPE, $post, $this->create_request() );
 
-		$this->assertEquals('', get_post_meta($post->ID, '_EventStartDateUTC',true));
-		$this->assertEquals('', get_post_meta($post->ID, '_EventEndDateUTC',true));
+		$this->assertEquals( '', get_post_meta( $post->ID, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '', get_post_meta( $post->ID, '_EventEndDateUTC', true ) );
 	}
 
-	public function test_on_rest_insert_event_adds_meta_to_event_post():void{
+	public function test_on_rest_insert_event_adds_meta_to_event_post(): void {
 		// Create the post with a post type that will not trigger any event-related filter or action.
-		$pseudo_event = static::factory()->post->create_and_get(  ['post_type'=>'pseudo_event']);
+		$pseudo_event = static::factory()->post->create_and_get( [ 'post_type' => 'pseudo_event' ] );
 
 		// Update the date post meta as the REST API save would.
-		update_post_meta($pseudo_event->ID, '_EventStartDate', '2020-01-01 10:00:00');
-		update_post_meta($pseudo_event->ID, '_EventEndDate', '2020-01-01 13:00:00');
-		update_post_meta($pseudo_event->ID, '_EventTimezone', 'Europe/Paris');
+		update_post_meta( $pseudo_event->ID, '_EventStartDate', '2020-01-01 10:00:00' );
+		update_post_meta( $pseudo_event->ID, '_EventEndDate', '2020-01-01 13:00:00' );
+		update_post_meta( $pseudo_event->ID, '_EventTimezone', 'Europe/Paris' );
 
 		// Update the event post type with a direct db call to avoid triggering any event-related filter or action.
 		global $wpdb;
-		DB::query( DB::prepare( "UPDATE %i SET post_type = %s WHERE ID = %d", $wpdb->posts, TEC::POSTTYPE, $pseudo_event->ID ) );
+		DB::query( DB::prepare( 'UPDATE %i SET post_type = %s WHERE ID = %d', $wpdb->posts, TEC::POSTTYPE, $pseudo_event->ID ) );
 
 		// Re-fetch the event.
 		clean_post_cache( $pseudo_event->ID );
 		$event = get_post( $pseudo_event->ID );
 
 		// Sanity check.
-		$this->assertEquals('', get_post_meta($event->ID, '_EventStartDateUTC',true));
-		$this->assertEquals('', get_post_meta($event->ID, '_EventEndDateUTC',true));
+		$this->assertEquals( '', get_post_meta( $event->ID, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '', get_post_meta( $event->ID, '_EventEndDateUTC', true ) );
 
 		$this->make_controller()->register();
 
@@ -83,26 +83,26 @@ class Meta_Test extends Controller_Test_Case {
 		);
 
 		// Sanity check.
-		$this->assertEquals('2020-01-01 09:00:00', get_post_meta($event->ID, '_EventStartDateUTC',true));
-		$this->assertEquals('2020-01-01 12:00:00', get_post_meta($event->ID, '_EventEndDateUTC',true));
+		$this->assertEquals( '2020-01-01 09:00:00', get_post_meta( $event->ID, '_EventStartDateUTC', true ) );
+		$this->assertEquals( '2020-01-01 12:00:00', get_post_meta( $event->ID, '_EventEndDateUTC', true ) );
 	}
 
-	public function test_on_rest_insert_events_does_not_change_meta_if_present():void{
+	public function test_on_rest_insert_events_does_not_change_meta_if_present(): void {
 		// Create the post with a post type that will not trigger any event-related filter or action.
-		$pseudo_event = static::factory()->post->create_and_get(  ['post_type'=>'pseudo_event']);
+		$pseudo_event = static::factory()->post->create_and_get( [ 'post_type' => 'pseudo_event' ] );
 
 		// Update the date post meta as the REST API save would.
-		update_post_meta($pseudo_event->ID, '_EventStartDate', '2020-01-01 10:00:00');
-		update_post_meta($pseudo_event->ID, '_EventEndDate', '2020-01-01 13:00:00');
-		update_post_meta($pseudo_event->ID, '_EventTimezone', 'Europe/Paris');
+		update_post_meta( $pseudo_event->ID, '_EventStartDate', '2020-01-01 10:00:00' );
+		update_post_meta( $pseudo_event->ID, '_EventEndDate', '2020-01-01 13:00:00' );
+		update_post_meta( $pseudo_event->ID, '_EventTimezone', 'Europe/Paris' );
 
 		// Set the UTC start and end date and time to very distinguishable strings.
-		update_post_meta($pseudo_event->ID, '_EventStartDateUTC', 'You cannot pass!');
-		update_post_meta($pseudo_event->ID, '_EventEndDateUTC', 'not a UTC time');
+		update_post_meta( $pseudo_event->ID, '_EventStartDateUTC', 'You cannot pass!' );
+		update_post_meta( $pseudo_event->ID, '_EventEndDateUTC', 'not a UTC time' );
 
 		// Update the event post type with a direct db call to avoid triggering any event-related filter or action.
 		global $wpdb;
-		DB::query( DB::prepare( "UPDATE %i SET post_type = %s WHERE ID = %d", $wpdb->posts, TEC::POSTTYPE, $pseudo_event->ID ) );
+		DB::query( DB::prepare( 'UPDATE %i SET post_type = %s WHERE ID = %d', $wpdb->posts, TEC::POSTTYPE, $pseudo_event->ID ) );
 
 		// Re-fetch the event.
 		clean_post_cache( $pseudo_event->ID );
@@ -112,7 +112,7 @@ class Meta_Test extends Controller_Test_Case {
 		apply_filters( 'rest_after_insert_' . TEC::POSTTYPE, $event, $this->create_request() );
 
 		// Sanity check.
-		$this->assertEquals('You cannot pass!', get_post_meta($event->ID, '_EventStartDateUTC',true));
-		$this->assertEquals('not a UTC time', get_post_meta($event->ID, '_EventEndDateUTC',true));
+		$this->assertEquals( 'You cannot pass!', get_post_meta( $event->ID, '_EventStartDateUTC', true ) );
+		$this->assertEquals( 'not a UTC time', get_post_meta( $event->ID, '_EventEndDateUTC', true ) );
 	}
 }

--- a/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
+++ b/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
@@ -138,6 +138,8 @@ describe( 'EventCost Component', () => {
 
 		const costInput = screen.getByLabelText( 'Event cost' );
 		await userEvent.type( costInput, '10.50' );
+        // click outside the input to trigger the change
+        await userEvent.click( document.body );
 
 		expect( container ).toMatchSnapshot();
 	} );
@@ -152,6 +154,8 @@ describe( 'EventCost Component', () => {
 
 		const costInput = screen.getByLabelText( 'Event cost' );
 		await userEvent.type( costInput, '10.50, 20.75, 15.25' );
+		// click outside the input to trigger the change
+		await userEvent.click( document.body );
 
 		expect( container ).toMatchSnapshot();
 	} );

--- a/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
+++ b/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
@@ -3,10 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { RegistryProvider } from '@wordpress/data';
-import { createRegistry } from '../../../../common/src/resources/packages/classy/store';
+import { getRegistry } from '@tec/common/classy/store';
 import EventCost from '../../../../src/resources/packages/classy/fields/EventCost/EventCost';
-import { Currency } from '../../../../common/src/resources/packages/classy/types/Currency';
-import { CurrencyPosition } from '../../../../common/src/resources/packages/classy/types/CurrencyPosition';
+import { Currency } from '@tec/common/classy/types/Currency';
+import { CurrencyPosition } from '@tec/common/classy/types/CurrencyPosition';
 
 type Selector = {
 	'core/editor': {
@@ -104,7 +104,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'renders correctly with default props', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />
@@ -115,7 +115,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'displays "Free" when event is free', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />
@@ -129,7 +129,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'formats single cost value correctly', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />
@@ -143,7 +143,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'formats multiple cost values correctly', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />
@@ -157,7 +157,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'handles invalid cost values gracefully', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />
@@ -171,7 +171,7 @@ describe( 'EventCost Component', () => {
 	} );
 
 	it( 'updates currency symbol and position correctly', async () => {
-		const registry = await createRegistry();
+		const registry = getRegistry();
 		const { container } = render(
 			<RegistryProvider value={ registry }>
 				<EventCost />

--- a/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
+++ b/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
@@ -18,10 +18,10 @@ jest.mock( '@wordpress/data', () => {
 			_EventCurrencyPosition: 'prefix',
 		},
 		editPost: jest.fn( ( { meta } ) => {
-            if ( meta ) {
-                mockState.meta = { ...mockState.meta, ...meta };
-            }
-        } ),
+			if ( meta ) {
+				mockState.meta = { ...mockState.meta, ...meta };
+			}
+		} ),
 	};
 
 	const mockSelect = ( storeName: string ) => {
@@ -138,7 +138,7 @@ describe( 'EventCost Component', () => {
 
 		// Initially, the input should not be disabled
 		expect( ( costInput as HTMLInputElement ).disabled ).toBe( false );
-        expect( ( costInput as HTMLInputElement ).value ).toBe( '' );
+		expect( ( costInput as HTMLInputElement ).value ).toBe( '' );
 		await userEvent.click( freeToggle );
 
 		// Wait for the state to update
@@ -165,8 +165,8 @@ describe( 'EventCost Component', () => {
 
 		const costInput = screen.getByLabelText( 'Event cost' );
 		await userEvent.type( costInput, '10.50' );
-        // click outside the input to trigger the change
-        await userEvent.click( document.body );
+		// click outside the input to trigger the change
+		await userEvent.click( document.body );
 
 		expect( container ).toMatchSnapshot();
 	} );

--- a/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
+++ b/tests/classy_jest/fields/EventCost/EventCost.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { RegistryProvider } from '@wordpress/data';
@@ -8,28 +8,31 @@ import EventCost from '../../../../src/resources/packages/classy/fields/EventCos
 import { Currency } from '@tec/common/classy/types/Currency';
 import { CurrencyPosition } from '@tec/common/classy/types/CurrencyPosition';
 
-type Selector = {
-	'core/editor': {
-		getEditedPostAttribute: ( attribute: string ) => any;
-	};
-	'tec/classy': {
-		getDefaultCurrency: () => Currency;
-	};
-};
-
 // Mock WordPress data store
 jest.mock( '@wordpress/data', () => {
+	// Mock state inside the mock function to avoid hoisting issues
+	const mockState = {
+		meta: {
+			_EventCost: '',
+			_EventCurrencySymbol: '$',
+			_EventCurrencyPosition: 'prefix',
+		},
+		editPost: jest.fn( ( { meta } ) => {
+            if ( meta ) {
+                mockState.meta = { ...mockState.meta, ...meta };
+            }
+        } ),
+	};
+
 	const mockSelect = ( storeName: string ) => {
 		if ( storeName === 'core/editor' ) {
 			return {
-				getEditedPostAttribute: () => ( {
-					meta: {
-						tribe_event_cost: '',
-						tribe_event_currency_symbol: '$',
-						tribe_event_currency_position: 'prefix',
-						tribe_event_is_free: false,
-					},
-				} ),
+				getEditedPostAttribute: ( attribute: string ) => {
+					if ( attribute === 'meta' ) {
+						return mockState.meta;
+					}
+					return null;
+				},
 			};
 		}
 		if ( storeName === 'tec/classy' ) {
@@ -47,7 +50,7 @@ jest.mock( '@wordpress/data', () => {
 	const mockDispatch = ( storeName: string ) => {
 		if ( storeName === 'core/editor' ) {
 			return {
-				editPost: jest.fn(),
+				editPost: mockState.editPost,
 			};
 		}
 		return {};
@@ -57,6 +60,7 @@ jest.mock( '@wordpress/data', () => {
 		useSelect: ( callback: ( select: typeof mockSelect ) => any ) => callback( mockSelect ),
 		useDispatch: ( storeName: string ) => mockDispatch( storeName ),
 		RegistryProvider: ( { children } ) => children,
+		__mockState: mockState, // Expose for testing
 	};
 } );
 
@@ -96,11 +100,18 @@ describe( 'EventCost Component', () => {
 		[ 'tribe_event_cost' ]: '',
 		[ 'tribe_event_currency_symbol' ]: '$',
 		[ 'tribe_event_currency_position' ]: 'prefix',
-		[ 'tribe_event_is_free' ]: false,
 	};
 
 	beforeEach( () => {
 		jest.resetAllMocks();
+		// Reset the mock meta state
+		const mockData = jest.requireMock( '@wordpress/data' ) as any;
+		mockData.__mockState.meta = {
+			_EventCost: '',
+			_EventCurrencySymbol: '$',
+			_EventCurrencyPosition: 'prefix',
+		};
+		mockData.__mockState.editPost.mockClear();
 	} );
 
 	it( 'renders correctly with default props', async () => {
@@ -123,7 +134,23 @@ describe( 'EventCost Component', () => {
 		);
 
 		const freeToggle = screen.getByLabelText( 'Event is free' );
+		const costInput = screen.getByLabelText( 'Event cost' );
+
+		// Initially, the input should not be disabled
+		expect( ( costInput as HTMLInputElement ).disabled ).toBe( false );
+        expect( ( costInput as HTMLInputElement ).value ).toBe( '' );
 		await userEvent.click( freeToggle );
+
+		// Wait for the state to update
+		await waitFor( () => {
+			// After clicking free toggle, the input should be disabled and show "Free"
+			expect( ( costInput as HTMLInputElement ).disabled ).toBe( true );
+			expect( ( costInput as HTMLInputElement ).value ).toBe( 'Free' );
+		} );
+
+		// Should also call editPost with meta value of '0' for free
+		const mockData = jest.requireMock( '@wordpress/data' ) as any;
+		expect( mockData.__mockState.editPost ).toHaveBeenCalledWith( { meta: { _EventCost: '0' } } );
 
 		expect( container ).toMatchSnapshot();
 	} );

--- a/tests/classy_jest/fields/EventCost/__snapshots__/EventCost.spec.tsx.snap
+++ b/tests/classy_jest/fields/EventCost/__snapshots__/EventCost.spec.tsx.snap
@@ -57,7 +57,7 @@ exports[`EventCost Component formats multiple cost values correctly 1`] = `
       >
         <input
           aria-label="Event cost"
-          value="10.50, 20.75, 15.25"
+          value="$10.50"
         />
       </div>
     </div>
@@ -100,7 +100,7 @@ exports[`EventCost Component formats single cost value correctly 1`] = `
       >
         <input
           aria-label="Event cost"
-          value="10.50"
+          value="$10.50"
         />
       </div>
     </div>

--- a/tests/classy_jest/fields/EventCost/__snapshots__/EventCost.spec.tsx.snap
+++ b/tests/classy_jest/fields/EventCost/__snapshots__/EventCost.spec.tsx.snap
@@ -39,7 +39,7 @@ exports[`EventCost Component displays "Free" when event is free 1`] = `
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;
@@ -82,7 +82,7 @@ exports[`EventCost Component formats multiple cost values correctly 1`] = `
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;
@@ -125,7 +125,7 @@ exports[`EventCost Component formats single cost value correctly 1`] = `
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;
@@ -168,7 +168,7 @@ exports[`EventCost Component handles invalid cost values gracefully 1`] = `
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;
@@ -211,7 +211,7 @@ exports[`EventCost Component renders correctly with default props 1`] = `
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;
@@ -254,7 +254,7 @@ exports[`EventCost Component updates currency symbol and position correctly 1`] 
   <div
     class="classy-field__input-note"
   >
-    If multiple entry prices are available, list each price separated by commas.
+    If multiple entry prices are available, list each price separated by dashes.
   </div>
 </div>
 `;

--- a/tests/classy_jest/functions/renderFields.spec.tsx
+++ b/tests/classy_jest/functions/renderFields.spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, jest } from '@jest/globals';
 import renderFields from '../../../src/resources/packages/classy/functions/renderFields.tsx';
 import { RegistryProvider } from '@wordpress/data';
-import { createRegistry } from '@tec/common/classy/store';
+import { getRegistry } from '@tec/common/classy/store';
 
 describe( 'renderFields', () => {
 	beforeEach( () => {
@@ -16,7 +16,7 @@ describe( 'renderFields', () => {
 
 	it( 'renders nothing if post is not Event', async () => {
 		// Create the Classy registry; this will register the default stores as well.
-		const registry = await createRegistry();
+		const registry = getRegistry();
 
 		// Render the component inside a RegistryProvider.
 		const { container } = render(


### PR DESCRIPTION
### 🗒️ Description
* Fixed an issue where setting offset timezones i.e `UTC+6` were not updating the date UTC value and hence not showing the Event in FE.
* Fixed saving `Free` value on toggle properly for Event Cost block.
* Removed redundant `update_cost` method, the cost value is properly updated with REST already.
* Switched to handling `-` instead of `,`  for cost range to keep backwards compatibility.
* Updated tests for JEST and integration.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
 🎥 screencast(s): https://www.loom.com/share/909def4a61524c2ea8130f803e34f1c2
