### PR TITLE
Rebrand to Nexcess | SCON-355

### DIFF
--- a/changelog/rebrand-to-liquid-web
+++ b/changelog/rebrand-to-liquid-web
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Updated branding references from StellarWP to Liquid Web.
+Updated branding references from StellarWP to Nexcess.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,13 +9,13 @@
 	</rule>
 
 	<rule ref="WordPress">
-		<!-- Exclude Generic rules that overlap with or are overridden by Liquid Web standards -->
+		<!-- Exclude Generic rules that overlap with or are overridden by Nexcess standards -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 
-		<!-- Exclude PEAR rules that overlap with Liquid Web standards -->
+		<!-- Exclude PEAR rules that overlap with Nexcess standards -->
 		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid"/>
 
-		<!-- Exclude WP rules that overlap with or are overridden by Liquid Web standards -->
+		<!-- Exclude WP rules that overlap with or are overridden by Nexcess standards -->
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === The Events Calendar ===
 
-Contributors: theeventscalendar, liquidweb, borkweb, bordoni, brianjessee, aguseo, camwynsp, jentheo, leahkoerper, lucatume, neillmcshea, vicskf, zbtirrell
+Contributors: theeventscalendar, nexcess, borkweb, bordoni, brianjessee, aguseo, camwynsp, jentheo, leahkoerper, lucatume, neillmcshea, vicskf, zbtirrell
 Tags: events, calendar, event, schedule, organizer
 Donate link: https://evnt.is/29
 Stable tag: 6.15.21


### PR DESCRIPTION
:ticket: [SCON-355]


Rebrand from Liquid Web to Nexcess. Follows the original `Rebrand to Liquid Web | SCON-355` PR (#5611).

The substitutions were derived from #5611's diff: every `+` line that introduced "Liquid Web" content was rewritten to say "Nexcess". Telemetry-related text and test snapshots were intentionally excluded so they can be reviewed separately.

**Note:** This PR targets `bucket/product-consolidation`. If a more appropriate base branch exists, a reviewer can update the base accordingly.

**Note:** phpcs failure is unrelated.

[SCON-355]: https://stellarwp.atlassian.net/browse/SCON-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ