### PR TITLE
Fix issue with recurring events on TEC-only calendar

### DIFF
--- a/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
@@ -3,7 +3,7 @@
  * Handles the plugin integration and compatibility with the `By_Day_View` class, the common ancestor of Month and
  * Week View.
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\Views\V2
  */
@@ -12,13 +12,12 @@ namespace TEC\Events\Custom_Tables\V1\Views\V2;
 
 use stdClass;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
-use Tribe\Events\Models\Post_Types\Event;
 use Tribe__Timezones as Timezones;
 
 /**
  * Class By_Day_View_Compatibility
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\Views\V2
  */
@@ -29,9 +28,9 @@ class By_Day_View_Compatibility {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param array<int>   $ids        A list of the Event post IDs to prepare the day results for.
-	 * @param string|null  $start_date Optional. Start date for filtering occurrences (Y-m-d format).
-	 * @param string|null  $end_date   Optional. End date for filtering occurrences (Y-m-d format).
+	 * @param array<int>  $ids        A list of the Event post IDs to prepare the day results for.
+	 * @param string|null $start_date Optional. Start date for filtering occurrences (Y-m-d format).
+	 * @param string|null $end_date   Optional. End date for filtering occurrences (Y-m-d format).
 	 *
 	 * @return array<int,stdClass> The prepared day results.
 	 */
@@ -49,8 +48,8 @@ class By_Day_View_Compatibility {
 		$prepared = [];
 
 		while ( $ids_count ) {
-			$ids_chunk   = array_splice( $ids, 0, $ids_chunk_size );
-			$ids_count   = count( $ids );
+			$ids_chunk = array_splice( $ids, 0, $ids_chunk_size );
+			$ids_count = count( $ids );
 
 			// When Events Calendar Pro is not active, limit to the earliest occurrence per event.
 			if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
@@ -67,19 +66,19 @@ class By_Day_View_Compatibility {
 					}
 				}
 			} else {
-				// When Pro is active, fetch all occurrences but filter by date range if provided
+				// When Pro is active, fetch all occurrences but filter by date range if provided.
 				$query = Occurrence::where_in( 'post_id', $ids_chunk );
 
-				// Filter by date range if provided (for Day View, Month View, etc.)
+				// Filter by date range if provided (for Day View, Month View, etc.).
 				if ( $start_date && $end_date ) {
-					// Convert Y-m-d to Y-m-d H:i:s format for comparison
+					// Convert Y-m-d to Y-m-d H:i:s format for comparison.
 					$start_datetime = $start_date . ' 00:00:00';
 					$end_datetime   = $end_date . ' 23:59:59';
 
 					// Find occurrences that overlap with the date range
-					// An occurrence overlaps if: occurrence_start < range_end AND occurrence_end > range_start
+					// An occurrence overlaps if: occurrence_start < range_end AND occurrence_end > range_start.
 					$query->where( $start_date_prop, '<', $end_datetime )
-					      ->where( $end_date_prop, '>', $start_datetime );
+						->where( $end_date_prop, '>', $start_datetime );
 				}
 
 				$occurrences = $query->all();

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -2,7 +2,7 @@
 /**
  * Provides integration with Views V2.
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\Views\V2
  */
@@ -19,7 +19,7 @@ use TEC\Common\Contracts\Service_Provider;
 /**
  * Class Provider
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\Views\V2
  */
@@ -35,24 +35,39 @@ class Provider extends Service_Provider {
 	public function register() {
 		$this->container->singleton( Customizer_Compatibility::class, Customizer_Compatibility::class );
 
-		add_filter( 'tribe_events_views_v2_by_day_view_day_results', [
-			$this,
-			'prepare_by_day_view_day_results',
-		], 10, 3 );
-
-		// When Pro is inactive, hydrate posts with their selected occurrence dates
-		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
-			add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
+		add_filter(
+			'tribe_events_views_v2_by_day_view_day_results',
+			[
 				$this,
-				'hydrate_posts_with_occurrence_dates',
-			], 10, 2 );
+				'prepare_by_day_view_day_results',
+			],
+			10,
+			3
+		);
+
+		// When Pro is inactive, hydrate posts with their selected occurrence dates.
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			add_filter(
+				'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts',
+				[
+					$this,
+					'hydrate_posts_with_occurrence_dates',
+				],
+				10,
+				2
+			);
 		}
 
 		// Handle Customizer styles.
-		add_filter( 'tribe_customizer_global_elements_css_template', [
-			$this,
-			'update_global_customizer_styles',
-		], 10, 3 );
+		add_filter(
+			'tribe_customizer_global_elements_css_template',
+			[
+				$this,
+				'update_global_customizer_styles',
+			],
+			10,
+			3
+		);
 	}
 
 	/**
@@ -68,14 +83,14 @@ class Provider extends Service_Provider {
 	 * @return array<int,stdClass> The prepared day results.
 	 */
 	public function prepare_by_day_view_day_results( array $day_results = null, array $event_ids = [], $view = null ) {
-		// Extract date range from the view context if available
+		// Extract date range from the view context if available.
 		$start_date = null;
 		$end_date   = null;
 
 		if ( $view && method_exists( $view, 'get_context' ) ) {
 			$context = $view->get_context();
 
-			// For Month View / Week View, get the date range
+			// For Month View / Week View, get the date range.
 			if ( isset( $context->start_date ) && isset( $context->end_date ) ) {
 				$start_date = $context->start_date;
 				$end_date   = $context->end_date;
@@ -83,7 +98,7 @@ class Provider extends Service_Provider {
 		}
 
 		return $this->container->make( By_Day_View_Compatibility::class )
-		                       ->prepare_day_results( $event_ids, $start_date, $end_date );
+							->prepare_day_results( $event_ids, $start_date, $end_date );
 	}
 
 	/**
@@ -91,18 +106,17 @@ class Provider extends Service_Provider {
 	 *
 	 * @since 6.0.0
 	 *
+	 * @param string             $css_template The CSS template, as produced by the Global Elements.
 	 * @param Customizer_Section $section      The Global Elements section.
 	 * @param Customizer         $customizer   The current Customizer instance.
-	 * @param string             $css_template The CSS template, as produced by the Global Elements.
 	 *
 	 * @return string The filtered CSS template.
 	 *
 	 * @throws Exception If the Color util is built incorrectly.
-	 *
 	 */
-	public function update_global_customizer_styles( $css_template, $section, $customizer ) {
+	public function update_global_customizer_styles( string $css_template, Customizer_Section $section, Customizer $customizer ): string {
 		return $this->container->make( Customizer_Compatibility::class )
-		                       ->update_global_customizer_styles( $css_template, $section, $customizer );;
+					->update_global_customizer_styles( $css_template, $section, $customizer );
 	}
 
 	/**
@@ -114,13 +128,13 @@ class Provider extends Service_Provider {
 	 *
 	 * @since TBD
 	 *
-	 * @param array $posts The posts returned by Custom_Tables_Query.
-	 * @param object $query The Custom_Tables_Query instance.
+	 * @param array<int,stdClass>|array<int,WP_Post> $posts The posts returned by Custom_Tables_Query.
+	 * @param object                                 $query The Custom_Tables_Query instance.
 	 *
 	 * @return array The posts with updated meta cache.
 	 */
 	public function hydrate_posts_with_occurrence_dates( $posts, $query ) {
-		// Safety check: if Pro is active, don't hydrate (Pro handles its own occurrence logic)
+		// Safety check: if Pro is active, don't hydrate (Pro handles its own occurrence logic).
 		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
 			return $posts;
 		}
@@ -129,20 +143,21 @@ class Provider extends Service_Provider {
 			return $posts;
 		}
 
-		// Get the date conditions that were used in the query
-		$date_conditions = $query->get( '_tec_occurrence_date_conditions', '' );
+		// Get the date conditions that were used in the query.
+		$date_conditions   = $query->get( '_tec_occurrence_date_conditions', '' );
 		$used_simple_limit = $query->get( '_tec_used_simple_limit', false );
 
-		// If the query used simple limit (no date conditions from meta_query),
-		// the main query's WHERE clause (date_overlaps, ends_after, etc.) already
-		// selected the right occurrence. We don't need to re-fetch or hydrate.
+		/*
+		 * If the query used simple limit (no date conditions from meta_query),
+		 * the main query's WHERE clause (date_overlaps, ends_after, etc.) already
+		 * selected the right occurrence. We don't need to re-fetch or hydrate.
+		 */
 		if ( empty( $date_conditions ) && $used_simple_limit ) {
 			return $posts;
 		}
 
 		foreach ( $posts as $post ) {
-			// During found_posts, $post is a post ID (integer)
-			// During posts_results, $post is a WP_Post object or stdClass
+			// During found_posts, $post is a post ID (integer) but during posts_results, $post is a WP_Post object or stdClass.
 			if ( $post instanceof \WP_Post ) {
 				$post_id = $post->ID;
 			} elseif ( is_object( $post ) && isset( $post->ID ) ) {
@@ -155,19 +170,21 @@ class Provider extends Service_Provider {
 				continue;
 			}
 
-			// Get the occurrence using the same date filtering as the query
-			// This ensures we get the right occurrence (e.g., first future one for List View)
+			/*
+			 * Get the occurrence using the same date filtering as the query.
+			 * This ensures we get the right occurrence (e.g., first future one for List View).
+			 */
 			global $wpdb;
 			$table = \TEC\Events\Custom_Tables\V1\Tables\Occurrences::table_name( true );
 
-			// Build the query with date conditions
-			// Note: date_conditions already includes quotes and is safe to use directly (not via prepare)
+			// Build the query with date conditions.
+			// Note: date_conditions already includes quotes and is safe to use directly (not via prepare).
 			$occ_date_conditions = str_replace( 'occ.', 'o.', $date_conditions );
 
-			// Prepare the post_id part first
+			// Prepare the post_id part first.
 			$post_id_condition = $wpdb->prepare( 'o.post_id = %d', $post_id );
 
-			// Build the full SQL (date conditions are already escaped from meta_query processing)
+			// Build the full SQL (date conditions are already escaped from meta_query processing).
 			$sql = "SELECT o.*
 				FROM {$table} o
 				WHERE {$post_id_condition}
@@ -175,26 +192,26 @@ class Provider extends Service_Provider {
 				ORDER BY o.start_date ASC, o.occurrence_id ASC
 				LIMIT 1";
 
-			$occurrence_row = $wpdb->get_row( $sql );
+			$occurrence_row = $wpdb->get_row( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 			if ( ! $occurrence_row ) {
 				continue;
 			}
 
-			// Update the post meta cache with this occurrence's dates
-			$cache_key = $post_id;
+			// Update the post meta cache with this occurrence's dates.
+			$cache_key  = $post_id;
 			$meta_cache = wp_cache_get( $cache_key, 'post_meta' );
 
 			if ( false === $meta_cache ) {
 				$meta_cache = update_meta_cache( 'post', [ $post_id ] );
-				$meta_cache = isset( $meta_cache[ $post_id ] ) ? $meta_cache[ $post_id ] : [];
+				$meta_cache = $meta_cache[ $post_id ] ?? [];
 			}
 
-			// Override the date fields with the selected occurrence's dates
-			$meta_cache['_EventStartDate'] = [ $occurrence_row->start_date ];
-			$meta_cache['_EventEndDate'] = [ $occurrence_row->end_date ];
+			// Override the date fields with the selected occurrence's dates.
+			$meta_cache['_EventStartDate']    = [ $occurrence_row->start_date ];
+			$meta_cache['_EventEndDate']      = [ $occurrence_row->end_date ];
 			$meta_cache['_EventStartDateUTC'] = [ $occurrence_row->start_date_utc ];
-			$meta_cache['_EventEndDateUTC'] = [ $occurrence_row->end_date_utc ];
+			$meta_cache['_EventEndDateUTC']   = [ $occurrence_row->end_date_utc ];
 
 			wp_cache_set( $cache_key, $meta_cache, 'post_meta' );
 		}

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -38,7 +38,15 @@ class Provider extends Service_Provider {
 		add_filter( 'tribe_events_views_v2_by_day_view_day_results', [
 			$this,
 			'prepare_by_day_view_day_results',
-		], 10, 2 );
+		], 10, 3 );
+
+		// When Pro is inactive, hydrate posts with their selected occurrence dates
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
+				$this,
+				'hydrate_posts_with_occurrence_dates',
+			], 10, 2 );
+		}
 
 		// Handle Customizer styles.
 		add_filter( 'tribe_customizer_global_elements_css_template', [
@@ -55,12 +63,27 @@ class Provider extends Service_Provider {
 	 * @param array<int,stdClass>|null $day_results  Either the prepared day results, or `null`
 	 *                                               if the day results have not been prepared yet.
 	 * @param array<int>               $event_ids    A list of the Event post IDs that should be prepared.
+	 * @param object|null              $view         The view instance (Day_View, Month_View, etc.).
 	 *
 	 * @return array<int,stdClass> The prepared day results.
 	 */
-	public function prepare_by_day_view_day_results( array $day_results = null, array $event_ids = [] ) {
+	public function prepare_by_day_view_day_results( array $day_results = null, array $event_ids = [], $view = null ) {
+		// Extract date range from the view context if available
+		$start_date = null;
+		$end_date   = null;
+
+		if ( $view && method_exists( $view, 'get_context' ) ) {
+			$context = $view->get_context();
+
+			// For Month View / Week View, get the date range
+			if ( isset( $context->start_date ) && isset( $context->end_date ) ) {
+				$start_date = $context->start_date;
+				$end_date   = $context->end_date;
+			}
+		}
+
 		return $this->container->make( By_Day_View_Compatibility::class )
-		                       ->prepare_day_results( $event_ids );
+		                       ->prepare_day_results( $event_ids, $start_date, $end_date );
 	}
 
 	/**
@@ -80,5 +103,102 @@ class Provider extends Service_Provider {
 	public function update_global_customizer_styles( $css_template, $section, $customizer ) {
 		return $this->container->make( Customizer_Compatibility::class )
 		                       ->update_global_customizer_styles( $css_template, $section, $customizer );;
+	}
+
+	/**
+	 * Hydrates event posts with their selected occurrence dates when Pro is inactive.
+	 *
+	 * When Pro is not active, each recurring event is limited to a single occurrence by the query.
+	 * This method updates the post meta cache so that tribe_get_event() returns the correct
+	 * dates for the selected occurrence, not the original event's first occurrence dates.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $posts The posts returned by Custom_Tables_Query.
+	 * @param object $query The Custom_Tables_Query instance.
+	 *
+	 * @return array The posts with updated meta cache.
+	 */
+	public function hydrate_posts_with_occurrence_dates( $posts, $query ) {
+		// Safety check: if Pro is active, don't hydrate (Pro handles its own occurrence logic)
+		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			return $posts;
+		}
+
+		if ( empty( $posts ) ) {
+			return $posts;
+		}
+
+		// Get the date conditions that were used in the query
+		$date_conditions = $query->get( '_tec_occurrence_date_conditions', '' );
+		$used_simple_limit = $query->get( '_tec_used_simple_limit', false );
+
+		// If the query used simple limit (no date conditions from meta_query),
+		// the main query's WHERE clause (date_overlaps, ends_after, etc.) already
+		// selected the right occurrence. We don't need to re-fetch or hydrate.
+		if ( empty( $date_conditions ) && $used_simple_limit ) {
+			return $posts;
+		}
+
+		foreach ( $posts as $post ) {
+			// During found_posts, $post is a post ID (integer)
+			// During posts_results, $post is a WP_Post object or stdClass
+			if ( $post instanceof \WP_Post ) {
+				$post_id = $post->ID;
+			} elseif ( is_object( $post ) && isset( $post->ID ) ) {
+				$post_id = (int) $post->ID;
+			} else {
+				$post_id = (int) $post;
+			}
+
+			if ( empty( $post_id ) ) {
+				continue;
+			}
+
+			// Get the occurrence using the same date filtering as the query
+			// This ensures we get the right occurrence (e.g., first future one for List View)
+			global $wpdb;
+			$table = \TEC\Events\Custom_Tables\V1\Tables\Occurrences::table_name( true );
+
+			// Build the query with date conditions
+			// Note: date_conditions already includes quotes and is safe to use directly (not via prepare)
+			$occ_date_conditions = str_replace( 'occ.', 'o.', $date_conditions );
+
+			// Prepare the post_id part first
+			$post_id_condition = $wpdb->prepare( 'o.post_id = %d', $post_id );
+
+			// Build the full SQL (date conditions are already escaped from meta_query processing)
+			$sql = "SELECT o.*
+				FROM {$table} o
+				WHERE {$post_id_condition}
+				{$occ_date_conditions}
+				ORDER BY o.start_date ASC, o.occurrence_id ASC
+				LIMIT 1";
+
+			$occurrence_row = $wpdb->get_row( $sql );
+
+			if ( ! $occurrence_row ) {
+				continue;
+			}
+
+			// Update the post meta cache with this occurrence's dates
+			$cache_key = $post_id;
+			$meta_cache = wp_cache_get( $cache_key, 'post_meta' );
+
+			if ( false === $meta_cache ) {
+				$meta_cache = update_meta_cache( 'post', [ $post_id ] );
+				$meta_cache = isset( $meta_cache[ $post_id ] ) ? $meta_cache[ $post_id ] : [];
+			}
+
+			// Override the date fields with the selected occurrence's dates
+			$meta_cache['_EventStartDate'] = [ $occurrence_row->start_date ];
+			$meta_cache['_EventEndDate'] = [ $occurrence_row->end_date ];
+			$meta_cache['_EventStartDateUTC'] = [ $occurrence_row->start_date_utc ];
+			$meta_cache['_EventEndDateUTC'] = [ $occurrence_row->end_date_utc ];
+
+			wp_cache_set( $cache_key, $meta_cache, 'post_meta' );
+		}
+
+		return $posts;
 	}
 }

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -2,7 +2,7 @@
 /**
  * An extension of the base WordPress WP_Query to redirect queries to the plugin custom tables.
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\WP_Query
  */
@@ -20,7 +20,7 @@ use WP_Query;
 /**
  * Class Custom_Tables_Query
  *
- * @since   6.0.0
+ * @since 6.0.0
  *
  * @package TEC\Events\Custom_Tables\V1\WP_Query
  */
@@ -48,22 +48,22 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  WP_Query                  $wp_query       A reference to the `WP_Query` instance that
+	 * @param WP_Query             $wp_query       A reference to the `WP_Query` instance that
 	 *                                                   should be used as a model to build an instance
 	 *                                                   of this class.
-	 * @param  array<string,mixed>|null  $override_args  An array of query arguments to override
+	 * @param ?array<string,mixed> $override_args  An array of query arguments to override
 	 *                                                   the ones set from the original query.
 	 *
 	 * @return Custom_Tables_Query An instance of the class, built using the input `WP_Query`
 	 *                             instance as a model.
 	 */
-	public static function from_wp_query( WP_Query $wp_query, array $override_args = null ) {
+	public static function from_wp_query( WP_Query $wp_query, ?array $override_args = null ) {
 		// Initialize a new instance of the query.
 		$ct_query = new self();
 		$ct_query->init();
-		$filtered_query = $ct_query->filter_query_vars( wp_parse_args( (array) $override_args, $wp_query->query ) );
-		$ct_query->query = $filtered_query;
-		$filtered_query_vars = $ct_query->filter_query_vars( wp_parse_args( (array) $override_args, $wp_query->query_vars ) );
+		$filtered_query       = $ct_query->filter_query_vars( wp_parse_args( (array) $override_args, $wp_query->query ) );
+		$ct_query->query      = $filtered_query;
+		$filtered_query_vars  = $ct_query->filter_query_vars( wp_parse_args( (array) $override_args, $wp_query->query_vars ) );
 		$ct_query->query_vars = $filtered_query_vars;
 
 		// Keep a reference to the original `WP_Query` instance.
@@ -80,7 +80,7 @@ class Custom_Tables_Query extends WP_Query {
 			 * to the Custom Tables query and set them up to avoid duplicated JOIN issues.
 			 *
 			 * @var Custom_Tables_Query_Filters $query_filters
-		     */
+			 */
 			$query_filters = $wp_query->builder->filter_query;
 			$query_filters->set_query( $ct_query );
 		}
@@ -96,7 +96,7 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param $query_vars array<string,mixed> The query variables, as created by WordPress or previous filtering
+	 * @param array<string,mixed> $query_vars The query variables, as created by WordPress or previous filtering
 	 *                                        methods.
 	 *
 	 * @return array<string,mixed> The filtered query variables.
@@ -195,7 +195,7 @@ class Custom_Tables_Query extends WP_Query {
 			add_filter( 'found_posts', [ $this, 'hydrate_posts_on_found_rows' ], 0, 2 );
 		} else {
 			$this->set( 'cache_results', false );
-			// When not calculating found_posts, hydrate via posts_results instead
+			// When not calculating found_posts, hydrate via posts_results instead.
 			add_filter( 'posts_results', [ $this, 'hydrate_posts_via_posts_results' ], 10, 2 );
 		}
 
@@ -220,7 +220,7 @@ class Custom_Tables_Query extends WP_Query {
 			if ( $set_found_rows ) {
 				// Avoid `SELECT FOUND_ROWS()` running twice. See #ECP-1360.
 				add_filter( 'found_posts_query', [ $this, 'filter_found_posts_query' ], 10, 2 );
-				$this->wp_query->found_posts = $this->found_posts;
+				$this->wp_query->found_posts   = $this->found_posts;
 				$this->wp_query->max_num_pages = $this->max_num_pages;
 			}
 
@@ -229,7 +229,7 @@ class Custom_Tables_Query extends WP_Query {
 		}
 
 		return $results;
-    }
+	}
 
 	/**
 	 * Replaces the `WP_Meta_Query` instance built in the `WP_Query::get_posts` method with an instance of
@@ -240,9 +240,9 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  string    $search    The WHERE clause as produced by the `WP_Query` instance.
-	 * @param  WP_Query  $wp_query  A reference to the `WP_Query` instance whose search WHERE clause is currently being
-	 *                              filtered.
+	 * @param string   $search    The WHERE clause as produced by the `WP_Query` instance.
+	 * @param WP_Query $wp_query  A reference to the `WP_Query` instance whose search WHERE clause is currently being
+	 *                            filtered.
 	 *
 	 * @return string The WHERE clause as produced by the `WP_Query` instance, untouched by the method.
 	 */
@@ -270,7 +270,7 @@ class Custom_Tables_Query extends WP_Query {
 			return $search;
 		}
 
-		$meta_queries = isset( $source_query->meta_query->queries ) ? $source_query->meta_query->queries : [];
+		$meta_queries = $source_query->meta_query->queries ?? [];
 
 		$this->meta_query = new Custom_Tables_Meta_Query( $meta_queries );
 
@@ -282,9 +282,9 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  string        $request_fields The original `SELECT` SQL.
-	 * @param  WP_Query|null $query          A reference to the `WP_Query` instance currently being
-	 *                                 filtered.
+	 * @param string    $request_fields The original `SELECT` SQL.
+	 * @param ?WP_Query $query          A reference to the `WP_Query` instance currently being
+	 *                                      filtered.
 	 *
 	 * @return string The filtered `SELECT` clause.
 	 */
@@ -314,8 +314,8 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  string         $groupby  The original `GROUP BY` SQL clause.
-	 * @param  WP_Query|null  $query    A reference to the `WP_Query` instance currently being filtered.
+	 * @param string    $groupby  The original `GROUP BY` SQL clause.
+	 * @param ?WP_Query $query    A reference to the `WP_Query` instance currently being filtered.
 	 *
 	 * @return string The updated `GROUP BY` SQL clause.
 	 */
@@ -343,7 +343,7 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @return string|false The redirected `ORDER BY` field, `false` on failure.
 	 */
-	protected function parse_orderby( $orderby ){
+	protected function parse_orderby( $orderby ) {
 		global $wpdb;
 		$occurrences = Occurrences::table_name( true );
 
@@ -374,12 +374,11 @@ class Custom_Tables_Query extends WP_Query {
 			case 'ID':
 			case $wpdb->posts . '.ID':
 				// If the order is by post ID, order by post ID and occurrence ID.
-				$original_order_by = $this->query_vars['orderby'] ?? [];
+				$original_order_by   = $this->query_vars['orderby'] ?? [];
 				$normalized_order_by = tribe_normalize_orderby( $original_order_by );
-				$occurrences = Occurrences::table_name( true );
-				$order = $normalized_order_by['ID'] ?? $normalized_order_by[ $wpdb->posts . '.ID' ] ?? 'DESC';
-
-				$order = $this->sanitize_order( $order );
+				$occurrences         = Occurrences::table_name( true );
+				$order               = $normalized_order_by['ID'] ?? $normalized_order_by[ $wpdb->posts . '.ID' ] ?? 'DESC';
+				$order               = $this->sanitize_order( $order );
 
 				// The second `order` is omitted: it will be added by the following `parse_order` call.
 				$parsed = "ID $order, $occurrences.occurrence_id";
@@ -407,7 +406,7 @@ class Custom_Tables_Query extends WP_Query {
 			if ( ! $meta_query_orderby && isset( reset( $meta_query_clauses )['original_meta_key'] ) ) {
 				$meta_query_orderby = reset( $meta_query_clauses )['original_meta_key'];
 			}
-		} else if ( isset( $meta_query_clauses[ $orderby ]['original_meta_key'] ) ) {
+		} elseif ( isset( $meta_query_clauses[ $orderby ]['original_meta_key'] ) ) {
 			// Handle the case where the order is by the meta query key.
 			$meta_query_orderby = $meta_query_clauses[ $orderby ]['original_meta_key'];
 		}
@@ -549,17 +548,17 @@ class Custom_Tables_Query extends WP_Query {
 		 */
 		$date_conditions = $this->build_date_conditions_from_meta_query( $query );
 
-		// Check for List View via eventDisplay parameter
+		// Check for List View via eventDisplay parameter.
 		$event_display = $this->get( 'eventDisplay', false );
 
 		// For List View, when no date conditions are in meta_query, apply a future events filter
-		// This ensures we select the first future occurrence, not the globally earliest one
+		// This ensures we select the first future occurrence, not the globally earliest one.
 		if ( $event_display === 'list' && empty( $date_conditions ) ) {
-			$current_time = current_time( 'mysql' );
+			$current_time    = current_time( 'mysql' );
 			$date_conditions = " AND occ.end_date > '{$current_time}'";
 		}
 
-		// Store the date conditions in the query object so hydration can use them
+		// Store the date conditions in the query object so hydration can use them.
 		$this->set( '_tec_occurrence_date_conditions', $date_conditions );
 
 		/**
@@ -568,7 +567,7 @@ class Custom_Tables_Query extends WP_Query {
 		 */
 		$use_simple_limit = empty( $date_conditions );
 
-		// Store whether we're using simple limit so hydration knows whether to apply date filtering
+		// Store whether we're using simple limit so hydration knows whether to apply date filtering.
 		$this->set( '_tec_used_simple_limit', $use_simple_limit );
 
 		/**
@@ -586,14 +585,14 @@ class Custom_Tables_Query extends WP_Query {
 		if ( $use_simple_limit ) {
 			// Simple limit: Get the earliest occurrence per post_id that matches the main WHERE clause
 			// We need to incorporate the date filtering from the main WHERE clause into the subquery
-			// Extract date conditions from the current WHERE clause
+			// Extract date conditions from the current WHERE clause.
 			$where_date_conditions = '';
 			if ( preg_match( '/wp_tec_occurrences\.(start_date|end_date)\s*[<>=]+\s*\'[^\']+\'/i', $where, $matches ) ) {
-				// Extract all date conditions that reference wp_tec_occurrences table
+				// Extract all date conditions that reference wp_tec_occurrences table.
 				preg_match_all( '/wp_tec_occurrences\.(start_date|end_date)\s*[<>=]+\s*\'[^\']+\'/i', $where, $all_matches );
 				if ( ! empty( $all_matches[0] ) ) {
 					foreach ( $all_matches[0] as $condition ) {
-						// Convert wp_tec_occurrences to o1/o2 aliases
+						// Convert wp_tec_occurrences to o1/o2 aliases.
 						$where_date_conditions .= ' AND ' . str_replace( 'wp_tec_occurrences', 'o1', $condition );
 					}
 				}
@@ -609,8 +608,8 @@ class Custom_Tables_Query extends WP_Query {
 				{$where_date_conditions}
 			)";
 		} else {
-			// Date-aware limit: include date conditions in the subquery to select the right occurrence
-			// This ensures that for queries like "events after now", we get the first future occurrence
+			// Date-aware limit: include date conditions in the subquery to select the right occurrence.
+			// This ensures that for queries like "events after now", we get the first future occurrence.
 			$o1_date_conditions = str_replace( 'occ.', 'o1.', $date_conditions );
 			$o2_date_conditions = str_replace( 'occ.', 'o2.', $date_conditions );
 
@@ -646,10 +645,9 @@ class Custom_Tables_Query extends WP_Query {
 			return '';
 		}
 
-		$occurrences = Occurrences::table_name( true );
 		$date_conditions = '';
 
-		// Map meta keys to occurrence table columns
+		// Map meta keys to occurrence table columns.
 		$meta_key_map = [
 			'_EventStartDate'    => 'start_date',
 			'_EventEndDate'      => 'end_date',
@@ -657,7 +655,7 @@ class Custom_Tables_Query extends WP_Query {
 			'_EventEndDateUTC'   => 'end_date_utc',
 		];
 
-		// Extract conditions from meta_query
+		// Extract conditions from meta_query.
 		$queries = $query->meta_query->queries;
 
 		foreach ( $queries as $query_key => $query_item ) {
@@ -665,31 +663,31 @@ class Custom_Tables_Query extends WP_Query {
 				continue;
 			}
 
-			// Check if this is the actual query or metadata (like 'relation')
+			// Check if this is the actual query or metadata (like 'relation').
 			if ( $query_key === 'relation' ) {
 				continue;
 			}
 
-			// Get the meta key - check both 'original_meta_key' (set by Custom Tables) and 'key'
+			// Get the meta key - check both 'original_meta_key' (set by Custom Tables) and 'key'.
 			$meta_key = $query_item['original_meta_key'] ?? $query_item['key'] ?? null;
 
 			if ( ! $meta_key ) {
 				continue;
 			}
 
-			// Only process date-related meta keys
+			// Only process date-related meta keys.
 			if ( ! isset( $meta_key_map[ $meta_key ] ) ) {
 				continue;
 			}
 
-			$column = $meta_key_map[ $meta_key ];
+			$column  = $meta_key_map[ $meta_key ];
 			$compare = $query_item['compare'] ?? '=';
-			$value = $query_item['value'] ?? '';
+			$value   = $query_item['value'] ?? '';
 
-			// Sanitize and escape the value
+			// Sanitize and escape the value.
 			$value = esc_sql( $value );
 
-			// Build the condition
+			// Build the condition.
 			$date_conditions .= " AND occ.{$column} {$compare} '{$value}'";
 		}
 
@@ -746,7 +744,7 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @return bool Whether a property is set on this object or not.
 	 */
-	public function __isset( $name ) {
+	public function __isset( $name ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::__isset( $name );
 	}
 
@@ -773,10 +771,10 @@ class Custom_Tables_Query extends WP_Query {
 	 *
 	 * @since 6.0.4
 	 *
-	 * @param string $found_posts_query The SQL query that would run to fill in the `found_posts` property of the
-	 *                                  `WP_Query` instance.
-	 * @param        $query             WP_Query The `WP_Query` instance that is currently filtering its `found_posts`
-	 *                                  property.
+	 * @param string   $found_posts_query The SQL query that would run to fill in the `found_posts` property of the
+	 *                                    `WP_Query` instance.
+	 * @param WP_Query $query             The `WP_Query` instance that is currently filtering its `found_posts`
+	 *                                    property.
 	 *
 	 * @return string The filtered SQL query that will run to fill in the `found_posts` property of the `WP_Query`
 	 *                instance.
@@ -900,9 +898,9 @@ class Custom_Tables_Query extends WP_Query {
 		 * @param array               $posts The posts that will be hydrated by the Custom Tables Query.
 		 * @param Custom_Tables_Query $this  The Custom Tables Query instance.
 		 */
-		// Pass $this instead of $query, because $this has the date conditions stored
 		$posts = apply_filters( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', $posts, $this );
 
+		// Pass $this instead of $query, because $this has the date conditions stored.
 		return $posts;
 	}
 
@@ -932,7 +930,8 @@ class Custom_Tables_Query extends WP_Query {
 		}
 
 		$redirected_orderbys = '';
-		$orderbys = explode( ',', $posts_orderby );
+		$orderbys            = explode( ',', $posts_orderby );
+
 		foreach ( $orderbys as $orderby_frag ) {
 			// Fast-track the `rand` order, no need to redirect anything.
 			if ( stripos( $orderby_frag, 'rand' ) === 0 ) {
@@ -947,7 +946,7 @@ class Custom_Tables_Query extends WP_Query {
 			} else {
 				// Follow the WordPress default and use DESC if no order is specified.
 				$orderby = $orderby_frag;
-				$order = 'DESC';
+				$order   = 'DESC';
 			}
 
 			if ( strpos( $redirected_orderbys, $orderby ) !== false ) {


### PR DESCRIPTION
This attempts to address a recurring events issue when Pro is not active.

### 🎫 Ticket

[TEC-5709]

### 🗒️ Description

If we create recurring events with ECP active, then deactivate ECP, the calendar query is broken as the custom tables code modifies it but does not handle the occurrences correctly - resulting in repeating the base event and repeating the month it occurs in.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
#### Broken (on a sandbox):
<img width="2926" height="4488" alt="Screen Shot 2025-10-07 at 12 51 10-fullpage" src="https://github.com/user-attachments/assets/b2d66473-3d11-446d-8906-07d740951bfa" />

#### Corrected (local):
##### With ECP:
<img width="2926" height="8966" alt="Screen Shot 2025-10-07 at 12 52 01-fullpage" src="https://github.com/user-attachments/assets/05be6da4-8fb5-4bdd-87fd-096519674262" />

##### Without ECP:
<img width="2926" height="4956" alt="Screen Shot 2025-10-07 at 20 30 36-fullpage" src="https://github.com/user-attachments/assets/eda4ff90-c9dd-483a-a22b-29a3168eb559" />



### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5709]: https://stellarwp.atlassian.net/browse/TEC-5709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ