### PR TITLE
tweak: rename parameter to argument

### DIFF
--- a/docs/REST/TEC/V1/creating-endpoints.md
+++ b/docs/REST/TEC/V1/creating-endpoints.md
@@ -90,7 +90,7 @@ class MyEntity extends Post_Entity_Endpoint implements RUD_Endpoint {
     }
 
     // Implement read(), update(), delete() methods with array $params
-    // Implement read_args(), update_args(), delete_args() methods
+    // Implement read_params(), update_params(), delete_params() methods
     // Implement read_schema(), update_schema(), delete_schema() methods
 }
 ```
@@ -112,7 +112,7 @@ public function read( array $params = [] ): WP_REST_Response {
     return new WP_REST_Response( $this->get_formatted_entity( $entity ), 200 );
 }
 
-public function read_args(): QueryArgumentCollection {
+public function read_params(): QueryArgumentCollection {
     $collection = new QueryArgumentCollection();
 
     // Path parameters are defined separately
@@ -138,7 +138,7 @@ public function read_schema(): OpenAPI_Schema {
         fn() => __( 'Returns a single entity', 'text-domain' ),
         'getEntity',
         [ tribe( TEC_Tag::class ) ],
-        $this->read_args()
+        $this->read_params()
     );
 
     // Add responses
@@ -167,12 +167,12 @@ public function create( array $params = [] ): WP_REST_Response {
 }
 
 // Use RequestBodyCollection for POST/PUT operations
-public function create_args(): RequestBodyCollection {
+public function create_params(): RequestBodyCollection {
     $collection = new RequestBodyCollection();
     $definition = new MyEntity_Request_Body_Definition();
-    
+
     $collection[] = new Definition_Parameter($definition);
-    
+
     return $collection
         ->set_description_provider(fn() => __('Entity data to create', 'text-domain'))
         ->set_required(true)
@@ -217,13 +217,13 @@ Define your endpoint's parameters based on the operation:
 ### For GET/DELETE Operations (Query Parameters)
 
 ```php
-public function read_args(): QueryArgumentCollection {
+public function read_params(): QueryArgumentCollection {
     $collection = new QueryArgumentCollection();
 
     $collection->add(
         new Positive_Integer('page', fn() => __('Page number', 'text-domain'), 1, 1)
     );
-    
+
     $collection->add(
         new Text('search', fn() => __('Search term', 'text-domain'))
     );
@@ -235,13 +235,13 @@ public function read_args(): QueryArgumentCollection {
 ### For POST/PUT Operations (Request Body)
 
 ```php
-public function create_args(): RequestBodyCollection {
+public function create_params(): RequestBodyCollection {
     $collection = new RequestBodyCollection();
-    
+
     // Use Definition_Parameter for complex objects
     $definition = new MyEntity_Request_Body_Definition();
     $collection[] = new Definition_Parameter($definition);
-    
+
     return $collection
         ->set_description_provider(fn() => __('Entity data', 'text-domain'))
         ->set_required(true)
@@ -270,7 +270,7 @@ class MyEntity_Request_Body_Definition extends Definition {
             ],
         ];
     }
-    
+
     public function get_example(): array {
         return [
             'title' => 'Example Entity',

--- a/docs/REST/TEC/V1/definitions.md
+++ b/docs/REST/TEC/V1/definitions.md
@@ -84,7 +84,7 @@ Key properties:
 
 [Full Documentation](definitions/organizer.md)
 
-**Extends**: `TEC_Post_Entity` (via allOf pattern)  
+**Extends**: `TEC_Post_Entity` (via allOf pattern)
 **Priority**: 2
 
 Key properties (in addition to base entity):
@@ -97,7 +97,7 @@ Key properties (in addition to base entity):
 
 [Full Documentation](definitions/venue.md)
 
-**Extends**: `TEC_Post_Entity` (via allOf pattern)  
+**Extends**: `TEC_Post_Entity` (via allOf pattern)
 **Priority**: 3
 
 Key properties (in addition to base entity):
@@ -154,7 +154,7 @@ public function read_schema(): OpenAPI_Schema {
         fn() => __( 'Returns a single event', 'the-events-calendar' ),
         'getEvent',
         [ tribe( TEC_Tag::class ) ],
-        $this->read_args()
+        $this->read_params()
     );
 
     $response = new Definition_Parameter( new Event_Definition() );

--- a/src/Events/REST/TEC/V1/Endpoints/Event.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Event.php
@@ -153,7 +153,7 @@ class Event extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		return new QueryArgumentCollection();
 	}
 
@@ -200,7 +200,7 @@ class Event extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function update_args(): RequestBodyCollection {
+	public function update_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Event_Request_Body_Definition();
@@ -236,7 +236,7 @@ class Event extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_tags(),
 			$this->get_path_parameters(),
 			null,
-			$this->update_args(),
+			$this->update_params(),
 			true
 		);
 
@@ -292,7 +292,7 @@ class Event extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_operation_id( 'delete' ),
 			$this->get_tags(),
 			$this->get_path_parameters(),
-			$this->delete_args(),
+			$this->delete_params(),
 			null,
 			true
 		);

--- a/src/Events/REST/TEC/V1/Endpoints/Events.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Events.php
@@ -144,7 +144,7 @@ class Events extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 			$this->get_operation_id( 'read' ),
 			$this->get_tags(),
 			null,
-			$this->read_args()
+			$this->read_params()
 		);
 
 		$headers_collection = new HeadersCollection();
@@ -213,7 +213,7 @@ class Events extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		$collection = new QueryArgumentCollection();
 
 		$collection[] = new Positive_Integer(
@@ -342,7 +342,7 @@ class Events extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 		 * @param QueryArgumentCollection $collection The collection of arguments.
 		 * @param Events                  $this       The events endpoint.
 		 */
-		return apply_filters( 'tec_events_rest_v1_events_read_args', $collection, $this );
+		return apply_filters( 'tec_events_rest_v1_events_read_params', $collection, $this );
 	}
 
 	/**
@@ -353,7 +353,7 @@ class Events extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function create_args(): RequestBodyCollection {
+	public function create_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Event_Request_Body_Definition();
@@ -381,7 +381,7 @@ class Events extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 			$this->get_tags(),
 			null,
 			null,
-			$this->create_args(),
+			$this->create_params(),
 			true
 		);
 

--- a/src/Events/REST/TEC/V1/Endpoints/Organizer.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Organizer.php
@@ -130,7 +130,7 @@ class Organizer extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		return new QueryArgumentCollection();
 	}
 
@@ -176,7 +176,7 @@ class Organizer extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function update_args(): RequestBodyCollection {
+	public function update_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Organizer_Request_Body_Definition();
@@ -204,7 +204,7 @@ class Organizer extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_tags(),
 			$this->get_path_parameters(),
 			null,
-			$this->update_args(),
+			$this->update_params(),
 			true
 		);
 
@@ -260,7 +260,7 @@ class Organizer extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_operation_id( 'delete' ),
 			$this->get_tags(),
 			$this->get_path_parameters(),
-			$this->delete_args(),
+			$this->delete_params(),
 			null,
 			true
 		);

--- a/src/Events/REST/TEC/V1/Endpoints/Organizers.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Organizers.php
@@ -138,7 +138,7 @@ class Organizers extends Post_Entity_Endpoint implements Readable_Endpoint, Crea
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		$collection = new QueryArgumentCollection();
 
 		$collection[] = new Positive_Integer(
@@ -202,7 +202,7 @@ class Organizers extends Post_Entity_Endpoint implements Readable_Endpoint, Crea
 			$this->get_operation_id( 'read' ),
 			$this->get_tags(),
 			null,
-			$this->read_args(),
+			$this->read_params(),
 		);
 
 		$headers_collection = new HeadersCollection();
@@ -272,7 +272,7 @@ class Organizers extends Post_Entity_Endpoint implements Readable_Endpoint, Crea
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function create_args(): RequestBodyCollection {
+	public function create_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Organizer_Request_Body_Definition();
@@ -300,7 +300,7 @@ class Organizers extends Post_Entity_Endpoint implements Readable_Endpoint, Crea
 			$this->get_tags(),
 			null,
 			null,
-			$this->create_args(),
+			$this->create_params(),
 			true
 		);
 

--- a/src/Events/REST/TEC/V1/Endpoints/Venue.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Venue.php
@@ -130,7 +130,7 @@ class Venue extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		return new QueryArgumentCollection();
 	}
 
@@ -176,7 +176,7 @@ class Venue extends Post_Entity_Endpoint implements RUD_Endpoint {
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function update_args(): RequestBodyCollection {
+	public function update_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Venue_Request_Body_Definition();
@@ -203,7 +203,7 @@ class Venue extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_tags(),
 			$this->get_path_parameters(),
 			null,
-			$this->update_args(),
+			$this->update_params(),
 			true
 		);
 
@@ -259,7 +259,7 @@ class Venue extends Post_Entity_Endpoint implements RUD_Endpoint {
 			$this->get_operation_id( 'delete' ),
 			$this->get_tags(),
 			$this->get_path_parameters(),
-			$this->delete_args(),
+			$this->delete_params(),
 			null,
 			true
 		);

--- a/src/Events/REST/TEC/V1/Endpoints/Venues.php
+++ b/src/Events/REST/TEC/V1/Endpoints/Venues.php
@@ -139,7 +139,7 @@ class Venues extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 	 *
 	 * @return QueryArgumentCollection
 	 */
-	public function read_args(): QueryArgumentCollection {
+	public function read_params(): QueryArgumentCollection {
 		$collection = new QueryArgumentCollection();
 
 		$collection[] = new Positive_Integer(
@@ -194,7 +194,7 @@ class Venues extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 		 * @param QueryArgumentCollection $collection The collection of arguments.
 		 * @param Venues                  $this       The venues endpoint.
 		 */
-		return apply_filters( 'tec_events_rest_v1_venues_read_args', $collection, $this );
+		return apply_filters( 'tec_events_rest_v1_venues_read_params', $collection, $this );
 	}
 
 	/**
@@ -211,7 +211,7 @@ class Venues extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 			$this->get_operation_id( 'read' ),
 			$this->get_tags(),
 			null,
-			$this->read_args(),
+			$this->read_params(),
 		);
 
 		$headers_collection = new HeadersCollection();
@@ -281,7 +281,7 @@ class Venues extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 	 *
 	 * @return RequestBodyCollection
 	 */
-	public function create_args(): RequestBodyCollection {
+	public function create_params(): RequestBodyCollection {
 		$collection = new RequestBodyCollection();
 
 		$definition = new Venue_Request_Body_Definition();
@@ -309,7 +309,7 @@ class Venues extends Post_Entity_Endpoint implements Readable_Endpoint, Creatabl
 			$this->get_tags(),
 			null,
 			null,
-			$this->create_args(),
+			$this->create_params(),
 			true
 		);
 


### PR DESCRIPTION
### 🎫 Ticket

No ticket ID found

### 🗒️ Description

This PR applies code review suggestions by renaming methods from `*_args()` to `*_params()` throughout the TEC REST API v1 endpoints for consistency and clarity.

**Type of changes:** Code improvement (non-breaking change which improves code clarity and consistency)

**Changes made:**
- Updated all REST API endpoint classes to use `*_params()` method naming instead of `*_args()`
- Affected endpoints: Events, Event, Venues, Venue, Organizers, Organizer
- Updated corresponding documentation to reflect the method name changes
- Updated filter names to maintain consistency (`tec_events_rest_v1_events_read_params`, `tec_events_rest_v1_venues_read_params`)

**Files changed:**
- `src/Events/REST/TEC/V1/Endpoints/Event.php`
- `src/Events/REST/TEC/V1/Endpoints/Events.php` 
- `src/Events/REST/TEC/V1/Endpoints/Organizer.php`
- `src/Events/REST/TEC/V1/Endpoints/Organizers.php`
- `src/Events/REST/TEC/V1/Endpoints/Venue.php`
- `src/Events/REST/TEC/V1/Endpoints/Venues.php`
- `docs/REST/TEC/V1/creating-endpoints.md`
- `docs/REST/TEC/V1/definitions.md`

This is a terminology standardization change that improves code readability by using "params" (parameters) instead of "args" (arguments) consistently across the REST API architecture. The functionality remains identical - only method names and related documentation have been updated.

### 🎥 Artifacts
Not applicable - no UI changes, purely internal method name refactoring.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.