### PR TITLE
Only show next occurrence when ECP is deactivated

### DIFF
--- a/changelog/fix-TEC-5709-only-show-next-occurrence
+++ b/changelog/fix-TEC-5709-only-show-next-occurrence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Handle event recurrences when Events Calendar Pro is deactivated. [TEC-5709]

--- a/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
@@ -12,7 +12,6 @@ namespace TEC\Events\Custom_Tables\V1\Views\V2;
 
 use stdClass;
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
-use Tribe\Events\Models\Post_Types\Event;
 use Tribe__Timezones as Timezones;
 
 /**
@@ -48,9 +47,41 @@ class By_Day_View_Compatibility {
 		$prepared = [];
 
 		while ( $ids_count ) {
-			$ids_chunk   = array_splice( $ids, 0, $ids_chunk_size );
-			$ids_count   = count( $ids );
+			$ids_chunk = array_splice( $ids, 0, $ids_chunk_size );
+			$ids_count = count( $ids );
+
 			$occurrences = Occurrence::where_in( 'post_id', $ids_chunk )->all();
+
+			// When Pro is not active, limit to one occurrence per event: the next
+			// upcoming one, or the most recent past one if none are upcoming.
+			if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+				$now       = current_time( 'mysql' );
+				$by_post   = [];
+
+				foreach ( $occurrences as $occurrence ) {
+					$by_post[ $occurrence->post_id ][] = $occurrence;
+				}
+
+				$occurrences = [];
+				foreach ( $by_post as $post_occurrences ) {
+					// Find the next upcoming occurrence.
+					$upcoming = null;
+					$latest   = null;
+
+					foreach ( $post_occurrences as $occ ) {
+						if ( $occ->start_date >= $now ) {
+							if ( ! $upcoming || $occ->start_date < $upcoming->start_date ) {
+								$upcoming = $occ;
+							}
+						}
+						if ( ! $latest || $occ->start_date > $latest->start_date ) {
+							$latest = $occ;
+						}
+					}
+
+					$occurrences[] = $upcoming ?? $latest;
+				}
+			}
 
 			foreach ( $occurrences as $occurrence ) {
 				/** @var Occurrence $occurrence */

--- a/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
@@ -64,22 +64,11 @@ class By_Day_View_Compatibility {
 
 				$occurrences = [];
 				foreach ( $by_post as $post_occurrences ) {
-					// Find the next upcoming occurrence.
-					$upcoming = null;
-					$latest   = null;
+					usort( $post_occurrences, static fn( $a, $b ) => $a->start_date <=> $b->start_date );
 
-					foreach ( $post_occurrences as $occ ) {
-						if ( $occ->start_date >= $now ) {
-							if ( ! $upcoming || $occ->start_date < $upcoming->start_date ) {
-								$upcoming = $occ;
-							}
-						}
-						if ( ! $latest || $occ->start_date > $latest->start_date ) {
-							$latest = $occ;
-						}
-					}
+					$upcoming = array_filter( $post_occurrences, static fn( $occ ) => $occ->start_date >= $now );
 
-					$occurrences[] = $upcoming ?? $latest;
+					$occurrences[] = ! empty( $upcoming ) ? reset( $upcoming ) : end( $post_occurrences );
 				}
 			}
 

--- a/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/By_Day_View_Compatibility.php
@@ -55,8 +55,8 @@ class By_Day_View_Compatibility {
 			// When Pro is not active, limit to one occurrence per event: the next
 			// upcoming one, or the most recent past one if none are upcoming.
 			if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
-				$now       = current_time( 'mysql' );
-				$by_post   = [];
+				$now     = current_time( 'mysql' );
+				$by_post = [];
 
 				foreach ( $occurrences as $occurrence ) {
 					$by_post[ $occurrence->post_id ][] = $occurrence;

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -33,6 +33,7 @@ class Provider extends Service_Provider {
 	 * with Views v2.
 	 *
 	 * @since 6.0.0
+	 * @since TBD Add filter to hydrate posts with next upcoming occurrence dates when Pro is inactive.
 	 */
 	public function register() {
 		$this->container->singleton( Customizer_Compatibility::class, Customizer_Compatibility::class );
@@ -43,10 +44,15 @@ class Provider extends Service_Provider {
 		], 10, 2 );
 
 		// Hydrate posts with next upcoming occurrence dates when Pro is inactive.
-		add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
-			$this,
-			'hydrate_posts_with_upcoming_occurrence_dates',
-		], 10, 2 );
+		add_filter(
+			'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts',
+			[
+				$this,
+				'hydrate_posts_with_upcoming_occurrence_dates',
+			],
+			10,
+			2
+		);
 
 		// Handle Customizer styles.
 		add_filter( 'tribe_customizer_global_elements_css_template', [

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -11,9 +11,11 @@ namespace TEC\Events\Custom_Tables\V1\Views\V2;
 
 use Exception;
 use stdClass;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use Tribe__Customizer as Customizer;
 use Tribe__Customizer__Section as Customizer_Section;
 use TEC\Common\Contracts\Service_Provider;
+use WP_Post;
 
 
 /**
@@ -39,6 +41,14 @@ class Provider extends Service_Provider {
 			$this,
 			'prepare_by_day_view_day_results',
 		], 10, 2 );
+
+		// When Pro is inactive, hydrate posts with next upcoming occurrence dates.
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
+				$this,
+				'hydrate_posts_with_upcoming_occurrence_dates',
+			], 10, 2 );
+		}
 
 		// Handle Customizer styles.
 		add_filter( 'tribe_customizer_global_elements_css_template', [
@@ -80,5 +90,80 @@ class Provider extends Service_Provider {
 	public function update_global_customizer_styles( $css_template, $section, $customizer ) {
 		return $this->container->make( Customizer_Compatibility::class )
 		                       ->update_global_customizer_styles( $css_template, $section, $customizer );;
+	}
+
+	/**
+	 * Updates the post meta cache with the next upcoming occurrence dates when Pro is inactive.
+	 *
+	 * When Pro is deactivated but recurring event data remains, the post meta still reflects the
+	 * original first occurrence dates. This method overrides the cached meta with the next upcoming
+	 * occurrence's dates so List View and other views display the correct date.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $posts The posts returned by the Custom Tables Query.
+	 *
+	 * @return array The posts, unchanged. Side effect: post meta cache is updated.
+	 */
+	public function hydrate_posts_with_upcoming_occurrence_dates( $posts ) {
+		if ( empty( $posts ) ) {
+			return $posts;
+		}
+
+		$now = current_time( 'mysql' );
+
+		foreach ( $posts as $post ) {
+			$post_id = $post instanceof WP_Post ? $post->ID : (int) $post;
+
+			if ( empty( $post_id ) ) {
+				continue;
+			}
+
+			// Only hydrate events that have multiple occurrences (leftover from Pro).
+			// Events with a single occurrence already have correct dates in post meta.
+			$occurrence_count = Occurrence::where( 'post_id', '=', $post_id )->count();
+
+			if ( $occurrence_count <= 1 ) {
+				continue;
+			}
+
+			// Get the next upcoming occurrence for this event.
+			$occurrence = Occurrence::where( 'post_id', '=', $post_id )
+				->where( 'start_date', '>=', $now )
+				->order_by( 'start_date', 'ASC' )
+				->first();
+
+			// Fall back to the most recent past occurrence.
+			if ( ! $occurrence ) {
+				$occurrence = Occurrence::where( 'post_id', '=', $post_id )
+					->order_by( 'start_date', 'DESC' )
+					->first();
+			}
+
+			if ( ! $occurrence ) {
+				continue;
+			}
+
+			// Update the post meta cache with this occurrence's dates.
+			$meta_cache = wp_cache_get( $post_id, 'post_meta' );
+
+			if ( false === $meta_cache ) {
+				update_meta_cache( 'post', [ $post_id ] );
+				$meta_cache = wp_cache_get( $post_id, 'post_meta' );
+			}
+
+			if ( ! is_array( $meta_cache ) ) {
+				continue;
+			}
+
+			$meta_cache['_EventStartDate']    = [ $occurrence->start_date ];
+			$meta_cache['_EventEndDate']      = [ $occurrence->end_date ];
+			$meta_cache['_EventStartDateUTC'] = [ $occurrence->start_date_utc ];
+			$meta_cache['_EventEndDateUTC']   = [ $occurrence->end_date_utc ];
+
+			wp_cache_set( $post_id, $meta_cache, 'post_meta' );
+		}
+
+		return $posts;
 	}
 }

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -44,10 +44,15 @@ class Provider extends Service_Provider {
 
 		// When Pro is inactive, hydrate posts with next upcoming occurrence dates.
 		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
-			add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
-				$this,
-				'hydrate_posts_with_upcoming_occurrence_dates',
-			], 10, 2 );
+			add_filter(
+				'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts',
+				[
+					$this,
+					'hydrate_posts_with_upcoming_occurrence_dates',
+				],
+				10,
+				2
+			);
 		}
 
 		// Handle Customizer styles.

--- a/src/Events/Custom_Tables/V1/Views/V2/Provider.php
+++ b/src/Events/Custom_Tables/V1/Views/V2/Provider.php
@@ -42,18 +42,11 @@ class Provider extends Service_Provider {
 			'prepare_by_day_view_day_results',
 		], 10, 2 );
 
-		// When Pro is inactive, hydrate posts with next upcoming occurrence dates.
-		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
-			add_filter(
-				'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts',
-				[
-					$this,
-					'hydrate_posts_with_upcoming_occurrence_dates',
-				],
-				10,
-				2
-			);
-		}
+		// Hydrate posts with next upcoming occurrence dates when Pro is inactive.
+		add_filter( 'tec_events_custom_tables_v1_custom_tables_query_hydrate_posts', [
+			$this,
+			'hydrate_posts_with_upcoming_occurrence_dates',
+		], 10, 2 );
 
 		// Handle Customizer styles.
 		add_filter( 'tribe_customizer_global_elements_css_template', [
@@ -111,43 +104,53 @@ class Provider extends Service_Provider {
 	 * @return array The posts, unchanged. Side effect: post meta cache is updated.
 	 */
 	public function hydrate_posts_with_upcoming_occurrence_dates( $posts ) {
-		if ( empty( $posts ) ) {
+		if ( ! $posts || class_exists( 'Tribe__Events__Pro__Main' ) ) {
 			return $posts;
+		}
+
+		// Collect post IDs that haven't been hydrated yet.
+		$post_ids = [];
+		foreach ( $posts as $post ) {
+			$post_id = $post instanceof WP_Post ? $post->ID : (int) $post;
+
+			if ( ! $post_id || wp_cache_get( $post_id, 'tec_occurrence_hydrated' ) ) {
+				continue;
+			}
+
+			$post_ids[] = $post_id;
+		}
+
+		if ( ! $post_ids ) {
+			return $posts;
+		}
+
+		// Batch-fetch all occurrences for these posts in a single query.
+		$all_occurrences = Occurrence::where_in( 'post_id', $post_ids )->all();
+
+		// Group occurrences by post_id.
+		$by_post = [];
+		foreach ( $all_occurrences as $occurrence ) {
+			$by_post[ $occurrence->post_id ][] = $occurrence;
 		}
 
 		$now = current_time( 'mysql' );
 
-		foreach ( $posts as $post ) {
-			$post_id = $post instanceof WP_Post ? $post->ID : (int) $post;
+		foreach ( $post_ids as $post_id ) {
+			wp_cache_set( $post_id, true, 'tec_occurrence_hydrated' );
 
-			if ( empty( $post_id ) ) {
+			$occurrences = $by_post[ $post_id ] ?? [];
+
+			// Only hydrate events with multiple occurrences (leftover from Pro).
+			if ( count( $occurrences ) <= 1 ) {
 				continue;
 			}
 
-			// Only hydrate events that have multiple occurrences (leftover from Pro).
-			// Events with a single occurrence already have correct dates in post meta.
-			$occurrence_count = Occurrence::where( 'post_id', '=', $post_id )->count();
+			// Sort by start_date and pick the next upcoming, or fall back to latest.
+			usort( $occurrences, static fn( $a, $b ) => $a->start_date <=> $b->start_date );
 
-			if ( $occurrence_count <= 1 ) {
-				continue;
-			}
+			$upcoming = array_filter( $occurrences, static fn( $occ ) => $occ->start_date >= $now );
 
-			// Get the next upcoming occurrence for this event.
-			$occurrence = Occurrence::where( 'post_id', '=', $post_id )
-				->where( 'start_date', '>=', $now )
-				->order_by( 'start_date', 'ASC' )
-				->first();
-
-			// Fall back to the most recent past occurrence.
-			if ( ! $occurrence ) {
-				$occurrence = Occurrence::where( 'post_id', '=', $post_id )
-					->order_by( 'start_date', 'DESC' )
-					->first();
-			}
-
-			if ( ! $occurrence ) {
-				continue;
-			}
+			$occurrence = ! empty( $upcoming ) ? reset( $upcoming ) : end( $occurrences );
 
 			// Update the post meta cache with this occurrence's dates.
 			$meta_cache = wp_cache_get( $post_id, 'post_meta' );

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -323,8 +323,14 @@ class Custom_Tables_Query extends WP_Query {
 
 		remove_filter( 'posts_groupby', [ $this, 'group_posts_by_occurrence_id' ] );
 
-		$occurrences = Occurrences::table_name( true );
 		global $wpdb;
+		$occurrences = Occurrences::table_name( true );
+
+		// When Pro is not active, group by post ID to collapse duplicate
+		// occurrences left behind by a previously-active Pro.
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			return "$wpdb->posts.ID";
+		}
 
 		// Group by the occurrence ID, not the post ID.
 		return str_replace( "$wpdb->posts.ID", "$occurrences.occurrence_id", $groupby );

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -319,6 +319,12 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 			return $groupby;
 		}
 
+		// When Pro is not active, keep grouping by post ID to collapse
+		// duplicate occurrences left behind by a previously-active Pro.
+		if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+			return $groupby;
+		}
+
 		$this->redirect();
 
 		global $wpdb;

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_filter_repository_queries__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_filter_repository_queries__1.php
@@ -1,9 +1,0 @@
-<?php return '
-			SELECT SQL_CALC_FOUND_ROWS  test_posts.ID, CAST( test_tec_occurrences.start_date AS DATETIME ) AS event_date
-			FROM test_posts 
-JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id 
-			WHERE 1=1  AND test_posts.post_password != \'\' AND test_posts.post_type = \'tribe_events\' AND ((test_posts.post_status <> \'trash\' AND test_posts.post_status <> \'auto-draft\'))
-			GROUP BY test_tec_occurrences.occurrence_id
-			ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
-			LIMIT 0, 10
-		';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set ID__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set ID__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set REST API like query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set REST API like query__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order and order by__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order and order by__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order by__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order by__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by ASC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by ASC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by DESC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by DESC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDate meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDate meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.end_date DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDateUTC meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDateUTC meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.end_date_utc DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDate meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDate meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDateUTC meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDateUTC meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date_utc DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by invalid order type__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by invalid order type__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested ASC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested ASC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested DESC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested DESC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested invalid order type__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested invalid order type__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date DESC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date_utc__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date_utc__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date_utc DESC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_duration__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_duration__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.duration DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set no orderby specified__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set no orderby specified__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set none__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set none__1.php
@@ -2,6 +2,6 @@
 					 FROM test_posts  JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
 					 WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 
+					 GROUP BY test_posts.ID
 					 
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set rand__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set rand__1.php
@@ -2,6 +2,6 @@
 					 FROM test_posts  JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
 					 WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 
+					 GROUP BY test_posts.ID
 					 ORDER BY RAND()
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set relevance__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set relevance__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set wp_posts.ID__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set wp_posts.ID__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -11,10 +11,10 @@ OR test_posts.post_status = \'private\')))
   1 => 'SELECT FOUND_ROWS()',
   2 => 'SELECT COUNT(*)
 FROM `test_tec_occurrences`
-WHERE (`post_id` IN (22,23,24))',
+WHERE (`post_id` IN (203,204,205))',
   3 => 'SELECT *
 FROM `test_tec_occurrences`
-WHERE (`post_id` IN (22,23,24))
+WHERE (`post_id` IN (203,204,205))
 LIMIT 50
 OFFSET 0',
   4 => 'SELECT 3',

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -11,12 +11,12 @@ OR test_posts.post_status = \'private\')))
   1 => 'SELECT FOUND_ROWS()',
   2 => 'SELECT COUNT(*)
 FROM `test_tec_occurrences`
-WHERE (`post_id` = 22)',
+WHERE (`post_id` = 203)',
   3 => 'SELECT COUNT(*)
 FROM `test_tec_occurrences`
-WHERE (`post_id` = 23)',
+WHERE (`post_id` = 204)',
   4 => 'SELECT COUNT(*)
 FROM `test_tec_occurrences`
-WHERE (`post_id` = 24)',
+WHERE (`post_id` = 205)',
   5 => 'SELECT 3',
 );

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -5,9 +5,18 @@
   test_tec_occurrences.start_date > \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_posts.post_date DESC
 					 LIMIT 0, 10',
   1 => 'SELECT FOUND_ROWS()',
-  2 => 'SELECT 3',
+  2 => 'SELECT COUNT(*)
+FROM `test_tec_occurrences`
+WHERE (`post_id` = 22)',
+  3 => 'SELECT COUNT(*)
+FROM `test_tec_occurrences`
+WHERE (`post_id` = 23)',
+  4 => 'SELECT COUNT(*)
+FROM `test_tec_occurrences`
+WHERE (`post_id` = 24)',
+  5 => 'SELECT 3',
 );

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -11,12 +11,11 @@ OR test_posts.post_status = \'private\')))
   1 => 'SELECT FOUND_ROWS()',
   2 => 'SELECT COUNT(*)
 FROM `test_tec_occurrences`
-WHERE (`post_id` = 203)',
-  3 => 'SELECT COUNT(*)
+WHERE (`post_id` IN (22,23,24))',
+  3 => 'SELECT *
 FROM `test_tec_occurrences`
-WHERE (`post_id` = 204)',
-  4 => 'SELECT COUNT(*)
-FROM `test_tec_occurrences`
-WHERE (`post_id` = 205)',
-  5 => 'SELECT 3',
+WHERE (`post_id` IN (22,23,24))
+LIMIT 50
+OFFSET 0',
+  4 => 'SELECT 3',
 );

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_an_event_query__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_an_event_query__1.php
@@ -5,6 +5,6 @@
   AND 
   test_tec_occurrences.end_date >= \'2022-09-28 13:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_main_events_query__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_main_events_query__1.php
@@ -5,6 +5,6 @@
   AND 
   test_tec_occurrences.end_date >= \'2022-09-28 13:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_not_filter_and_order_a_query_if_suppressed__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_not_filter_and_order_a_query_if_suppressed__1.php
@@ -1,6 +1,6 @@
 <?php return 'SELECT SQL_CALC_FOUND_ROWS  test_posts.ID
 					 FROM test_posts  JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
 					 WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 
+					 GROUP BY test_posts.ID
 					 ORDER BY test_posts.post_date DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_not_filter_and_order_the_main_query_if_suppressed__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_not_filter_and_order_the_main_query_if_suppressed__1.php
@@ -1,6 +1,6 @@
 <?php return 'SELECT SQL_CALC_FOUND_ROWS  test_posts.ID
 					 FROM test_posts  JOIN test_tec_occurrences ON test_posts.ID = test_tec_occurrences.post_id
 					 WHERE 1=1  AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 
+					 GROUP BY test_posts.ID
 					 ORDER BY test_posts.post_date DESC
 					 LIMIT 0, 10';


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5709]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

If a user creates a recurring event, each occurrence is saved in the database in the `tec_occurrences` table, but if ECP is deactivated, the meta data (including the dates) are not accessible and each occurrence on the frontend looks appears to just be the first event duplicated as many times as there are occurrences. 

The fix here is to only show the next upcoming occurrence when ECP is deactivated. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
After: 

https://github.com/user-attachments/assets/7c7ac261-6d64-42dc-b158-275c58a46e41



### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5709]: https://stellarwp.atlassian.net/browse/TEC-5709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ