### PR TITLE
TEC-5214 Add aria-label to day link in week view

### DIFF
--- a/changelog/fix-TEC-5214-add-meaning-to-link-text
+++ b/changelog/fix-TEC-5214-add-meaning-to-link-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Add aria-label for day links in week view. [TEC-5214]


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5214]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This link does not include meaningful text in either the visible text, an aria-label, or hidden screen reader text. Screen reader users would not know where the link goes outside of the context of the page and whether they would want to click it. The same issue was reported in the ticket for month view and just needed to also be implemented for week view. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="3422" height="1848" alt="TEC_5214-Before" src="https://github.com/user-attachments/assets/499a3f23-d749-4bea-bcfd-984a9fdf7e21" />

After:
<img width="3446" height="1928" alt="TEC-5214-After" src="https://github.com/user-attachments/assets/37ba659d-a252-4e96-9103-603859b7d446" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5214]: https://stellarwp.atlassian.net/browse/TEC-5214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ