### PR TITLE
Fix/TEC-5061 - Enhance timezone definition 

### DIFF
--- a/changelog/fix-TEC-5061-fix-timezone-definition-2
+++ b/changelog/fix-TEC-5061-fix-timezone-definition-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enhanced iCal feed timezone definitions to include extended DST transition data for better calendar compatibility. [TEC-5061]

--- a/src/Tribe/iCal.php
+++ b/src/Tribe/iCal.php
@@ -634,8 +634,29 @@ class Tribe__Events__iCal {
 			$ordered['start'] = array_values( $ordered['start'] );
 			$ordered['end']   = array_values( $ordered['end'] );
 
-			$start = reset( $ordered['start'] );
-			$end   = reset( $ordered['end'] );
+			$start_year = date( 'Y', reset( $ordered['start'] ) );  // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+			$end_year   = date( 'Y', reset( $ordered['end'] ) );  // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+
+			/**
+			 * Filters the number of years to extend timezone transitions in each direction.
+			 *
+			 * @since TBD
+			 *
+			 * @param int    $years    The number of years to extend before and after event years. Default 3.
+			 * @param string $timezone The timezone identifier (e.g., 'Europe/Berlin').
+			 * @param array  $events   The events being processed for this timezone.
+			 */
+			$extend_years = apply_filters( 'tec_events_ical_timezone_extend_years', 1, $timezone->getName(), $row['events'] );
+
+			// Ensure we have a valid positive integer.
+			$extend_years = max( 1, (int) $extend_years );
+
+			// Extend the range by the specified number of years in each direction.
+			$extended_start = strtotime( 'first day of january ' . ( $start_year - $extend_years ) );
+			$extended_end   = strtotime( 'last day of december ' . ( $end_year + $extend_years ) );
+
+			$start = $extended_start;
+			$end   = $extended_end;
 
 			if ( empty( $start ) || empty( $end ) ) {
 				continue;


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5061]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Our iCal feed timezone definitions are "not complete" - for the lack of a better word.
In the VTIMEZONE block we provide rules for the DST change. The range goes from the earliest event to the latest in the feed. However, that doesn't seem to be sufficient, and, as a result, in some applications the events are imported with no, or the wrong time zone and wrong start time.

There are 2 solutions to this:
* Include an RRULE in the VTIMEZONE block for the rules of the DST time changes. -> There is no PHP solution for this. We could potentially look for a library that could help with the rules. This would require further investigation.
* Extend the date range by 1 year in each direction for which to add the DST rules. Based on tests this solves the issue the implementation is easier.

The second solution is covered in this PR.

### 🎥 Artifacts <!-- if applicable-->
[Screenshot](https://dl.dropbox.com/scl/fi/1p0mv6z8e3s2oetanc1bh/shot_250925_171017.png?rlkey=veqsv6wuhov3a2xky7sh3qq25&dl=0)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5061]: https://stellarwp.atlassian.net/browse/TEC-5061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ