### PR TITLE
Fix transform_entity filter chain in REST API

### DIFF
--- a/src/Events/REST/TEC/V1/Traits/With_Transform_Organizers_And_Venues.php
+++ b/src/Events/REST/TEC/V1/Traits/With_Transform_Organizers_And_Venues.php
@@ -33,6 +33,9 @@ trait With_Transform_Organizers_And_Venues {
 	 * @return array
 	 */
 	protected function transform_entity( array $entity ): array {
+		// First, call the parent transform_entity method to apply filters like occurrence ID transformation.
+		$entity = parent::transform_entity( $entity );
+
 		if ( ! empty( $entity['organizers'] ) ) {
 			$organizers           = tribe( Organizers::class );
 			$entity['organizers'] = array_map( fn ( WP_Post $organizer ) => $organizers->get_formatted_entity( $organizer ), $entity['organizers']->all() );


### PR DESCRIPTION
- Call parent::transform_entity() first in With_Transform_Organizers_And_Venues trait
- This ensures occurrence ID transformation filters are applied before venue/organizer transformations
- Fixes issue where occurrence IDs were returned instead of real post IDs
- Critical for proper database relationships between events, tickets, and other entities

Previously, the trait was overriding transform_entity() without calling the parent method that applies the tec_rest_v1_tribe_events_transform_entity filter, breaking the occurrence ID to post ID transformation.

See: https://github.com/the-events-calendar/events-pro/pull/2822