### PR TITLE
Classy - rework store types

### DIFF
--- a/src/resources/packages/classy/fields/EventAdmission/EventAdmission.tsx
+++ b/src/resources/packages/classy/fields/EventAdmission/EventAdmission.tsx
@@ -7,11 +7,13 @@ import { FieldProps } from '@tec/common/classy/types/FieldProps.ts';
 import { IconTicket } from '@tec/common/classy/components';
 import { EventCost } from '../EventCost';
 import clsx from 'clsx';
+import { StoreSelect } from '../../types/Store';
 
 export default function EventAdmission( props: FieldProps ) {
 	// Initially select and subscribe to the store that will control whether tickets are supported or not.
-	const areTicketsSupported: boolean = useSelect( ( select: Function ) => {
-		return select( 'tec/classy/events' ).areTicketsSupported();
+	const areTicketsSupported: boolean = useSelect( ( select ) => {
+		const tecStore: StoreSelect = select( 'tec/classy/events' );
+		return tecStore.areTicketsSupported();
 	}, [] );
 
 	// The initial value depends on whether tickets are supported or not.

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
-import {useEffect} from 'react';
-import {RefObject, useCallback, useMemo, useRef, useState} from '@wordpress/element';
-import {useDispatch, useSelect} from '@wordpress/data';
-import {Hours} from '@tec/common/classy/types/Hours';
-import {Minutes} from '@tec/common/classy/types/Minutes';
-import {DateTimeUpdateType, DateUpdateType, FieldProps} from '@tec/common/classy/types/FieldProps';
-import {ToggleControl} from '@wordpress/components';
-import {_x} from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { RefObject, useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { Hours } from '@tec/common/classy/types/Hours';
+import { Minutes } from '@tec/common/classy/types/Minutes';
+import { DateTimeUpdateType, DateUpdateType, FieldProps } from '@tec/common/classy/types/FieldProps';
+import { ToggleControl } from '@wordpress/components';
+import { _x } from '@wordpress/i18n';
 import {
 	METADATA_EVENT_ALLDAY,
 	METADATA_EVENT_END_DATE,
 	METADATA_EVENT_START_DATE,
 	METADATA_EVENT_TIMEZONE,
 } from '../../constants';
-import {format} from '@wordpress/date';
-import {EndSelector, StartSelector, TimeZone} from '@tec/common/classy/components';
-import {StoreSelect} from '../../types/Store';
-import {addFilter, removeFilter} from '@wordpress/hooks';
-import {areDatesOnSameDay, areDatesOnSameTime} from '@tec/common/classy/functions';
+import { format } from '@wordpress/date';
+import { EndSelector, StartSelector, TimeZone } from '@tec/common/classy/components';
+import { StoreSelect } from '../../types/Store';
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { areDatesOnSameDay, areDatesOnSameTime } from '@tec/common/classy/functions';
 
 type DateTimeRefs = {
 	endTimeHours: number;

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -1,23 +1,23 @@
 import * as React from 'react';
-import { RefObject, useCallback, useMemo, useRef, useState } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { Hours } from '@tec/common/classy/types/Hours';
-import { Minutes } from '@tec/common/classy/types/Minutes';
-import { DateTimeUpdateType, DateUpdateType, FieldProps } from '@tec/common/classy/types/FieldProps';
-import { ToggleControl } from '@wordpress/components';
-import { _x } from '@wordpress/i18n';
+import {useEffect} from 'react';
+import {RefObject, useCallback, useMemo, useRef, useState} from '@wordpress/element';
+import {useDispatch, useSelect} from '@wordpress/data';
+import {Hours} from '@tec/common/classy/types/Hours';
+import {Minutes} from '@tec/common/classy/types/Minutes';
+import {DateTimeUpdateType, DateUpdateType, FieldProps} from '@tec/common/classy/types/FieldProps';
+import {ToggleControl} from '@wordpress/components';
+import {_x} from '@wordpress/i18n';
 import {
 	METADATA_EVENT_ALLDAY,
 	METADATA_EVENT_END_DATE,
 	METADATA_EVENT_START_DATE,
 	METADATA_EVENT_TIMEZONE,
 } from '../../constants';
-import { format } from '@wordpress/date';
-import { TimeZone, StartSelector, EndSelector } from '@tec/common/classy/components';
-import { EventDateTimeDetails } from '../../types/EventDateTimeDetails';
-import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useEffect } from 'react';
-import { areDatesOnSameDay, areDatesOnSameTime } from '@tec/common/classy/functions';
+import {format} from '@wordpress/date';
+import {EndSelector, StartSelector, TimeZone} from '@tec/common/classy/components';
+import {StoreSelect} from '../../types/Store';
+import {addFilter, removeFilter} from '@wordpress/hooks';
+import {areDatesOnSameDay, areDatesOnSameTime} from '@tec/common/classy/functions';
 
 type DateTimeRefs = {
 	endTimeHours: number;
@@ -246,11 +246,9 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 		startOfWeek,
 		timeFormat,
 	} = useSelect( ( select ) => {
-		const { getEventDateTimeDetails }: { getEventDateTimeDetails: () => EventDateTimeDetails } =
-			select( 'tec/classy/events' );
-		const { isNewEvent }: { isNewEvent: () => boolean } = select( 'tec/classy/events' );
+		const tecStore: StoreSelect = select( 'tec/classy/events' );
 
-		return { ...getEventDateTimeDetails(), isNewEvent: isNewEvent() };
+		return { ...tecStore.getEventDateTimeDetails(), isNewEvent: tecStore.isNewEvent() };
 	}, [] );
 
 	useEffect( (): void => {

--- a/src/resources/packages/classy/fields/EventLocation/EventLocation.tsx
+++ b/src/resources/packages/classy/fields/EventLocation/EventLocation.tsx
@@ -13,6 +13,7 @@ import { METADATA_EVENT_VENUE_ID } from '../../constants';
 import { VenueData } from '../../types/VenueData';
 import VenueUpsertModal from './VenueUpsertModal.tsx';
 import { fetchVenues, upsertVenue } from '../../api';
+import { StoreSelect } from '../../types/Store';
 
 function buildOptionFromFetchedVenue( venue: FetchedVenue ): CustomSelectOption {
 	return {
@@ -50,9 +51,7 @@ export default function EventLocation( props: FieldProps ) {
 			const editorStore: {
 				getEditedPostAttribute: ( attribute: string ) => any;
 			} = select( 'core/editor' );
-			const classyStore: {
-				getVenuesLimit: () => number;
-			} = select( 'tec/classy/events' );
+			const classyStore: StoreSelect = select( 'tec/classy/events' );
 
 			const meta = editorStore.getEditedPostAttribute( 'meta' ) || null;
 			const venuesLimit = classyStore.getVenuesLimit() || 1;

--- a/src/resources/packages/classy/store/reducer.ts
+++ b/src/resources/packages/classy/store/reducer.ts
@@ -1,5 +1,5 @@
 import { Action } from '@tec/common/classy/types/Actions';
-import { StoreState } from '../types/StoreState';
+import { StoreState } from '../types/Store';
 
 export const reducer = ( state: StoreState, action: Action ) => {
 	return state;

--- a/src/resources/packages/classy/store/selectors.ts
+++ b/src/resources/packages/classy/store/selectors.ts
@@ -3,7 +3,7 @@ import { EventMeta } from '../types/EventMeta';
 import { Settings } from '@tec/common/classy/types/LocalizedData';
 import { getDate } from '@wordpress/date';
 import { METADATA_EVENT_ORGANIZER_ID, METADATA_EVENT_VENUE_ID } from '../constants';
-import { StoreState } from '../types/StoreState';
+import { StoreState } from '../types/Store';
 import { TECSettings } from '../types/Settings';
 import { EventDateTimeDetails } from '../types/EventDateTimeDetails';
 

--- a/src/resources/packages/classy/types/Store.d.ts
+++ b/src/resources/packages/classy/types/Store.d.ts
@@ -1,6 +1,6 @@
-import {TECSettings} from './Settings';
-import {EventMeta} from "./EventMeta";
-import {EventDateTimeDetails} from "./EventDateTimeDetails";
+import { TECSettings } from './Settings';
+import { EventMeta } from './EventMeta';
+import { EventDateTimeDetails } from './EventDateTimeDetails';
 
 export type StoreState = {
 	areTicketsSupported?: boolean;
@@ -20,9 +20,9 @@ export type StoreSelect = {
 	getEventDateTimeDetails: () => EventDateTimeDetails;
 	getEditedPostOrganizerIds: () => number[];
 	getEditedPostVenueIds: () => number[];
-	areTicketsSupported: (state: StoreState) => boolean;
+	areTicketsSupported: ( state: StoreState ) => boolean;
 	isNewEvent: () => boolean;
-	getVenuesLimit: () => number
+	getVenuesLimit: () => number;
 };
 
 /**
@@ -33,5 +33,4 @@ export type StoreSelect = {
  * const tecStore: StoreDispatch = dispatch('tec/classy/events');
  * ```
  */
-export type StoreDispatch = {
-};
+export type StoreDispatch = {};

--- a/src/resources/packages/classy/types/Store.d.ts
+++ b/src/resources/packages/classy/types/Store.d.ts
@@ -1,0 +1,37 @@
+import {TECSettings} from './Settings';
+import {EventMeta} from "./EventMeta";
+import {EventDateTimeDetails} from "./EventDateTimeDetails";
+
+export type StoreState = {
+	areTicketsSupported?: boolean;
+};
+
+/**
+ * The type that should be assigned to the return value of the `select('tec/classy/events')` call.
+ *
+ * @example
+ * ```
+ * const tecStore: StoreSelect = select('tec/classy/events');
+ * ```
+ */
+export type StoreSelect = {
+	getSettings: () => TECSettings;
+	getPostMeta: () => EventMeta;
+	getEventDateTimeDetails: () => EventDateTimeDetails;
+	getEditedPostOrganizerIds: () => number[];
+	getEditedPostVenueIds: () => number[];
+	areTicketsSupported: (state: StoreState) => boolean;
+	isNewEvent: () => boolean;
+	getVenuesLimit: () => number
+};
+
+/**
+ * The type that should be assigned to the return value of the `dispatch('tec/classy/events')` call.
+ *
+ * @example
+ * ```
+ * const tecStore: StoreDispatch = dispatch('tec/classy/events');
+ * ```
+ */
+export type StoreDispatch = {
+};

--- a/src/resources/packages/classy/types/StoreState.d.ts
+++ b/src/resources/packages/classy/types/StoreState.d.ts
@@ -1,3 +1,0 @@
-export type StoreState = {
-	areTicketsSupported?: boolean;
-};


### PR DESCRIPTION
This PR updates the types defined for the TEC Classy store to provide the `StoreSelect` and `StoreDispatch` types similarly to what is done in the Common Classy package.
