### PR TITLE
Fix Elementor event template CSS enqueue

### DIFF
--- a/changelog/fix-elementor-css-enqueue
+++ b/changelog/fix-elementor-css-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Properly enqueue event template stylesheets for Elementor so they get regenerated if needed (props to @pressidium)

--- a/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
+++ b/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php
@@ -9,6 +9,7 @@
 
 namespace TEC\Events\Integrations\Plugins\Elementor;
 
+use Elementor\Core\Files\CSS\Post as Post_CSS;
 use TEC\Events\Integrations\Plugins\Elementor\Template\Documents\Event_Single_Static;
 use TEC\Events\Integrations\Plugins\Elementor\Template\Importer;
 use Tribe\Events\Views\V2\Template_Bootstrap;
@@ -257,13 +258,7 @@ class Assets_Manager extends Controller {
 			return;
 		}
 
-		$upload_dir = wp_upload_dir();
-
-		wp_enqueue_style(
-			'elementor-event-template-' . $template->ID,
-			$upload_dir['baseurl'] . '/elementor/css/post-' . $template->ID . '.css',
-			[],
-			\Tribe__Events__Main::VERSION
-		);
+		$post_css = Post_CSS::create( $template->ID );
+		$post_css->enqueue();
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

N/A

### 🗒️ Description

The Elementor integration file ([`src/Events/Integrations/Plugins/Elementor/Assets_Manager.php`](https://github.com/the-events-calendar/the-events-calendar/blob/master/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php)) enqueues the event template stylesheet by directing calling [`wp_enqueue_style()`](https://developer.wordpress.org/reference/functions/wp_enqueue_style/), like this:

https://github.com/the-events-calendar/the-events-calendar/blob/master/src/Events/Integrations/Plugins/Elementor/Assets_Manager.php#L262-L267

Though, Elementor will only pick up the stylesheet and regenerate the CSS file when needed if it's enqueued through [`\Elementor\Core\Files\CSS\Post::enqueue()`](https://github.com/elementor/elementor/blob/main/core/files/css/post.php#L183-L202):

https://github.com/elementor/elementor/blob/main/core/files/css/post.php#L183-L202

https://github.com/elementor/elementor/blob/main/core/files/css/base.php#L227-L232

As a result of this, visiting a single event page can lead to `404` responses for CSS files like:

```
/wp-content/uploads/elementor/css/post-{event_template_ID}.css
```

This PR fixes that by calling [`\Elementor\Core\Files\CSS\Post::enqueue()`](https://github.com/elementor/elementor/blob/main/core/files/css/post.php#L183-L202) so that Elementor can properly pick up the stylesshet, regenerate it when necessary, and enqueue it.

### 🎥 Artifacts

N/A

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.