### PR TITLE
TEC-4242 no subscribe on mobile js

### DIFF
--- a/changelog/fix-TEC-4242-no-subscribe-on-mobile-js
+++ b/changelog/fix-TEC-4242-no-subscribe-on-mobile-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Hide unsupported items from the Subscribe to Calendar dropdown. [TEC-4242]

--- a/changelog/fix-TEC-4242-no-subscribe-on-mobile-js
+++ b/changelog/fix-TEC-4242-no-subscribe-on-mobile-js
@@ -1,4 +1,4 @@
 Significance: minor
 Type: tweak
 
-Hide unsupported items from the Subscribe to Calendar dropdown. [TEC-4242]
+Hide unsupported items from the Subscribe to Calendar dropdown for archive pages. [TEC-4242]

--- a/src/resources/postcss/components/skeleton/_ical-link.pcss
+++ b/src/resources/postcss/components/skeleton/_ical-link.pcss
@@ -116,3 +116,19 @@
 		}
 	}
 }
+
+/* -----------------------------------------------------------------------------
+ *
+ * Hide items
+ *
+ * ----------------------------------------------------------------------------- */
+.tec-is-android.post-type-archive-tribe_events {
+
+	.tribe-events-c-subscribe-dropdown__list-item--gcal {
+    	display: none;
+	}
+
+	.tribe-events-c-subscribe-dropdown__list-item--ical {
+    	display: none;
+	}
+}

--- a/src/views/blocks/parts/subscribe-list.php
+++ b/src/views/blocks/parts/subscribe-list.php
@@ -47,7 +47,7 @@ $classes = isset( $attributes['className'] ) ? array_merge( $default_classes, [ 
 					<div id="tribe-events-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 						<ul class="tribe-events-c-subscribe-dropdown__list">
 							<?php foreach ( $items as $item ) : ?>
-								<li class="tribe-events-c-subscribe-dropdown__list-item">
+								<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--<?php echo esc_attr( $item->get_slug() ); ?>">
 									<a
 										href="<?php echo esc_url( $item->get_uri( null ) ); ?>"
 										class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/src/views/v2/components/subscribe-links/item.php
+++ b/src/views/v2/components/subscribe-links/item.php
@@ -27,7 +27,7 @@ if( ! $item->is_visible( $view ) ) {
 }
 ?>
 
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--<?php echo esc_attr( $item->get_slug() ); ?>">
 	<a
 		href="<?php echo esc_url( $item->get_uri( $view ) ); ?>"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_no_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_no_custom_classes__1.php
@@ -28,7 +28,7 @@
 					</div>
 					<div id="tribe-events-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 						<ul class="tribe-events-c-subscribe-dropdown__list">
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -37,7 +37,7 @@
 									>
 										Google Calendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -46,7 +46,7 @@
 									>
 										iCalendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -55,7 +55,7 @@
 									>
 										Outlook 365									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_multiple_custom_classes__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_multiple_custom_classes__1.php
@@ -28,7 +28,7 @@
 					</div>
 					<div id="tribe-events-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 						<ul class="tribe-events-c-subscribe-dropdown__list">
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -37,7 +37,7 @@
 									>
 										Google Calendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -46,7 +46,7 @@
 									>
 										iCalendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -55,7 +55,7 @@
 									>
 										Outlook 365									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_single_custom_class__1.php
+++ b/tests/views_integration/Tribe/Events/Views/Blocks/__snapshots__/Event_LinksTest__test_render_with_single_custom_class__1.php
@@ -28,7 +28,7 @@
 					</div>
 					<div id="tribe-events-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 						<ul class="tribe-events-c-subscribe-dropdown__list">
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -37,7 +37,7 @@
 									>
 										Google Calendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -46,7 +46,7 @@
 									>
 										iCalendar									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -55,7 +55,7 @@
 									>
 										Outlook 365									</a>
 								</li>
-															<li class="tribe-events-c-subscribe-dropdown__list-item">
+															<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 									<a
 										href=""
 										class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_single_with_all__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_single_with_all__1.php
@@ -19,7 +19,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -29,7 +29,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -39,7 +39,7 @@
 		iCalendar	</a>
 </li>
 																		
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa/?path=/calendar/action/compose&#038;rrv=addevent&#038;startdt=2018-07-01T10%3A00%3A00%2B02%3A00&#038;enddt=2018-07-01T13%3A00%3A00%2B02%3A00&#038;location&#038;subject=Test%20Event%20-%202018-07-01%2011am&#038;body"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -49,7 +49,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa/?path=/calendar/action/compose&#038;rrv=addevent&#038;startdt=2018-07-01T10%3A00%3A00%2B02%3A00&#038;enddt=2018-07-01T13%3A00%3A00%2B02%3A00&#038;location&#038;subject=Test%20Event%20-%202018-07-01%2011am&#038;body"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_all__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_all__1.php
@@ -19,7 +19,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -29,7 +29,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -39,7 +39,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/?post_type=tribe_events&#038;eventDisplay=reflector&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -49,7 +49,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -59,7 +59,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_gcal_only__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_gcal_only__1.php
@@ -19,7 +19,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -29,7 +29,7 @@
 		Google Calendar	</a>
 </li>
 																		
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/?post_type=tribe_events&#038;eventDisplay=reflector&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -39,7 +39,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -49,7 +49,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_ical_only__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_ical_only__1.php
@@ -19,7 +19,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 																		
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -29,7 +29,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/?post_type=tribe_events&#038;eventDisplay=reflector&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -39,7 +39,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -49,7 +49,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_icalendar_export_only__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Partials/Components/__snapshots__/Ical_LinkTest__test_render_with_icalendar_export_only__1.php
@@ -19,7 +19,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 																											
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/?post_type=tribe_events&#038;eventDisplay=reflector&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -29,7 +29,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -39,7 +39,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Integrations/__snapshots__/Restrict_Content_Pro_Test__test_render_unrestricted__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Integrations/__snapshots__/Restrict_Content_Pro_Test__test_render_unrestricted__1.php
@@ -3560,7 +3560,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3570,7 +3570,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3580,7 +3580,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3590,7 +3590,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3600,7 +3600,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3610,7 +3610,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_empty__1.php
@@ -479,7 +479,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -489,7 +489,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -499,7 +499,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -509,7 +509,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -519,7 +519,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/today/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -529,7 +529,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/today/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events__1.php
@@ -544,7 +544,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -554,7 +554,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -564,7 +564,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -574,7 +574,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -584,7 +584,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/today/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -594,7 +594,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/today/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__1.php
@@ -642,7 +642,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -652,7 +652,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe_events_cat=cat-1&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -662,7 +662,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -672,7 +672,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -682,7 +682,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/today/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -692,7 +692,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/today/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Day_ViewTest__test_render_w_events_w_taxonomies__2.php
@@ -682,7 +682,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -692,7 +692,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -702,7 +702,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -712,7 +712,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -722,7 +722,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/today/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -732,7 +732,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/today/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_empty__1.php
@@ -509,7 +509,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -519,7 +519,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1&#038;eventDisplay=list"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -529,7 +529,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -539,7 +539,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -549,7 +549,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -559,7 +559,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;outlook-ical=1#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_events__1.php
@@ -572,7 +572,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -582,7 +582,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1&#038;eventDisplay=list"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -592,7 +592,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -602,7 +602,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -612,7 +612,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -622,7 +622,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;outlook-ical=1#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__1.php
@@ -610,7 +610,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -620,7 +620,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe-bar-date=2019-01-01+09%3A00%3A00&#038;tribe_events_cat=cat-1&#038;ical=1&#038;eventDisplay=list"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -630,7 +630,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -640,7 +640,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -650,7 +650,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -660,7 +660,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;outlook-ical=1#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/List_ViewTest__test_render_with_upcoming_taxonomy_events__2.php
@@ -650,7 +650,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -660,7 +660,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1&#038;eventDisplay=list"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -670,7 +670,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -680,7 +680,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe-bar-date%3D2019-01-01%2B09%253A00%253A00%26ical%3D1%26eventDisplay%3Dlist&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -690,7 +690,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -700,7 +700,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/list/?tribe-bar-date=2019-01-01+09%3A00%3A00&#038;outlook-ical=1#038;ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_empty__1.php
@@ -3354,7 +3354,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3364,7 +3364,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3374,7 +3374,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3384,7 +3384,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3394,7 +3394,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3404,7 +3404,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events__1.php
@@ -3560,7 +3560,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3570,7 +3570,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3580,7 +3580,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3590,7 +3590,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3600,7 +3600,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3610,7 +3610,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_hide_endtime__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_hide_endtime__1.php
@@ -3551,7 +3551,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3561,7 +3561,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3571,7 +3571,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3581,7 +3581,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3591,7 +3591,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3601,7 +3601,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__1.php
@@ -3527,7 +3527,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3537,7 +3537,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;tribe_events_cat=cat-1&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3547,7 +3547,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3557,7 +3557,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26tribe_events_cat%3Dcat-1%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3567,7 +3567,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3577,7 +3577,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/category/cat-1/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/__snapshots__/Month_ViewTest__test_render_with_events_w_taxonomies__2.php
@@ -3567,7 +3567,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3577,7 +3577,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3587,7 +3587,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3597,7 +3597,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3607,7 +3607,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/month/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -3617,7 +3617,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/tag/tag-1/month/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"

--- a/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/__snapshots__/ExtendingViewTest__should_render_the_default_view_if_view_not_found__1.php
@@ -488,7 +488,7 @@
 		<div id="tribe-events-c-subscribe-dropdown-content" class="tribe-events-c-subscribe-dropdown__content">
 			<ul class="tribe-events-c-subscribe-dropdown__list">
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--gcal">
 	<a
 		href="https://www.google.com/calendar/render?cid=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -498,7 +498,7 @@
 		Google Calendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ical">
 	<a
 		href="webcal://test.tri.be/?post_type=tribe_events&#038;ical=1&#038;eventDisplay=list&#038;tribe-bar-date=2021-07-04"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -508,7 +508,7 @@
 		iCalendar	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-365">
 	<a
 		href="https://outlook.office.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -518,7 +518,7 @@
 		Outlook 365	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-live">
 	<a
 		href="https://outlook.live.com/owa?path=/calendar/action/compose&#038;rru=addsubscription&#038;url=webcal%3A%2F%2Ftest.tri.be%2F%3Fpost_type%3Dtribe_events%26ical%3D1%26eventDisplay%3Dlist%26tribe-bar-date%3D2021-07-04&#038;name=The+Events+Calendar+Tests+Events+–+The+Events+Calendar+Tests"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -528,7 +528,7 @@
 		Outlook Live	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--ics">
 	<a
 		href="http://test.tri.be/events/list/?ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"
@@ -538,7 +538,7 @@
 		Export .ics file	</a>
 </li>
 									
-<li class="tribe-events-c-subscribe-dropdown__list-item">
+<li class="tribe-events-c-subscribe-dropdown__list-item tribe-events-c-subscribe-dropdown__list-item--outlook-ics">
 	<a
 		href="http://test.tri.be/events/list/?outlook-ical=1"
 		class="tribe-events-c-subscribe-dropdown__list-item-link"


### PR DESCRIPTION
### 🎫 Ticket

[TEC-4242]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Choosing Subscribe to calendar > Google Calendar on a calendar page does not work on Android phones, simply because it is not properly supported. The case is similar when choosing iCalendar.
So, we decided to hide those options on the calendar pages entirely and create a KB article about the why's.
The links work on single event pages, so there is no change there.

The part in TEC adds the necessary CSS selectors and rules.
The PR for Common: [link](https://github.com/the-events-calendar/tribe-common/pull/2742)

### 🎥 Artifacts <!-- if applicable-->
[Screen recording](https://docs.google.com/videos/d/16fXO6t7mP3QJw-XNjJQ9jQ_bPxkMHl1boNsJCJL5Nk0/edit?usp=sharing)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-4242]: https://stellarwp.atlassian.net/browse/TEC-4242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ