### PR TITLE
Cast return as string.

### DIFF
--- a/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
@@ -154,7 +154,7 @@ class Controller extends Controller_Contract {
 	 * @return mixed results of option query.
 	 */
 	public function filter_tribe_get_single_option( $option, $default_value, $option_name ) {
-		// ONly this option.
+		// Only this option.
 		if ( 'tribeEventsTemplate' !== $option_name ) {
 			return $option;
 		}

--- a/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
@@ -113,6 +113,7 @@ class Controller extends Controller_Contract {
 	 * Force the correct Single Event template object for Elementor theme.
 	 *
 	 * @since 6.4.0
+	 * @since TBD Cast return as string.
 	 *
 	 * @param string $option The value of the option.
 	 *
@@ -121,12 +122,12 @@ class Controller extends Controller_Contract {
 	public function filter_events_template_setting_option( $option ): string {
 		// Only for events.
 		if ( ! is_singular( TEC::POSTTYPE ) ) {
-			return $option;
+			return (string) $option;
 		}
 
 		// Only for single events.
 		if ( ! tribe( Template_Bootstrap::class )->is_single_event() ) {
-			return $option;
+			return (string) $option;
 		}
 
 		/**
@@ -138,7 +139,7 @@ class Controller extends Controller_Contract {
 		 *                       it will prevent the use of the provided Elementor templates.
 		 * @param string $option The original value, or an empty string signifying the default events template.
 		 */
-		return apply_filters( 'tec_events_filter_events_template_setting_option', '', $option );
+		return (string) apply_filters( 'tec_events_filter_events_template_setting_option', '', $option );
 	}
 
 	/**

--- a/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
+++ b/src/Events/Integrations/Plugins/Elementor/Template/Controller.php
@@ -178,7 +178,7 @@ class Controller extends Controller_Contract {
 		 *                       than an empty string, it will prevent the use of the provided Elementor templates.
 		 * @param string $option The original value, or an empty string signifying the default events template.
 		 */
-		return apply_filters( 'tec_events_filter_tribe_get_single_option', '', $option );
+		return (string) apply_filters( 'tec_events_filter_tribe_get_single_option', '', $option );
 	}
 
 	/**

--- a/tests/elementor_integration/ControllerTest.php
+++ b/tests/elementor_integration/ControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace TEC\Events\Integrations\Plugins\Elementor;
 use Tribe__Main;
+use TEC\Events\Integrations\Plugins\Elementor\Template\Controller as Elementor_Controller;
 
 class ControllerTest extends \Codeception\TestCase\WPTestCase {
 	/**
@@ -86,4 +87,34 @@ class ControllerTest extends \Codeception\TestCase\WPTestCase {
 		// Verify the setting remains unchanged.
 		$this->assertEquals( '', tribe_get_option( 'tribeEventsTemplate' ) );
 	}
+
+	/**
+	 * Provides different option values to test normalization and casting.
+	 *
+	 * @return \Generator
+	 */
+	public function provider_option_values(): \Generator {
+		yield 'string option remains unchanged' => [ 'default-template', 'default-template' ];
+		yield 'empty string remains unchanged'  => [ '', '' ];
+		yield 'null becomes empty string'       => [ null, '' ];
+		yield 'integer is cast to string'       => [ 123, '123' ];
+	}
+
+	/**
+	 * It should always return a string regardless of the input type.
+	 *
+	 * @test
+	 * @dataProvider provider_option_values
+	 *
+	 * @param mixed  $input    Input option value.
+	 * @param string $expected Expected normalized string output.
+	 */
+	public function it_always_returns_a_string_from_filter_events_template_setting_option( $input, string $expected ) {
+		$controller = tribe( Elementor_Controller::class );
+
+		$result = $controller->filter_events_template_setting_option( $input );
+
+		$this->assertSame( $expected, $result );
+	}
+
 }


### PR DESCRIPTION
While testing, Victor received a fatal 
```
PHP Fatal error:  Uncaught TypeError: Return value of TEC\Events\Integrations\Plugins\Elementor\Template\Controller::filter_events_template_setting_option() must be of the type string, null returned in /.../wp-content/plugins/the-events-calendar/src/Events/Integrations/Plugins/Elementor/Template/Controller.php:124
Stack trace:
#0 /.../wp-includes/class-wp-hook.php(326): TEC\Events\Integrations\Plugins\Elementor\Template\Controller->filter_events_template_setting_option(NULL)
#1 /.../wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array)
#2 /.../wp-content/plugins/the-events-calendar/common/src/functions/template-tags/general.php(57): apply_filters('tribe_get_optio...', NULL, 'tribeEventsTemp...', 'default')
#3 /.../wp-content/plugins/the-events-calendar/src/Tribe/Views/V2 in /.../wp-content/plugins/the-events-calendar/src/Events/Integrations/Plugins/Elementor/Template/Controller.php on line 124
```

We were unable to replicate it. However, this fix should fix the issue if it was to occur again.

[skip-changelog]