### PR TITLE
[TEC-5750] Fix SEO excessive indexed urls

### DIFF
--- a/changelog/TEC-5750-disabled-view-404
+++ b/changelog/TEC-5750-disabled-view-404
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-URLs specifying a disabled view slug via ?eventDisplay returning HTTP 200 instead of 404. [TEC-5750]
+URLs specifying a disabled view slug via ?eventDisplay now return HTTP 404 instead of 200. [TEC-5750]

--- a/changelog/TEC-5750-disabled-view-404
+++ b/changelog/TEC-5750-disabled-view-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+URLs specifying a disabled view slug via ?eventDisplay returning HTTP 200 instead of 404. [TEC-5750]

--- a/changelog/TEC-5750-list-view-seo
+++ b/changelog/TEC-5750-list-view-seo
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Dated List view URLs carrying ?tribe-bar-date outside the known event range returning HTTP 200, preventing accumulation of low-value indexed pages in search engines. [TEC-5750]

--- a/changelog/TEC-5750-list-view-seo
+++ b/changelog/TEC-5750-list-view-seo
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Dated List view URLs carrying ?tribe-bar-date outside the known event range returning HTTP 200, preventing accumulation of low-value indexed pages in search engines. [TEC-5750]
+Dated List view URLs carrying ?tribe-bar-date outside the known event range now return HTTP 404 by default, and can be configured to use a soft noindex response instead, helping prevent accumulation of low-value indexed pages in search engines. [TEC-5750]

--- a/changelog/TEC-5750-seo-settings
+++ b/changelog/TEC-5750-seo-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: feat
 
-Added a "SEO & URL Handling" settings, allowing site owners to configure out-of-range URL behavior [TEC-5750]
+Added "SEO & URL Handling" settings, allowing site owners to configure out-of-range URL behavior [TEC-5750]

--- a/changelog/TEC-5750-seo-settings
+++ b/changelog/TEC-5750-seo-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: feat
+
+Added a "SEO & URL Handling" settings, allowing site owners to configure out-of-range URL behavior [TEC-5750]

--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -214,9 +214,22 @@ class Controller extends Controller_Contract {
 
 
 	/**
-	 * Determine if a nonindex should be added for list based views that don't have events.
+	 * Determine if a noindex should be added for list-based views.
+	 *
+	 * Returns true when:
+	 * - The view has no events (existing behaviour).
+	 * - The URL carries ?tribe-bar-date as a raw query parameter, meaning the user
+	 *   navigated to a date-specific List view URL. These parameterised URLs produce
+	 *   duplicate content — the canonical tag already points to the base /events/list/
+	 *   URL — so adding noindex closes the indexing loop without removing content.
+	 *
+	 * To allow date-parameterised List view URLs to be indexed (e.g. for sites that
+	 * intentionally expose dated list views), add:
+	 *
+	 *     add_filter( 'tec_events_seo_robots_meta_include_list', '__return_false' );
 	 *
 	 * @since 6.2.6
+	 * @since TBD Also returns true when ?tribe-bar-date is present.
 	 *
 	 * @param View_Interface $instance The view instance.
 	 *
@@ -227,6 +240,12 @@ class Controller extends Controller_Contract {
 
 		if ( ! $context->is( 'tec_post_type' ) ) {
 			return false;
+		}
+
+		// Any dated List view URL (?tribe-bar-date present) is a parameterised variant
+		// of the canonical base URL and should not be independently indexed.
+		if ( ! empty( tribe_get_request_var( 'tribe-bar-date' ) ) ) {
+			return true;
 		}
 
 		$events = $instance->get_repository();

--- a/src/Events/SEO/Controller.php
+++ b/src/Events/SEO/Controller.php
@@ -10,6 +10,7 @@
  namespace TEC\Events\SEO;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Events\SEO\Settings;
 use Tribe\Events\Views\V2\View_Interface;
 use Tribe\Events\Views\V2\Views;
 use Tribe__Date_Utils as Dates;
@@ -50,6 +51,11 @@ class Controller extends Controller_Contract {
 
 		// Hook to determine robots noindex.
 		add_action( 'wp', [ $this, 'hook_issue_noindex' ] );
+
+		// Register admin settings for SEO & URL Handling.
+		/** @var Settings $settings */
+		$settings = $this->container->make( Settings::class );
+		$settings->add_hooks();
 	}
 
 	/**
@@ -58,6 +64,10 @@ class Controller extends Controller_Contract {
 	public function unregister(): void {
 		remove_action( 'wp', [ $this, 'hook_issue_noindex' ] );
 		remove_action( 'tec_events_before_view_html_cache', [ $this, 'issue_noindex' ] );
+
+		/** @var Settings $settings */
+		$settings = $this->container->make( Settings::class );
+		$settings->unregister_hooks();
 	}
 
 	/**
@@ -244,7 +254,11 @@ class Controller extends Controller_Contract {
 
 		// Any dated List view URL (?tribe-bar-date present) is a parameterised variant
 		// of the canonical base URL and should not be independently indexed.
-		if ( ! empty( tribe_get_request_var( 'tribe-bar-date' ) ) ) {
+		// This can be disabled per-site via Settings > Display > SEO & URL Handling.
+		if (
+			! empty( tribe_get_request_var( 'tribe-bar-date' ) )
+			&& tribe_get_option( Settings::OPT_NOINDEX_DATED_LIST_URLS, true )
+		) {
 			return true;
 		}
 

--- a/src/Events/SEO/Headers/Controller.php
+++ b/src/Events/SEO/Headers/Controller.php
@@ -97,18 +97,34 @@ class Controller extends Controller_Contract {
 			! isset( $wp_query->query['post_type'] )
 			|| $wp_query->query['post_type'] !== TEC::POSTTYPE
 			|| ! isset( $wp_query->query['eventDisplay'] )
-			|| ! isset( $wp_query->query['eventDate'] )
 		) {
 			return;
 		}
 
-		$enabled_views = tribe_get_option( 'tribeEnableViews' );
+		$enabled_views = tribe_get_option( 'tribeEnableViews', [] );
 		$event_display = $wp_query->query['eventDisplay'];
+
+		// 404 for any view that is currently disabled, regardless of how the URL was built.
+		if ( ! in_array( $event_display, $enabled_views, true ) ) {
+			$this->set_404( $wp_query );
+			return;
+		}
+
+		// Day/Month views carry the date as a WP query var (set by URL rewrite rules).
+		// List view keeps the date as a raw GET parameter (?tribe-bar-date) instead.
+		$has_pretty_date = isset( $wp_query->query['eventDate'] );
+		$has_list_date   = 'list' === $event_display && ! empty( tribe_get_request_var( 'tribe-bar-date' ) );
+
+		if ( ! $has_pretty_date && ! $has_list_date ) {
+			return;
+		}
 
 		if ( 'day' === $event_display ) {
 			$this->check_day_view( $wp_query, $enabled_views );
 		} elseif ( 'month' === $event_display ) {
 			$this->check_month_view( $wp_query, $enabled_views );
+		} elseif ( 'list' === $event_display ) {
+			$this->check_list_view( $wp_query, $enabled_views );
 		}
 	}
 
@@ -167,7 +183,7 @@ class Controller extends Controller_Contract {
 	 */
 	private function check_day_view( object $wp_query, array $enabled_views ) {
 		if ( ! in_array( 'day', $enabled_views, true ) ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
@@ -180,13 +196,13 @@ class Controller extends Controller_Contract {
 		}
 
 		if ( strtotime( $data['earliest_date_str'] ) > $data['event_timestamp'] ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
 
 		if ( strtotime( $data['latest_date_str'] ) < $data['event_timestamp'] ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
@@ -203,7 +219,7 @@ class Controller extends Controller_Contract {
 	 */
 	private function check_month_view( object $wp_query, array $enabled_views ) {
 		if ( ! in_array( 'month', $enabled_views, true ) ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
@@ -217,16 +233,88 @@ class Controller extends Controller_Contract {
 		}
 
 		if ( $data['earliest_date_str'] > $data['event_date_str'] ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
 
 		if ( $data['latest_date_str'] < $data['event_date_str'] ) {
-			$wp_query->set_404();
+			$this->set_404( $wp_query );
 
 			return;
 		}
+	}
+
+	/**
+	 * Check the conditions for the list view.
+	 *
+	 * Returns a 404 when:
+	 * - List view is disabled in TEC settings.
+	 * - The ?tribe-bar-date parameter refers to a date before the earliest event on record.
+	 * - The ?tribe-bar-date parameter refers to a date after the latest event on record.
+	 *
+	 * Mirrors the grace logic used in check_day_view(): if the site has no events yet and
+	 * the requested date is in the current month, validation is skipped so the live list
+	 * view is not erroneously suppressed.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $wp_query      The global WP_Query object.
+	 * @param array  $enabled_views An array of the enabled view slugs.
+	 */
+	private function check_list_view( object $wp_query, array $enabled_views ): void {
+		if ( ! in_array( 'list', $enabled_views, true ) ) {
+			$this->set_404( $wp_query );
+			return;
+		}
+
+		// List view stores the date in ?tribe-bar-date (a raw GET param, not a WP query var).
+		$tribe_bar_date = tribe_get_request_var( 'tribe-bar-date', '' );
+
+		if ( empty( $tribe_bar_date ) ) {
+			return;
+		}
+
+		$event_timestamp = strtotime( $tribe_bar_date );
+
+		// Bail on malformed date strings.
+		if ( false === $event_timestamp ) {
+			return;
+		}
+
+		$event_month   = gmdate( 'Y-m', $event_timestamp );
+		$current_month = static::get_current_month();
+
+		$earliest_date_str = tribe_events_earliest_date( 'Y-m-d' );
+		$latest_date_str   = tribe_events_latest_date( 'Y-m-d' );
+
+		// Skip validation when no events exist yet but the date is in the current month.
+		if ( ( ! $earliest_date_str || ! $latest_date_str ) && $event_month === $current_month ) {
+			return;
+		}
+
+		if ( $earliest_date_str && strtotime( $earliest_date_str ) > $event_timestamp ) {
+			$this->set_404( $wp_query );
+			return;
+		}
+
+		if ( $latest_date_str && strtotime( $latest_date_str ) < $event_timestamp ) {
+			$this->set_404( $wp_query );
+		}
+	}
+
+	/**
+	 * Set the query to 404 and send the HTTP 404 status header.
+	 *
+	 * WordPress's handle_404() only sends status_header(404) when it is the one
+	 * deciding to set the 404 state. When the state is already set (by our
+	 * send_headers callback) it bails early, so we must send the header ourselves.
+	 *
+	 * @param \WP_Query $wp_query The query to mark as 404.
+	 */
+	private function set_404( \WP_Query $wp_query ): void {
+		$wp_query->set_404();
+		status_header( 404 );
 	}
 
 	/**

--- a/src/Events/SEO/Headers/Controller.php
+++ b/src/Events/SEO/Headers/Controller.php
@@ -10,6 +10,7 @@
 namespace TEC\Events\SEO\Headers;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Events\SEO\Settings;
 use Tribe__Events__Main as TEC;
 
 /**
@@ -104,26 +105,34 @@ class Controller extends Controller_Contract {
 		$enabled_views = tribe_get_option( 'tribeEnableViews', [] );
 		$event_display = $wp_query->query['eventDisplay'];
 
+		// 'past' is a List view display-mode modifier, not a view slug — normalize it so
+		// the enabled-view guard and per-view dispatch both treat it as 'list'.
+		$effective_display = 'past' === $event_display ? 'list' : $event_display;
+
 		// 404 for any view that is currently disabled, regardless of how the URL was built.
-		if ( ! in_array( $event_display, $enabled_views, true ) ) {
-			$this->set_404( $wp_query );
+		// Site owners can disable this guard via Settings > Display > SEO & URL Handling.
+		if ( ! in_array( $effective_display, $enabled_views, true ) ) {
+			if ( tribe_get_option( Settings::OPT_DISABLED_VIEW_404, true ) ) {
+				$this->set_404( $wp_query );
+			}
+			// Either way, skip per-view date checks for a disabled view.
 			return;
 		}
 
 		// Day/Month views carry the date as a WP query var (set by URL rewrite rules).
 		// List view keeps the date as a raw GET parameter (?tribe-bar-date) instead.
 		$has_pretty_date = isset( $wp_query->query['eventDate'] );
-		$has_list_date   = 'list' === $event_display && ! empty( tribe_get_request_var( 'tribe-bar-date' ) );
+		$has_list_date   = 'list' === $effective_display && ! empty( tribe_get_request_var( 'tribe-bar-date' ) );
 
 		if ( ! $has_pretty_date && ! $has_list_date ) {
 			return;
 		}
 
-		if ( 'day' === $event_display ) {
+		if ( 'day' === $effective_display ) {
 			$this->check_day_view( $wp_query, $enabled_views );
-		} elseif ( 'month' === $event_display ) {
+		} elseif ( 'month' === $effective_display ) {
 			$this->check_month_view( $wp_query, $enabled_views );
-		} elseif ( 'list' === $event_display ) {
+		} elseif ( 'list' === $effective_display ) {
 			$this->check_list_view( $wp_query, $enabled_views );
 		}
 	}
@@ -248,7 +257,7 @@ class Controller extends Controller_Contract {
 	/**
 	 * Check the conditions for the list view.
 	 *
-	 * Returns a 404 when:
+	 * Returns a 404 (or noindex, depending on the tec_seo_out_of_range_behavior setting) when:
 	 * - List view is disabled in TEC settings.
 	 * - The ?tribe-bar-date parameter refers to a date before the earliest event on record.
 	 * - The ?tribe-bar-date parameter refers to a date after the latest event on record.
@@ -294,21 +303,50 @@ class Controller extends Controller_Contract {
 		}
 
 		if ( $earliest_date_str && strtotime( $earliest_date_str ) > $event_timestamp ) {
-			$this->set_404( $wp_query );
+			$this->handle_out_of_range( $wp_query );
 			return;
 		}
 
 		if ( $latest_date_str && strtotime( $latest_date_str ) < $event_timestamp ) {
-			$this->set_404( $wp_query );
+			$this->handle_out_of_range( $wp_query );
 		}
 	}
 
 	/**
-	 * Set the query to 404 and send the HTTP 404 status header.
+	 * Respond to an out-of-range date request.
 	 *
-	 * WordPress's handle_404() only sends status_header(404) when it is the one
-	 * deciding to set the 404 state. When the state is already set (by our
-	 * send_headers callback) it bails early, so we must send the header ourselves.
+	 * By default (setting: 'hard_404'), the WP_Query is set to a 404 so WordPress
+	 * returns an HTTP 404 Not Found response — the strongest SEO signal.
+	 *
+	 * When the site owner has chosen 'soft_noindex' in Settings > Display >
+	 * SEO & URL Handling, the page is still served (HTTP 200) but a noindex
+	 * robots directive is injected via the wp_robots filter, so search engines
+	 * will not index the URL without surfacing a 404 error page to visitors.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $wp_query The global WP_Query object.
+	 */
+	private function handle_out_of_range( object $wp_query ): void {
+		$behavior = tribe_get_option( Settings::OPT_OUT_OF_RANGE_BEHAVIOR, 'hard_404' );
+
+		if ( 'soft_noindex' === $behavior ) {
+			// Add noindex at the wp_robots filter stage instead of returning a 404.
+			add_filter(
+				'wp_robots',
+				static function ( array $robots ): array {
+					$robots['noindex'] = true;
+					return $robots;
+				}
+			);
+			return;
+		}
+
+		$this->set_404( $wp_query );
+	}
+
+	/**
+	 * Set the query to 404 and send the HTTP 404 status header.
 	 *
 	 * @param \WP_Query $wp_query The query to mark as 404.
 	 */

--- a/src/Events/SEO/Headers/Controller.php
+++ b/src/Events/SEO/Headers/Controller.php
@@ -109,6 +109,11 @@ class Controller extends Controller_Contract {
 		// the enabled-view guard and per-view dispatch both treat it as 'list'.
 		$effective_display = 'past' === $event_display ? 'list' : $event_display;
 
+		// disabled-view guard — otherwise the main events page receives a false 404.
+		if ( 'default' === $effective_display ) {
+			return;
+		}
+
 		// 404 for any view that is currently disabled, regardless of how the URL was built.
 		// Site owners can disable this guard via Settings > Display > SEO & URL Handling.
 		if ( ! in_array( $effective_display, $enabled_views, true ) ) {

--- a/src/Events/SEO/Headers/Controller.php
+++ b/src/Events/SEO/Headers/Controller.php
@@ -297,17 +297,20 @@ class Controller extends Controller_Contract {
 		$earliest_date_str = tribe_events_earliest_date( 'Y-m-d' );
 		$latest_date_str   = tribe_events_latest_date( 'Y-m-d' );
 
-		// Skip validation when no events exist yet but the date is in the current month.
-		if ( ( ! $earliest_date_str || ! $latest_date_str ) && $event_month === $current_month ) {
+		// No events exist yet: allow only the current month (grace), 404 everything else.
+		if ( ! $earliest_date_str || ! $latest_date_str ) {
+			if ( $event_month !== $current_month ) {
+				$this->handle_out_of_range( $wp_query );
+			}
 			return;
 		}
 
-		if ( $earliest_date_str && strtotime( $earliest_date_str ) > $event_timestamp ) {
+		if ( strtotime( $earliest_date_str ) > $event_timestamp ) {
 			$this->handle_out_of_range( $wp_query );
 			return;
 		}
 
-		if ( $latest_date_str && strtotime( $latest_date_str ) < $event_timestamp ) {
+		if ( strtotime( $latest_date_str ) < $event_timestamp ) {
 			$this->handle_out_of_range( $wp_query );
 		}
 	}

--- a/src/Events/SEO/Settings.php
+++ b/src/Events/SEO/Settings.php
@@ -185,7 +185,7 @@ class Settings {
 					),
 				]
 			),
-			self::OPT_OUT_OF_RANGE_BEHAVIOR   => [
+			self::OPT_OUT_OF_RANGE_BEHAVIOR          => [
 				'type'            => 'radio',
 				'label'           => esc_html__( 'Out-of-range date URL behavior', 'the-events-calendar' ),
 				'tooltip'         => esc_html__( 'What to do when a visitor or search engine requests an event listing page with a date that falls before the earliest event or after the latest event on record.', 'the-events-calendar' ),
@@ -196,14 +196,14 @@ class Settings {
 					'soft_noindex' => esc_html__( 'Return HTTP 200 with a noindex directive — softer behaviour, the events page is still shown to visitors.', 'the-events-calendar' ),
 				],
 			],
-			self::OPT_NOINDEX_DATED_LIST_URLS => [
+			self::OPT_NOINDEX_DATED_LIST_URLS        => [
 				'type'            => 'checkbox_bool',
 				'label'           => esc_html__( 'Add noindex to dated List view URLs', 'the-events-calendar' ),
 				'tooltip'         => esc_html__( 'Adds a noindex robots directive to any List view URL that carries a ?tribe-bar-date query parameter. The canonical tag already points to the base /events/list/ URL, so these parameterised URLs produce duplicate content. Disable if you intentionally expose dated list views as standalone pages.', 'the-events-calendar' ),
 				'default'         => true,
 				'validation_type' => 'boolean',
 			],
-			self::OPT_DISABLED_VIEW_404       => [
+			self::OPT_DISABLED_VIEW_404              => [
 				'type'            => 'checkbox_bool',
 				'label'           => esc_html__( 'Return 404 for disabled view URLs', 'the-events-calendar' ),
 				'tooltip'         => esc_html__( 'Returns HTTP 404 when a URL specifies a view (e.g. ?eventDisplay=photo) that is currently disabled under Events > Settings > Display. This prevents accumulation of disabled-view URLs in search indexes.', 'the-events-calendar' ),

--- a/src/Events/SEO/Settings.php
+++ b/src/Events/SEO/Settings.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * SEO & URL Handling settings for The Events Calendar.
+ *
+ * Registers a "SEO & URL Handling" sub-tab in the Display settings tab,
+ * exposing options that control how TEC handles URL parameters and SEO
+ * directives to reduce duplicate-content crawl problems.
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\SEO
+ */
+
+namespace TEC\Events\SEO;
+
+use Tribe__Settings_Tab;
+use Tribe\Events\Admin\Settings as Admin_Settings;
+use TEC\Common\Admin\Entities\Div;
+use TEC\Common\Admin\Entities\Plain_Text;
+use TEC\Common\Admin\Entities\H3;
+use Tribe\Utils\Element_Classes;
+use TEC\Common\Admin\Entities\Paragraph;
+
+/**
+ * Class Settings
+ *
+ * Manages the admin-facing settings for TEC SEO & URL Handling.
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\SEO
+ */
+class Settings {
+
+	/**
+	 * Option key: behaviour when a dated event-list URL falls outside the
+	 * range of known events (before earliest or after latest).
+	 *
+	 * Accepted values:
+	 *   'hard_404'    — return HTTP 404 Not Found (default, recommended for SEO).
+	 *   'soft_noindex' — return HTTP 200 with a noindex robots directive instead.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const OPT_OUT_OF_RANGE_BEHAVIOR = 'tec_seo_out_of_range_behavior';
+
+	/**
+	 * Option key: whether to add a noindex directive to any List view URL that
+	 * carries the ?tribe-bar-date query parameter.
+	 *
+	 * The canonical tag already points to the base /events/list/ URL, so these
+	 * parameterised URLs add no independent SEO value.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const OPT_NOINDEX_DATED_LIST_URLS = 'tec_seo_noindex_dated_list_urls';
+
+	/**
+	 * Option key: whether to return HTTP 404 when a URL specifies a view slug
+	 * (via ?eventDisplay) that is currently disabled in TEC settings.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const OPT_DISABLED_VIEW_404 = 'tec_seo_disabled_view_404';
+
+	/**
+	 * Identifier used to register the sub-tab inside the Display tab.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public static string $tab_slug = 'display-seo-settings';
+
+	/**
+	 * Registers the hooks needed to inject the settings tab.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function add_hooks(): void {
+		add_action( 'tec_events_settings_tab_display', [ $this, 'register_tab' ] );
+	}
+
+	/**
+	 * Removes the hooks added by add_hooks().
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister_hooks(): void {
+		remove_action( 'tec_events_settings_tab_display', [ $this, 'register_tab' ] );
+	}
+
+	/**
+	 * Creates the "SEO & URL Handling" sub-tab and attaches it to the Display tab.
+	 *
+	 * @since TBD
+	 *
+	 * @param Tribe__Settings_Tab $display_tab The parent Display settings tab object.
+	 *
+	 * @return void
+	 */
+	public function register_tab( Tribe__Settings_Tab $display_tab ): void {
+		// Only show on the TEC events settings page, not the Tickets settings page.
+		if ( ! tribe( Admin_Settings::class )->is_tec_events_settings() ) {
+			return;
+		}
+
+		$tab = new Tribe__Settings_Tab(
+			self::$tab_slug,
+			esc_html__( 'SEO & URL Handling', 'the-events-calendar' ),
+			[
+				'priority' => 5.40,
+				'fields'   => apply_filters(
+					'tec_events_settings_display_seo_section',
+					$this->generate_settings()
+				),
+			]
+		);
+
+		/**
+		 * Fires after the SEO & URL Handling settings tab has been created, allowing
+		 * add-ons or site-specific code to attach additional fields or sub-tabs.
+		 *
+		 * @since TBD
+		 *
+		 * @param Tribe__Settings_Tab $tab The SEO settings tab instance.
+		 */
+		do_action( 'tec_events_settings_tab_display_seo', $tab );
+
+		$display_tab->add_child( $tab );
+	}
+
+	/**
+	 * Builds the settings fields array for the SEO & URL Handling tab.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,mixed> Settings fields keyed by option name.
+	 */
+	public function generate_settings(): array {
+		$title_block = new Div(
+			new Element_Classes( [ 'tec-settings-form__header-block', 'tec-settings-form__header-block--horizontal' ] )
+		);
+
+		$title_block->add_child(
+			new H3(
+				_x( 'SEO & URL Handling', 'SEO settings section header', 'the-events-calendar' ),
+				new Element_Classes( 'tec-settings-form__section-header' )
+			)
+		);
+
+		$title_block->add_child(
+			( new Paragraph( new Element_Classes( 'tec-settings-form__section-description' ) ) )->add_children(
+				[
+					new Plain_Text(
+						esc_html__( 'Manage SEO and URL handling settings to prevent duplicate-content crawl problems.', 'the-events-calendar' )
+					),
+				]
+			)
+		);
+
+		$header = [
+			'tec-events-seo-settings-header' => $title_block,
+		];
+
+		$fields = [
+			'tec-events-seo-settings-section-header' => ( new Div( new Element_Classes( [ 'tec-settings-form__header-block' ] ) ) )->add_children(
+				[
+					new H3(
+						_x( 'URL & Crawl Protection', 'SEO settings sub-section header', 'the-events-calendar' ),
+						new Element_Classes( [ 'tec-settings-form__section-header' ] )
+					),
+					new Plain_Text(
+						esc_html__( 'Control how The Events Calendar handles URL parameters and robots directives to reduce duplicate-content crawl problems.', 'the-events-calendar' )
+					),
+				]
+			),
+			self::OPT_OUT_OF_RANGE_BEHAVIOR   => [
+				'type'            => 'radio',
+				'label'           => esc_html__( 'Out-of-range date URL behavior', 'the-events-calendar' ),
+				'tooltip'         => esc_html__( 'What to do when a visitor or search engine requests an event listing page with a date that falls before the earliest event or after the latest event on record.', 'the-events-calendar' ),
+				'default'         => 'hard_404',
+				'validation_type' => 'options',
+				'options'         => [
+					'hard_404'     => esc_html__( 'Return HTTP 404 Not Found — recommended for SEO, prevents these URLs from being indexed.', 'the-events-calendar' ),
+					'soft_noindex' => esc_html__( 'Return HTTP 200 with a noindex directive — softer behaviour, the events page is still shown to visitors.', 'the-events-calendar' ),
+				],
+			],
+			self::OPT_NOINDEX_DATED_LIST_URLS => [
+				'type'            => 'checkbox_bool',
+				'label'           => esc_html__( 'Add noindex to dated List view URLs', 'the-events-calendar' ),
+				'tooltip'         => esc_html__( 'Adds a noindex robots directive to any List view URL that carries a ?tribe-bar-date query parameter. The canonical tag already points to the base /events/list/ URL, so these parameterised URLs produce duplicate content. Disable if you intentionally expose dated list views as standalone pages.', 'the-events-calendar' ),
+				'default'         => true,
+				'validation_type' => 'boolean',
+			],
+			self::OPT_DISABLED_VIEW_404       => [
+				'type'            => 'checkbox_bool',
+				'label'           => esc_html__( 'Return 404 for disabled view URLs', 'the-events-calendar' ),
+				'tooltip'         => esc_html__( 'Returns HTTP 404 when a URL specifies a view (e.g. ?eventDisplay=photo) that is currently disabled under Events > Settings > Display. This prevents accumulation of disabled-view URLs in search indexes.', 'the-events-calendar' ),
+				'default'         => true,
+				'validation_type' => 'boolean',
+			],
+		];
+
+		$fields = tribe( 'settings' )->wrap_section_content( 'tec-events-settings-seo', $fields );
+
+		return array_merge( $header, $fields );
+	}
+}

--- a/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_Disabled_View_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_Disabled_View_Test.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tribe\Events\Views\V2\SEO\Headers;
+
+use TEC\Events\SEO\Headers\Controller;
+
+/**
+ * Tests that filter_headers() returns a 404 for any TEC view slug that is
+ * currently disabled in the site's TEC settings, regardless of URL form.
+ *
+ * This covers the Phase 3 guard added to filter_headers() that fires before
+ * the per-view (check_day_view / check_month_view / check_list_view) dispatching,
+ * ensuring that optional views like Photo, Week, Map, and Summary also 404
+ * when they have been turned off.
+ */
+class Controller_Disabled_View_Test extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * A view slug that is absent from tribeEnableViews should always 404,
+	 * even when eventDate is present (pretty-URL form).
+	 *
+	 * Uses 'photo' as the example since it has no dedicated check_*_view()
+	 * method, which means the Phase 3 guard is the only thing that catches it.
+	 *
+	 * @test
+	 */
+	public function test_disabled_view_slug_with_event_date_shows_404(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month', 'day' ], 10, 3 );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'photo',
+			'eventDate'    => '2023-06',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'Accessing a disabled view slug should return a 404.' );
+	}
+
+	/**
+	 * The disabled-view guard must also fire when the request has no eventDate
+	 * (e.g. the view was reached via a query-param URL rather than a pretty URL).
+	 *
+	 * @test
+	 */
+	public function test_disabled_view_slug_without_event_date_shows_404(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'week',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'A disabled view slug with no eventDate should still return a 404.' );
+	}
+
+	/**
+	 * When a view is present in tribeEnableViews the disabled-view guard must
+	 * not set a 404. The list view without a tribe-bar-date param is used so
+	 * that no per-view date checks can also trigger a 404, keeping this test
+	 * focused on the guard alone.
+	 *
+	 * @test
+	 */
+	public function test_enabled_view_slug_does_not_trigger_guard(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+
+		// No tribe-bar-date → check_list_view() bails immediately (nothing to check).
+		unset( $_REQUEST['tribe-bar-date'] );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'An enabled view slug should not trigger the disabled-view 404 guard.' );
+	}
+
+	/**
+	 * ?eventDisplay=past is NOT a view slug — it is a display-mode modifier that
+	 * renders the List view in "past events" mode. It must never trigger the
+	 * disabled-view 404 guard, even though 'past' is absent from tribeEnableViews.
+	 *
+	 * @test
+	 */
+	public function test_past_display_mode_does_not_trigger_guard_when_list_enabled(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+
+		unset( $_REQUEST['tribe-bar-date'] );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'past',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse(
+			$wp_query->is_404,
+			'?eventDisplay=past is a List view modifier, not a view slug — it must not 404 when list is enabled.'
+		);
+	}
+
+	/**
+	 * ?eventDisplay=past should 404 when the List view itself is disabled,
+	 * because past-events browsing depends on the List view being available.
+	 *
+	 * @test
+	 */
+	public function test_past_display_mode_shows_404_when_list_disabled(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'month' ], 10, 3 ); // list not enabled.
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'past',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue(
+			$wp_query->is_404,
+			'?eventDisplay=past should 404 when the List view is disabled, since it relies on the list view layout.'
+		);
+	}
+
+	/**
+	 * Non-tribe_events post types must be ignored entirely; the guard must not
+	 * fire for regular WordPress post types that happen to carry an eventDisplay
+	 * query var.
+	 *
+	 * @test
+	 */
+	public function test_wrong_post_type_skips_guard(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'post',   // Not tribe_events.
+			'eventDisplay' => 'photo',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'The guard should not fire for non-tribe_events post types.' );
+	}
+
+	/**
+	 * When eventDisplay is absent there is nothing to validate; the method
+	 * returns early before reaching the guard.
+	 *
+	 * @test
+	 */
+	public function test_missing_event_display_skips_guard(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type' => 'tribe_events',
+			// eventDisplay intentionally absent.
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'When eventDisplay is absent the guard should not fire.' );
+	}
+}

--- a/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_List_View_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_List_View_Test.php
@@ -62,7 +62,7 @@ class Controller_List_View_Test extends \Codeception\TestCase\WPTestCase {
 	public function test_list_view_disabled_always_shows_404(): void {
 		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'month' ], 10, 3 );
 
-		$this->create_test_events( '2023-06-20', '2023-12-31', '2023-06-15' );
+		$this->create_test_events( '2023-06-20', '2023-12-31', '2023-06-21' );
 		tribe_update_option( 'earliest_date', false );
 		tribe_update_option( 'latest_date', false );
 

--- a/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_List_View_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_List_View_Test.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Tribe\Events\Views\V2\SEO\Headers;
+
+use TEC\Events\SEO\Headers\Controller;
+use TEC\Events\SEO\Settings;
+use Tribe\Tests\Traits\With_Uopz;
+
+/**
+ * Tests for the list view date-range 404 behavior in the SEO Headers Controller.
+ *
+ * List view stores its date in the raw GET parameter ?tribe-bar-date rather than
+ * in a WP query var (eventDate), so it requires its own check_list_view() path
+ * inside filter_headers(). These tests mirror the patterns established by
+ * Controller_Day_View_Test and Controller_Month_View_Test.
+ */
+class Controller_List_View_Test extends \Codeception\TestCase\WPTestCase {
+
+	use With_Uopz;
+
+	public function setUp(): void {
+		parent::setUp();
+		unset( $_REQUEST['tribe-bar-date'] );
+	}
+
+	public function tearDown(): void {
+		unset( $_REQUEST['tribe-bar-date'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create three events spanning a date range for use in range-boundary tests.
+	 *
+	 * @param string $range_start Earliest event date (Y-m-d).
+	 * @param string $range_end   Latest event date (Y-m-d).
+	 * @param string $test_day    A middle date within the range (Y-m-d).
+	 */
+	private function create_test_events( string $range_start, string $range_end, string $test_day ): void {
+		$timezone_string = get_option( 'timezone_string' ) ?: 'UTC';
+
+		foreach ( [
+			[ $range_start, '09:00', 'Test Event Start' ],
+			[ $test_day,    '12:00', 'Test Event Middle' ],
+			[ $range_end,   '12:30', 'Test Event End' ],
+		] as [ $date, $time, $title ] ) {
+			tribe_events()->set_args( [
+				'start_date' => $date . ' ' . $time,
+				'timezone'   => $timezone_string,
+				'duration'   => 3 * HOUR_IN_SECONDS,
+				'title'      => $title,
+				'status'     => 'publish',
+			] )->create();
+		}
+	}
+
+	/**
+	 * When list view is disabled in TEC settings the URL is illegitimate regardless
+	 * of what date is requested.
+	 *
+	 * @test
+	 */
+	public function test_list_view_disabled_always_shows_404(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'month' ], 10, 3 );
+
+		$this->create_test_events( '2023-06-20', '2023-12-31', '2023-06-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2023-06-20';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'When the list view is disabled, a 404 should be set.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_list_view_before_range_shows_404(): void {
+		$this->create_test_events( '2023-06-20', '2023-12-31', '2023-09-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2023-05-15';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'A tribe-bar-date before the earliest event should trigger a 404.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_list_view_after_range_shows_404(): void {
+		$this->create_test_events( '2023-01-01', '2023-06-10', '2023-06-05' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2024-01-15';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'A tribe-bar-date after the latest event should trigger a 404.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_list_view_with_valid_range_no_404(): void {
+		$this->create_test_events( '2023-01-01', '2023-12-31', '2023-06-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2023-06-16';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'A tribe-bar-date within the event range should not trigger a 404.' );
+	}
+
+	/**
+	 * Fresh install with no events: the current month must not 404 so that the
+	 * live list view remains accessible before any events are created.
+	 *
+	 * @test
+	 */
+	public function test_no_events_within_current_month_shows_no_404(): void {
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$date = new \DateTime( '2023-06-11 22:00:00', new \DateTimeZone( 'America/New_York' ) );
+		$now  = $date->getTimestamp();
+		$this->set_class_fn_return( Controller::class, 'get_current_month', static fn() => date( 'Y-m', $now ), true );
+
+		$_REQUEST['tribe-bar-date'] = '2023-06-16';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'When there are no events and the date is in the current month, no 404 should be set.' );
+	}
+
+	/**
+	 * Fresh install with no events: a date outside the current month should 404
+	 * because there is no known event range to validate against.
+	 *
+	 * @test
+	 */
+	public function test_no_event_and_outside_current_month_shows_404(): void {
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$date = new \DateTime( '2023-06-11 22:00:00', new \DateTimeZone( 'America/New_York' ) );
+		$now  = $date->getTimestamp();
+		$this->set_class_fn_return( Controller::class, 'get_current_month', static fn() => date( 'Y-m', $now ), true );
+
+		$_REQUEST['tribe-bar-date'] = '2023-05-16';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertTrue( $wp_query->is_404, 'When there are no events and the date is outside the current month, a 404 should be set.' );
+	}
+
+	/**
+	 * A malformed tribe-bar-date value cannot be parsed to a timestamp; the
+	 * check should bail gracefully and leave the page accessible.
+	 *
+	 * @test
+	 */
+	public function test_malformed_date_no_404(): void {
+		$this->create_test_events( '2023-01-01', '2023-12-31', '2023-06-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = 'not-a-date';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'A malformed tribe-bar-date value should not trigger a 404.' );
+	}
+
+	/**
+	 * When tribe-bar-date is absent the list view base URL should always return
+	 * a 200; there is no date to validate.
+	 *
+	 * @test
+	 */
+	public function test_no_tribe_bar_date_param_no_404(): void {
+		$this->create_test_events( '2023-01-01', '2023-12-31', '2023-06-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'When tribe-bar-date is absent, the base list view URL should not trigger a 404.' );
+	}
+
+	/**
+	 * When the site owner switches the out-of-range behaviour to 'soft_noindex',
+	 * a pre-range date must NOT return a 404; instead, noindex should be added
+	 * to the wp_robots filter so search engines ignore the page while visitors
+	 * still see content.
+	 *
+	 * @test
+	 */
+	public function test_before_range_soft_noindex_no_404_but_noindex_added(): void {
+		add_filter(
+			'tribe_get_option_' . Settings::OPT_OUT_OF_RANGE_BEHAVIOR,
+			static fn() => 'soft_noindex'
+		);
+
+		$this->create_test_events( '2023-06-20', '2023-12-31', '2023-09-15' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2023-05-15';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'In soft_noindex mode, an out-of-range date must not return a 404.' );
+
+		$robots = apply_filters( 'wp_robots', [] );
+		$this->assertArrayHasKey( 'noindex', $robots, 'In soft_noindex mode, noindex should be added via wp_robots.' );
+		$this->assertTrue( $robots['noindex'], 'The noindex directive should be true.' );
+
+		remove_all_filters( 'tribe_get_option_' . Settings::OPT_OUT_OF_RANGE_BEHAVIOR );
+		remove_all_filters( 'wp_robots' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_after_range_soft_noindex_no_404_but_noindex_added(): void {
+		add_filter(
+			'tribe_get_option_' . Settings::OPT_OUT_OF_RANGE_BEHAVIOR,
+			static fn() => 'soft_noindex'
+		);
+
+		$this->create_test_events( '2023-01-01', '2023-06-10', '2023-06-05' );
+		tribe_update_option( 'earliest_date', false );
+		tribe_update_option( 'latest_date', false );
+
+		$_REQUEST['tribe-bar-date'] = '2024-01-15';
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'list',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse( $wp_query->is_404, 'In soft_noindex mode, a post-range date must not return a 404.' );
+
+		$robots = apply_filters( 'wp_robots', [] );
+		$this->assertArrayHasKey( 'noindex', $robots, 'In soft_noindex mode, noindex should be added via wp_robots.' );
+		$this->assertTrue( $robots['noindex'] );
+
+		remove_all_filters( 'tribe_get_option_' . Settings::OPT_OUT_OF_RANGE_BEHAVIOR );
+		remove_all_filters( 'wp_robots' );
+	}
+
+	/**
+	 * When OPT_DISABLED_VIEW_404 is turned off, accessing a disabled view slug
+	 * should NOT trigger a 404 — the guard is deliberately suppressed.
+	 *
+	 * @test
+	 */
+	public function test_disabled_view_404_guard_can_be_turned_off(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month' ], 10, 3 );
+		add_filter(
+			'tribe_get_option_' . Settings::OPT_DISABLED_VIEW_404,
+			static fn() => false
+		);
+
+		global $wp_query;
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'week',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse(
+			$wp_query->is_404,
+			'When the disabled-view 404 guard is turned off in settings, a disabled view slug must not 404.'
+		);
+
+		remove_all_filters( 'tribe_get_option_' . Settings::OPT_DISABLED_VIEW_404 );
+	}
+}

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
@@ -3,6 +3,7 @@
 namespace Tribe\Events\Views\V2\Views\Traits;
 
 use TEC\Events\SEO\Controller;
+use TEC\Events\SEO\Settings;
 use Tribe\Events\Views\V2\View;
 use Tribe\Events\Views\V2\Views\Month_View;
 use Tribe\Events\Views\V2\Views\List_View;
@@ -37,7 +38,6 @@ class With_NoindexTest extends TecViewTestCase {
 			'event_date' => $now->format( 'Y-m-d' ),
 		] );
 
-		// Ensure our controller is registered and available
 		tribe_register_provider( Controller::class );
 		$this->controller = tribe( Controller::class );
 
@@ -227,10 +227,7 @@ class With_NoindexTest extends TecViewTestCase {
 	 * @test
 	 */
 	public function test_integration_of_nofollow_and_filter_robots_directives() {
-		// First add nofollow
-		$robots = $this->controller->set_nofollow( [] );
-
-		// Then filter robots directives
+		$robots       = $this->controller->set_nofollow( [] );
 		$final_robots = $this->controller->filter_robots_directives( $robots );
 
 		$this->assertArrayHasKey( 'noindex', $final_robots );
@@ -304,5 +301,129 @@ class With_NoindexTest extends TecViewTestCase {
 
 		$this->assertFalse( has_action( 'wp', [ $this->controller, 'hook_issue_noindex' ] ) );
 		$this->assertFalse( has_action( 'tec_events_before_view_html_cache', [ $this->controller, 'issue_noindex' ] ) );
+	}
+
+	/**
+	 * A List view URL that carries ?tribe-bar-date is a parameterised variant of
+	 * the canonical /events/list/ URL and must receive a noindex directive so
+	 * that search engines stop treating each dated URL as a unique indexable page.
+	 *
+	 * The tec_post_type context flag is set to true so that
+	 * should_add_no_index_for_list_based_views() passes its early guard (the same
+	 * guard that causes the base list-view test in view_data_set to return false).
+	 *
+	 * @test
+	 */
+	public function test_list_view_with_tribe_bar_date_gets_noindex(): void {
+		$_REQUEST['tribe-bar-date'] = '2019-01-01';
+
+		// tec_post_type must be true to pass the early guard in should_add_no_index_for_list_based_views().
+		$context = $this->context->alter( [ 'tec_post_type' => true ] );
+
+		$was_called = false;
+		add_filter(
+			'tec_events_seo_robots_meta_include_list',
+			function ( $add_noindex ) use ( &$was_called ) {
+				$was_called = true;
+				$this->assertTrue(
+					$add_noindex,
+					'A List view URL carrying ?tribe-bar-date should have noindex set to true.'
+				);
+				return $add_noindex;
+			}
+		);
+
+		$view = View::make( List_View::class, $context );
+		$view->get_html();
+		tribe( Controller::class )->issue_noindex( $view );
+
+		$this->assertTrue( $was_called, 'The tec_events_seo_robots_meta_include_list filter should have been called.' );
+
+		unset( $_REQUEST['tribe-bar-date'] );
+	}
+
+	/**
+	 * When the site owner disables the "Add noindex to dated List view URLs" option
+	 * (Settings::OPT_NOINDEX_DATED_LIST_URLS = false), a List view URL carrying
+	 * ?tribe-bar-date must NOT receive noindex even though the param is present.
+	 *
+	 * @test
+	 */
+	public function test_list_view_with_tribe_bar_date_no_noindex_when_setting_disabled(): void {
+		$_REQUEST['tribe-bar-date'] = '2019-01-01';
+
+		add_filter(
+			'tribe_get_option_' . Settings::OPT_NOINDEX_DATED_LIST_URLS,
+			static fn() => false
+		);
+
+		$context    = $this->context->alter( [ 'tec_post_type' => true ] );
+		$was_called = false;
+
+		add_filter(
+			'tec_events_seo_robots_meta_include_list',
+			function ( $add_noindex ) use ( &$was_called ) {
+				$was_called = true;
+				$this->assertFalse(
+					$add_noindex,
+					'When OPT_NOINDEX_DATED_LIST_URLS is disabled, noindex must not be set even with ?tribe-bar-date present.'
+				);
+				return $add_noindex;
+			}
+		);
+
+		$view = View::make( List_View::class, $context );
+		$view->get_html();
+		tribe( Controller::class )->issue_noindex( $view );
+
+		$this->assertTrue( $was_called, 'The tec_events_seo_robots_meta_include_list filter should have been called.' );
+
+		unset( $_REQUEST['tribe-bar-date'] );
+		remove_all_filters( 'tribe_get_option_' . Settings::OPT_NOINDEX_DATED_LIST_URLS );
+	}
+
+	/**
+	 * A List view URL without ?tribe-bar-date that has events should NOT receive
+	 * noindex — the base /events/list/ URL is the canonical page and must remain
+	 * indexable.
+	 *
+	 * @test
+	 */
+	public function test_list_view_without_tribe_bar_date_and_with_events_no_noindex(): void {
+		unset( $_REQUEST['tribe-bar-date'] );
+
+		$timezone_string = 'Europe/Paris';
+		$timezone        = new \DateTimeZone( $timezone_string );
+		update_option( 'timezone_string', $timezone_string );
+
+		$now = new \DateTimeImmutable( $this->mock_date_value, $timezone );
+		tribe_events()->set_args( [
+			'start_date' => $now->setTime( 10, 0 ),
+			'timezone'   => $timezone,
+			'duration'   => 3 * HOUR_IN_SECONDS,
+			'title'      => 'Test Event for noindex check',
+			'status'     => 'publish',
+		] )->create();
+
+		$context = $this->context->alter( [ 'tec_post_type' => true ] );
+
+		$was_called = false;
+		add_filter(
+			'tec_events_seo_robots_meta_include_list',
+			function ( $add_noindex ) use ( &$was_called ) {
+				$was_called = true;
+				$this->assertFalse(
+					$add_noindex,
+					'The base List view URL (no ?tribe-bar-date) with events should not have noindex.'
+				);
+				return $add_noindex;
+			}
+		);
+
+		$view = View::make( List_View::class, $context );
+		$view->get_html();
+		tribe( Controller::class )->issue_noindex( $view );
+
+		$this->assertTrue( $was_called, 'The tec_events_seo_robots_meta_include_list filter should have been called.' );
 	}
 }

--- a/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Views/Traits/With_NoindexTest.php
@@ -352,6 +352,18 @@ class With_NoindexTest extends TecViewTestCase {
 	public function test_list_view_with_tribe_bar_date_no_noindex_when_setting_disabled(): void {
 		$_REQUEST['tribe-bar-date'] = '2019-01-01';
 
+		// Create an event so the "no events → noindex" existing behavior does not
+		// trigger, keeping the test focused on the OPT_NOINDEX_DATED_LIST_URLS toggle.
+		$timezone = new \DateTimeZone( 'UTC' );
+		$now      = new \DateTimeImmutable( $this->mock_date_value, $timezone );
+		tribe_events()->set_args( [
+			'start_date' => $now->setTime( 10, 0 ),
+			'timezone'   => 'UTC',
+			'duration'   => 3 * HOUR_IN_SECONDS,
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+		] )->create();
+
 		add_filter(
 			'tribe_get_option_' . Settings::OPT_NOINDEX_DATED_LIST_URLS,
 			static fn() => false


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-965](https://linear.app/nexcess/issue/SMTNC-965/seo-tec-creates-a-lot-of-urls-with-parameters-that-are-indexed-by)

---

### 🗒️ Description

**Bug fix** — Prevents TEC from generating thousands of low-value indexed URLs that waste crawl budget. One customer grew from 16k to 150k indexed junk pages in a single month.

The List view appends `?tribe-bar-date=YYYY-MM-DD` to the URL on every datepicker click, creating a distinct crawlable URL for every date combination. There was no 404 or noindex protection for these URLs — unlike Day/Month views which already had date-range guards.

#### Changes

**Date-range 404 for List view**

Extended `filter_headers()` to detect `?tribe-bar-date` (raw GET param used by List view) and added `check_list_view()`: returns 404 when the date falls outside the known event range. Mirrors the grace logic from Day view — skips validation when no events exist yet and the date is in the current month.

**Noindex for dated List view URLs**

Any List view URL carrying `?tribe-bar-date` now receives a `noindex` directive. The canonical already points to the base `/events/list/` URL, so noindex closes the indexing loop without hiding content from visitors.

**404 for disabled view slugs**

Added a guard that 404s any `?eventDisplay=<slug>` request when that view is disabled in TEC settings. `?eventDisplay=past` is normalized to `list` before the check (it's a display-mode modifier, not a standalone view slug) — so it only 404s when the List view itself is disabled.

**Admin settings** — new "SEO & URL Handling" sub-tab under Events → Settings → Display

| Setting | Default |
|---|---|
| Out-of-range date URL behavior (hard 404 or soft noindex) | `hard_404` |
| Add noindex to dated List view URLs | `true` |
| Return 404 for disabled view URLs | `true` |

All options default to the most protective value. Site owners only need to act if they want to relax a behavior.

---

### 🎥 Artifacts

https://drive.google.com/drive/folders/1GDHwr-evIgv_8bziBLFFLG_D2KDrpvEp?usp=sharing

---

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5750]: https://stellarwp.atlassian.net/browse/TEC-5750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ