### PR TITLE
[CE-278] Close on escape

### DIFF
--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -659,10 +659,6 @@ jQuery( function ( $ ) {
 				$dpDiv.attrchange( {
 					trackValues: true,
 					callback( attr ) {
-						if (escapeClosing) {
-							// Skip any close handling when Escape triggered it
-							return;
-						}
 						// This is a non-ideal, but very reliable way to look for the closing of the ui-datepicker box,
 						// since onClose method is often occluded by other plugins, including Events Calender PRO.
 						if (

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -613,17 +613,17 @@ jQuery( function ( $ ) {
 					if (e.key === 'Escape' || e.key === 'Esc') {
 						e.preventDefault();
 
-						// Close datepicker and temporarily disable auto-open
+						// Close datepicker and temporarily disable auto-open.
 						object.input.datepicker('option', 'showOn', 'manual');
 						$.datepicker._hideDatepicker();
 
-						// Manually hide in case any watchers miss it
+						// Manually hide in case any watchers miss it.
 						$('#ui-datepicker-div').css('display', 'none');
 
-						// Return focus safely
+						// Return focus safely.
 						object.input.focus();
 
-						// Re-enable auto-open after a tick
+						// Re-enable auto-open after a tick.
 						setTimeout(() => {
 							object.input.datepicker('option', 'showOn', 'focus');
 						}, 100);

--- a/src/resources/js/events-admin.js
+++ b/src/resources/js/events-admin.js
@@ -613,13 +613,20 @@ jQuery( function ( $ ) {
 					if (e.key === 'Escape' || e.key === 'Esc') {
 						e.preventDefault();
 
-						// Trigger datepicker's own close handler cleanly.
-						if ($.datepicker._curInst) {
-							$.datepicker._hideDatepicker();
-							$.datepicker._curInst.input.datepicker('destroy');
-						}
+						// Close datepicker and temporarily disable auto-open
+						object.input.datepicker('option', 'showOn', 'manual');
+						$.datepicker._hideDatepicker();
 
+						// Manually hide in case any watchers miss it
+						$('#ui-datepicker-div').css('display', 'none');
+
+						// Return focus safely
 						object.input.focus();
+
+						// Re-enable auto-open after a tick
+						setTimeout(() => {
+							object.input.datepicker('option', 'showOn', 'focus');
+						}, 100);
 
 						return;
 					}
@@ -652,6 +659,10 @@ jQuery( function ( $ ) {
 				$dpDiv.attrchange( {
 					trackValues: true,
 					callback( attr ) {
+						if (escapeClosing) {
+							// Skip any close handling when Escape triggered it
+							return;
+						}
 						// This is a non-ideal, but very reliable way to look for the closing of the ui-datepicker box,
 						// since onClose method is often occluded by other plugins, including Events Calender PRO.
 						if (


### PR DESCRIPTION
### 🎫 Ticket

[CE-278] 
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Tweaked the code again, when Romine tested there was a specific scenario that would cause the datepicker to be fully destroyed and the field would lose the mask.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://github.com/user-attachments/assets/08ae91a7-4da5-481e-8dba-35c1b2268b2f

[skip-changelog]

[CE-278]: https://stellarwp.atlassian.net/browse/CE-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ