### PR TITLE
Classy - fix issue 20

### DIFF
--- a/src/Tribe/Admin/Event_Meta_Box.php
+++ b/src/Tribe/Admin/Event_Meta_Box.php
@@ -414,6 +414,10 @@ class Tribe__Events__Admin__Event_Meta_Box {
 			return;
 		}
 
+		if ( tec_using_classy_editor() ) {
+			return;
+		}
+
 		$show_box = tribe_get_option( 'disable_metabox_custom_fields' );
 
 		if ( ! tribe_is_truthy( $show_box ) ) {

--- a/tests/classy_integration/Tribe/Events/Admin/Event_Meta_Box_Test.php
+++ b/tests/classy_integration/Tribe/Events/Admin/Event_Meta_Box_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tribe\Events\Admin;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe__Events__Main as TEC;
+
+/**
+ * This test method covers the class behavior in  scenario where Classy is active by default.
+ *
+ * @covers Tribe__Events__Admin__Event_Meta_Box
+ */
+class Event_Meta_Box_Test extends WPTestCase {
+	/**
+	 * @covers Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox
+	 */
+	public function test_display_wp_custom_fields_metabox_when_using_classy(): void {
+		tribe( 'tec.admin.event-meta-box' )->display_wp_custom_fields_metabox();
+		$post_type_supports = get_post_types_by_support( 'custom-fields' );
+
+		$this->assertContains( TEC::POSTTYPE, $post_type_supports );
+	}
+
+	/**
+	 * @covers Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox
+	 */
+	public function test_display_wp_custom_fields_metabox_without_classy(): void {
+		add_filter( 'tec_using_classy_editor', '__return_false' );
+		// Re-register the post type to make sure the filter is applied.
+		TEC::instance()->registerPostType();
+
+		tribe( 'tec.admin.event-meta-box' )->display_wp_custom_fields_metabox();
+		$post_type_supports = get_post_types_by_support( 'custom-fields' );
+
+		$this->assertNotContains( TEC::POSTTYPE, $post_type_supports );
+	}
+}

--- a/tests/integration/Tribe/Events/Admin/Event_Meta_Box_Test.php
+++ b/tests/integration/Tribe/Events/Admin/Event_Meta_Box_Test.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tribe\Events\Admin;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe__Events__Main as TEC;
+
+/**
+ * This test method covers the class behavior in the default integration scenario, where Classy might or might not be
+ * activated by default.
+ *
+ * @covers Tribe__Events__Admin__Event_Meta_Box
+ */
+class Event_Meta_Box_Test extends WPTestCase {
+	/**
+	 * @var object
+	 */
+	private ?object $original_editor = null;
+
+	/**
+	 * @before
+	 */
+	public function setup_editor_mocks(): void {
+		$this->original_editor = tribe( 'editor' );
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_editor_binding(): void {
+		if ( $this->original_editor === null ) {
+			return;
+		}
+
+		tribe()->singleton( 'editor', $this->original_editor );
+	}
+
+	/**
+	 * @covers Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox
+	 */
+	public function test_display_wp_custom_fields_metabox_when_using_blocks(): void {
+		// Depending on whether Classy is loaded by default or not, we cannot know in advance the filters controlling this.
+		tribe()->singleton( 'editor',
+			new class {
+				public function should_load_blocks(): bool {
+					return true;
+				}
+			}
+		);
+		add_filter( 'tec_using_classy_editor', '__return_false' );
+		// Re-register the post type to make sure the filter is applied.
+		TEC::instance()->registerPostType();
+
+		tribe( 'tec.admin.event-meta-box' )->display_wp_custom_fields_metabox();
+		$post_type_supports = get_post_types_by_support( 'custom-fields' );
+
+		$this->assertContains( TEC::POSTTYPE, $post_type_supports );
+	}
+
+	/**
+	 * @covers Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox
+	 */
+	public function test_display_wp_custom_fields_metabox_when_using_classy(): void {
+		// Depending on whether Classy is loaded by default or not, we cannot know in advance the filters controlling this.
+		tribe()->singleton( 'editor',
+			new class {
+				public function should_load_blocks(): bool {
+					return false;
+				}
+			}
+		);
+		add_filter( 'tec_using_classy_editor', '__return_true' );
+		// Re-register the post type to make sure the filter is applied.
+		TEC::instance()->registerPostType();
+
+		tribe( 'tec.admin.event-meta-box' )->display_wp_custom_fields_metabox();
+		$post_type_supports = get_post_types_by_support( 'custom-fields' );
+
+		$this->assertContains( TEC::POSTTYPE, $post_type_supports );
+	}
+
+	/**
+	 * @covers Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox
+	 */
+	public function test_display_wp_custom_fields_metabox_using_neither_block_editor_nor_classy(): void {
+		// Depending on whether Classy is loaded by default or not, we cannot know in advance the filters controlling this.
+		tribe()->singleton( 'editor',
+			new class {
+				public function should_load_blocks(): bool {
+					return false;
+				}
+			}
+		);
+		add_filter( 'tec_using_classy_editor', '__return_false' );
+		// Re-register the post type to make sure the filter is applied.
+		TEC::instance()->registerPostType();
+
+		tribe( 'tec.admin.event-meta-box' )->display_wp_custom_fields_metabox();
+		$post_type_supports = get_post_types_by_support( 'custom-fields' );
+
+		$this->assertNotContains( TEC::POSTTYPE, $post_type_supports );
+	}
+}


### PR DESCRIPTION
This adds a check on the method that would remove the `custom-fields` support from the Events post type if not using the Block Editor to keep it when using Classy.  

The `custom-fields` support is required to correctly process Event meta updates during saves in new installations.

**Issue**
When saving data through the REST API (as the Block Editor and Classy do), meta fields must be registered using the `register_post_meta` function (already handled in the `Classy\Meta` controller) ...
... And the post type must support `custom-fields`.

By default, the `Tribe__Events__Main::registerPostType` method already registers the Event post type with `custom-fields` support.

To avoid custom fields, enabled by the `custom-fields` support, to show uncontrolled to the user in the context of the Classic Editor metabox, the `Tribe__Events__Admin__Event_Meta_Box::display_wp_custom_fields_metabox` would remove the `custom-fields` support from the Event post if not using the Block Editor (subject to an option, but irrelevant for the issue at hand).

Classy overtakes the Block Editor feature detection logic by short-circuiting some checks to prevent the legacy Block Editor loading.
One of thos short-circuits would mark the site as **not** using the Block Editor: correct in most instances, but not here.

**Solution**
Add a guard that will behave the same way (**not** removing the `custom-fields` support) when using Classy.

Artifacts: 
* tests in the `integration` and `classy_integration` suites
* [demo](https://share.cleanshot.com/6hGX9d36)
