### PR TITLE
TEC-5579 Remove padding from dropdown

### DIFF
--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -870,7 +870,6 @@
 .tec-events-onboarding__form-wrapper .tec-react-select__input-container {
 	color: #2c3338;
 	font-size: var(--tec-font-size-2);
-	box-shadow: none;
 }
 
 /* Dropdown indicator */

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -888,7 +888,6 @@
 	border: 1px solid #8c8f94;
 	border-radius: 3px;
 	border-top: none;
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 	margin-top: -1px;
 }
 

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -892,8 +892,8 @@
 	border: 1px solid #8c8f94;
 	border-radius: 3px;
 	border-top: none;
-	margin-top: -1px;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+	margin-top: -1px;
 }
 
 .tec-events-onboarding__form-wrapper .tec-react-select__menu-list {

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -839,7 +839,6 @@
 	box-shadow: none;
 	cursor: text;
 	min-height: calc(var(--tec-spacer-5) + var(--tec-spacer-1));
-	padding: var(--tec-spacer-1) var(--tec-spacer-2);
 }
 
 .tec-events-onboarding__form-wrapper .tec-react-select__control:hover {

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -831,6 +831,10 @@
 	font-size: var(--tec-font-size-2);
 }
 
+.tec-events-onboarding__form-wrapper .tec-react-select__input:focus {
+	box-shadow: none;
+}
+
 /* Control (the main input area) */
 .tec-events-onboarding__form-wrapper .tec-react-select__control {
 	background-color: #fff;
@@ -866,6 +870,7 @@
 .tec-events-onboarding__form-wrapper .tec-react-select__input-container {
 	color: #2c3338;
 	font-size: var(--tec-font-size-2);
+	box-shadow: none;
 }
 
 /* Dropdown indicator */
@@ -889,6 +894,7 @@
 	border-radius: 3px;
 	border-top: none;
 	margin-top: -1px;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .tec-events-onboarding__form-wrapper .tec-react-select__menu-list {


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5579]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Quick follow up to a recently merged PR to remove unnecessary padding and the shadow-box from some dropdown options in the onboarding wizard. 

No changelog is needed since this is to tweak a PR recently merged with a changelog. 

### 🎥 Artifacts 
Before: 
<img width="3428" height="1918" alt="CleanShot 2025-09-05 at 09 25 54@2x" src="https://github.com/user-attachments/assets/c88f9d9a-2ae8-49c2-a405-96bdd6b1b0cb" />
<img width="3376" height="1836" alt="CleanShot 2025-09-05 at 09 37 06@2x" src="https://github.com/user-attachments/assets/82c29f71-5be8-4434-baca-8e9daacc568a" />

After:
<img width="3444" height="1910" alt="CleanShot 2025-09-05 at 09 36 57@2x" src="https://github.com/user-attachments/assets/54d0d49e-9d80-4a51-8109-6ed27fe61e99" />
<img width="3428" height="1908" alt="CleanShot 2025-09-05 at 09 48 21@2x" src="https://github.com/user-attachments/assets/6976332c-b974-4efa-85d8-3a351f8ddbc6" />




### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5579]: https://stellarwp.atlassian.net/browse/TEC-5579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ