### PR TITLE
Fix/site editor editentityrecord guard

### DIFF
--- a/changelog/2026-04-10-23-54-04-896929
+++ b/changelog/2026-04-10-23-54-04-896929
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compatibility
+
+Guard editEntityRecord calls with getCurrentPostType() check to prevent crash in the FSE site editor when the tribe_events entity config is not registered in core-data

--- a/src/modules/blocks/event-venue/data/__tests__/meta-sync.test.js
+++ b/src/modules/blocks/event-venue/data/__tests__/meta-sync.test.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { syncVenuesWithPost } from '../meta-sync';
+
+jest.mock( '@moderntribe/common/utils/globals', () => {
+	const dispatchModule = {
+		editEntityRecord: jest.fn(),
+	};
+	const selectModule = {
+		getCurrentPostId: jest.fn( () => 1 ),
+		getCurrentPostType: jest.fn( () => 'tribe_events' ),
+	};
+
+	return {
+		__esModule: true,
+		wpData: {
+			dispatch: jest.fn( () => dispatchModule ),
+			select: jest.fn( () => selectModule ),
+		},
+	};
+} );
+
+jest.mock( '@moderntribe/events/data/blocks/venue', () => {
+	return {
+		__esModule: true,
+		selectors: {
+			getVenuesInBlock: jest.fn( () => [ 42 ] ),
+		},
+	};
+} );
+
+jest.mock( '@moderntribe/common/store', () => {
+	return {
+		__esModule: true,
+		store: {
+			getState: jest.fn( () => ( {} ) ),
+		},
+	};
+} );
+
+jest.mock( '@moderntribe/common/data', () => {
+	return {
+		__esModule: true,
+		editor: {
+			EVENT: 'tribe_events',
+			VENUE: 'tribe_venue',
+			ORGANIZER: 'tribe_organizer',
+		},
+	};
+} );
+
+const { wpData } = require( '@moderntribe/common/utils/globals' );
+
+describe( '[BLOCK] - Event Venue meta-sync', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'Should sync venue ID to post meta when current post type is tribe_events', () => {
+		syncVenuesWithPost();
+
+		expect( wpData.select( 'core/editor' ).getCurrentPostType ).toHaveBeenCalledTimes( 1 );
+		expect( wpData.select( 'core/editor' ).getCurrentPostId ).toHaveBeenCalledTimes( 1 );
+		expect( wpData.dispatch( 'core' ).editEntityRecord ).toHaveBeenCalledTimes( 1 );
+		expect( wpData.dispatch( 'core' ).editEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'tribe_events',
+			1,
+			{ meta: { _EventVenueID: [ 42 ] } }
+		);
+	} );
+
+	it( 'Should not call editEntityRecord when current post type is not tribe_events (e.g. FSE site editor)', () => {
+		wpData.select( 'core/editor' ).getCurrentPostType.mockReturnValueOnce( 'wp_template' );
+
+		syncVenuesWithPost();
+
+		expect( wpData.select( 'core/editor' ).getCurrentPostType ).toHaveBeenCalledTimes( 1 );
+		expect( wpData.select( 'core/editor' ).getCurrentPostId ).toHaveBeenCalledTimes( 0 );
+		expect( wpData.dispatch( 'core' ).editEntityRecord ).toHaveBeenCalledTimes( 0 );
+	} );
+} );

--- a/src/modules/blocks/event-venue/data/meta-sync.js
+++ b/src/modules/blocks/event-venue/data/meta-sync.js
@@ -13,6 +13,11 @@ const { getState } = store;
  * @since 6.2.0
  */
 export const syncVenuesWithPost = () => {
+	const postType = wpData.select( 'core/editor' ).getCurrentPostType();
+	if ( postType !== editor.EVENT ) {
+		return;
+	}
+
 	const postId = wpData.select( 'core/editor' ).getCurrentPostId();
 	const modifiedPost = {
 		meta: {

--- a/src/modules/data/blocks/organizers/__tests__/subscribers.test.js
+++ b/src/modules/data/blocks/organizers/__tests__/subscribers.test.js
@@ -22,6 +22,7 @@ jest.mock( '@moderntribe/common/utils', () => {
 	};
 	const selectModule = {
 		getCurrentPostId: jest.fn( () => {} ),
+		getCurrentPostType: jest.fn( () => 'tribe_events' ),
 		getBlocks: jest.fn( () => {} ),
 	};
 
@@ -211,6 +212,23 @@ describe( '[STORE] - Organizers subscribers', () => {
 		expect( organizerActions.removeOrganizerInClassic ).toHaveBeenCalledTimes( 0 );
 		expect( formActions.removeVolatile ).toHaveBeenCalledTimes( 0 );
 		expect( organizerSelectors.getOrganizersInClassic ).toHaveBeenCalledTimes( 0 );
+		expect( globals.wpData.select( 'core/editor' ).getCurrentPostId ).toHaveBeenCalledTimes( 0 );
+		expect( globals.wpData.dispatch( 'core' ).editEntityRecord ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'Should not call editEntityRecord when current post type is not tribe_events (e.g. FSE site editor)', () => { // eslint-disable-line max-len
+		globals.wpData.select( 'core/editor' ).getCurrentPostType.mockReturnValueOnce( 'wp_template' );
+
+		const organizerBlockWithOrganizer = {
+			name: 'tribe/event-organizer',
+			clientId: 'organizer-1',
+			attributes: { organizer: 99 },
+		};
+
+		handleBlockRemoved( [] )( organizerBlockWithOrganizer );
+		expect( organizerActions.removeOrganizerInClassic ).toHaveBeenCalledTimes( 1 );
+		expect( formActions.removeVolatile ).toHaveBeenCalledTimes( 1 );
+		expect( globals.wpData.select( 'core/editor' ).getCurrentPostType ).toHaveBeenCalledTimes( 1 );
 		expect( globals.wpData.select( 'core/editor' ).getCurrentPostId ).toHaveBeenCalledTimes( 0 );
 		expect( globals.wpData.dispatch( 'core' ).editEntityRecord ).toHaveBeenCalledTimes( 0 );
 	} );

--- a/src/modules/data/blocks/organizers/subscribers.js
+++ b/src/modules/data/blocks/organizers/subscribers.js
@@ -114,16 +114,19 @@ export const handleBlockRemoved = ( currBlocks ) => ( block ) => {
 		dispatch( organizerActions.removeOrganizerInClassic( organizer ) );
 		dispatch( formActions.removeVolatile( organizer ) );
 
-		// set event organizer meta
-		const classicOrganizers = organizerSelectors.getOrganizersInClassic( getState() );
-		const postId = globals.wpData.select( 'core/editor' ).getCurrentPostId();
-		const record = {
-			meta: {
-				_EventOrganizerID: classicOrganizers,
-			},
-		};
+		// set event organizer meta only when editing a tribe_events post
+		const currentPostType = globals.wpData.select( 'core/editor' ).getCurrentPostType();
+		if ( currentPostType === editor.EVENT ) {
+			const classicOrganizers = organizerSelectors.getOrganizersInClassic( getState() );
+			const postId = globals.wpData.select( 'core/editor' ).getCurrentPostId();
+			const record = {
+				meta: {
+					_EventOrganizerID: classicOrganizers,
+				},
+			};
 
-		globals.wpData.dispatch( 'core' ).editEntityRecord( 'postType', editor.EVENT, postId, record );
+			globals.wpData.dispatch( 'core' ).editEntityRecord( 'postType', editor.EVENT, postId, record );
+		}
 	}
 };
 

--- a/src/modules/data/blocks/subscribers.js
+++ b/src/modules/data/blocks/subscribers.js
@@ -68,6 +68,12 @@ const subscribe = () => {
 			website: [ websiteReducer.defaultStateToMetaMap, websiteSelectors.getWebsiteBlock ],
 		};
 		const blockKeys = Object.keys( blockToMapAndSelectorMap );
+
+		const postType = wpSelect( 'core/editor' ).getCurrentPostType();
+		if ( postType !== editor.EVENT ) {
+			return;
+		}
+
 		const postId = wpSelect( 'core/editor' ).getCurrentPostId();
 
 		const meta = blockKeys.reduce(


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
 TECTRIA-645
https://wordpress.org/support/topic/the-editor-is-dirty-before-meta-is-available/

### 🗒️ Description

In the WordPress Full Site Editor (FSE), when editing templates that contain The Events Calendar blocks, the block editor subscribers fire and attempt to call editEntityRecord('postType', 'tribe_events', ...) against WordPress core-data. However, in the FSE context the current "post" is a wp_template or wp_template_part — the tribe_events entity config is never loaded into the core-data store, so the store's entity config lookup returns undefined and accessing .meta on it throws:

```
TypeError: Cannot read properties of undefined (reading 'meta')
    at core-data.min.js Array.reduce
    at editEntityRecord
    at build/app/main.js
```    
    
#### Changes

Added a getCurrentPostType() guard before each editEntityRecord call in three places:

`src/modules/data/blocks/subscribers.js` — datetime/price/venue/website meta sync
`src/modules/data/blocks/organizers/subscribers.js` — organizer removal handler
`src/modules/blocks/event-venue/data/meta-sync.js` — syncVenuesWithPost
When the current post type is not tribe_events the functions return early, preventing the crash. Normal event editing behavior is completely unaffected.

#### Testing

Updated organizers/subscribers.test.js mock to include getCurrentPostType and added a new test asserting editEntityRecord is not called in the FSE context
Created event-venue/data/__tests__/meta-sync.test.js covering both the happy path (tribe_events) and the FSE bail-out (wp_template)

<img width="573" height="308" alt="Screenshot 2026-04-11 at 12 26 44 PM" src="https://github.com/user-attachments/assets/400688c0-e98d-4aab-8ae3-726973180a50" />

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
