### PR TITLE
Fix - Start Time picker should show all options.

### DIFF
--- a/src/resources/packages/classy/fields/EventAdmission/EventAdmission.tsx
+++ b/src/resources/packages/classy/fields/EventAdmission/EventAdmission.tsx
@@ -52,14 +52,10 @@ export default function EventAdmission( props: FieldProps ) {
 				) }
 
 				{ /* Provide a slot for tickets to render their fields. */ }
-				{ isUsingTickets && (
-					<Slot name="tec.classy.fields.tickets" />
-				) }
+				{ isUsingTickets && <Slot name="tec.classy.fields.tickets" /> }
 
 				{ /* When not using tickets, render the EventCost component. */ }
-				{ ! isUsingTickets && (
-					<EventCost />
-				) }
+				{ ! isUsingTickets && <EventCost /> }
 			</div>
 		</div>
 	);

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -343,8 +343,7 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 		isSelectingDate,
 		startOfWeek,
 		timeFormat,
-        dates.start,
-        dates.end, // Watch end date changes as they can affect start time
+        dates,
 	] );
 
 	const endSelector = useMemo( () => {
@@ -366,11 +365,9 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 		);
 	}, [
 		dateWithYearFormat,
-		endDateIsoString,
 		isAllDayValue,
 		isMultidayValue,
 		isSelectingDate,
-		startDateIsoString,
 		startOfWeek,
 		timeFormat,
 		dates,

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -62,7 +62,7 @@ function getNewStartEndDates(
 	try {
 		switch ( updated ) {
 			case 'startDate':
-				newStartDate.setDate( new Date( newDate ).getDate());
+				newStartDate.setDate( new Date( newDate ).getDate() );
 
 				// If not multiday update end date with original duration.
 				if ( ! isMultiday ) {
@@ -336,15 +336,7 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 				timeFormat={ timeFormat }
 			/>
 		);
-	}, [
-		dateWithYearFormat,
-		isAllDayValue,
-		isMultidayValue,
-		isSelectingDate,
-		startOfWeek,
-		timeFormat,
-        dates,
-	] );
+	}, [ dateWithYearFormat, isAllDayValue, isMultidayValue, isSelectingDate, startOfWeek, timeFormat, dates ] );
 
 	const endSelector = useMemo( () => {
 		return (
@@ -363,15 +355,7 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 				timeFormat={ timeFormat }
 			/>
 		);
-	}, [
-		dateWithYearFormat,
-		isAllDayValue,
-		isMultidayValue,
-		isSelectingDate,
-		startOfWeek,
-		timeFormat,
-		dates,
-	] );
+	}, [ dateWithYearFormat, isAllDayValue, isMultidayValue, isSelectingDate, startOfWeek, timeFormat, dates ] );
 
 	const onMultiDayToggleChange = useCallback(
 		( newValue: boolean ) => {

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -323,7 +323,7 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 		return (
 			<StartSelector
 				dateWithYearFormat={ dateWithYearFormat }
-				endDate={ endDate }
+				endDate={ null }
 				highlightTime={ highlightStartTime }
 				isAllDay={ isAllDayValue }
 				isMultiday={ isMultidayValue }

--- a/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
+++ b/src/resources/packages/classy/fields/EventDateTime/EventDateTime.tsx
@@ -338,14 +338,13 @@ export default function EventDateTime( props: FieldProps ): JSX.Element {
 		);
 	}, [
 		dateWithYearFormat,
-		endDateIsoString,
 		isAllDayValue,
 		isMultidayValue,
 		isSelectingDate,
-		startDateIsoString,
 		startOfWeek,
 		timeFormat,
-        dates,
+        dates.start,
+        dates.end, // Watch end date changes as they can affect start time
 	] );
 
 	const endSelector = useMemo( () => {


### PR DESCRIPTION
* Updated StartSelector to always show all time options and not be limited by end time.

Screencast: https://share.cleanshot.com/tjyjGCJC