### PR TITLE
Fix meta tag title in events archive and single

### DIFF
--- a/changelog/fix-TEC-5759-title-tag-events-archive
+++ b/changelog/fix-TEC-5759-title-tag-events-archive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved the Title Meta tag in Events single and archive showing past date. [TEC-5759]

--- a/changelog/fix-TEC-5759-title-tag-events-archive
+++ b/changelog/fix-TEC-5759-title-tag-events-archive
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved the Title Meta tag in Events single and archive showing past date. [TEC-5759]
+Ensure no past Event dates are shown in the Title meta tag on Events archive and single views. [TEC-5759]

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -2,7 +2,7 @@
 /**
  * Handles the manipulation of the template title to correctly render it in the context of a Views v2 request.
  *
- * @since   4.9.10
+ * @since 4.9.10
  *
  * @package Tribe\Events\Views\V2\Template
  */
@@ -20,7 +20,7 @@ use Tribe__Events__Main as TEC;
 /**
  * Class Title
  *
- * @since   4.9.10
+ * @since 4.9.10
  *
  * @package Tribe\Events\Views\V2\Template
  */
@@ -251,8 +251,8 @@ class Title {
 	 * @return array The built post range title.
 	 */
 	public static function build_post_range_title( Context $context, $event_date, array $posts ) {
-		$event_date         = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
-		$is_past = 'past' === $context->get( 'event_display_mode' );
+		$event_date = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
+		$is_past    = 'past' === $context->get( 'event_display_mode' );
 
 		if ( $is_past ) {
 			$first = end( $posts );
@@ -467,7 +467,7 @@ class Title {
 	 * @since 5.12.3 Added params, refined logic around category archive titles.
 	 *
 	 * @param string      $title     The input title.
-	 * @param  \WP_Term    $cat       The category term to use to build the title.
+	 * @param \WP_Term    $cat       The category term to use to build the title.
 	 * @param boolean     $depth     Whether to display the taxonomy hierarchy as part of the title.
 	 * @param null|string $separator The separator sequence to separate the title components.
 	 *
@@ -483,7 +483,7 @@ class Title {
 		 *
 		 * @param boolean     $depth Whether to display the taxonomy hierarchy as part of the title.
 		 * @param string      $title The input title.
-		 * @param  \WP_Term   $cat   The category term to use to build the title.
+		 * @param \WP_Term   $cat   The category term to use to build the title.
 		 */
 		$depth = apply_filters( 'tec_events_views_v2_display_tax_hierarchy_in_title', $depth, $title, $cat );
 

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -251,9 +251,11 @@ class Title {
 	 * @return array The built post range title.
 	 */
 	public static function build_post_range_title( Context $context, $event_date, array $posts ) {
-		$event_date = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
+		$event_date         = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
+		$event_display_mode = $context->get( 'event_display_mode' );
+		$is_past            = 'past' === $event_display_mode;
 
-		if ( $context->get( 'event_display_mode' ) === 'past' ) {
+		if ( $is_past ) {
 			$first = end( $posts );
 			$last  = reset( $posts );
 		} else {
@@ -262,6 +264,7 @@ class Title {
 		}
 
 		$first_returned_date = tribe_get_start_date( $first, false, Dates::DBDATEFORMAT );
+		$last_returned_date  = tribe_get_start_date( $last, false, Dates::DBDATEFORMAT );
 		$first_event_date    = tribe_get_start_date( $first, false );
 		$last_event_date     = tribe_get_start_date( $last, false );
 
@@ -271,7 +274,24 @@ class Title {
 		 */
 		$page = $context->get( 'paged', 1 );
 		if ( 1 == $page && $event_date < $first_returned_date ) {
-			$first_event_date = tribe_format_date( $event_date, false );
+			$first_event_date    = tribe_format_date( $event_date, false );
+			$first_returned_date = $event_date;
+		}
+
+		/*
+		 * For upcoming views, never let the range start in the past — recurring events whose
+		 * series started earlier can otherwise leak an outdated date into the page title.
+		 */
+		if ( ! $is_past ) {
+			$today = Dates::build_date_object( 'now' )->format( Dates::DBDATEFORMAT );
+			if ( $first_returned_date < $today ) {
+				$first_event_date    = tribe_format_date( $today, false );
+				$first_returned_date = $today;
+			}
+		}
+
+		if ( $first_returned_date === $last_returned_date ) {
+			return $first_event_date;
 		}
 
 		return "$first_event_date - $last_event_date";

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -252,8 +252,7 @@ class Title {
 	 */
 	public static function build_post_range_title( Context $context, $event_date, array $posts ) {
 		$event_date         = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
-		$event_display_mode = $context->get( 'event_display_mode' );
-		$is_past            = 'past' === $event_display_mode;
+		$is_past = 'past' === $context->get( 'event_display_mode' );
 
 		if ( $is_past ) {
 			$first = end( $posts );

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -281,10 +281,12 @@ class Title {
 		/*
 		 * For upcoming views, never let the range start in the past — recurring events whose
 		 * series started earlier can otherwise leak an outdated date into the page title.
+		 * Only clamp when the last date is still in the future, so we don't invert ranges that
+		 * are entirely in the past.
 		 */
 		if ( ! $is_past ) {
 			$today = Dates::build_date_object( 'now' )->format( Dates::DBDATEFORMAT );
-			if ( $first_returned_date < $today ) {
+			if ( $first_returned_date < $today && $last_returned_date >= $today ) {
 				$first_event_date    = tribe_format_date( $today, false );
 				$first_returned_date = $today;
 			}

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
@@ -108,13 +108,13 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 		$future       = date( 'Y-m-d', strtotime( '+30 days' ) );
 		$past_event   = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9001,
-			'start_date' => '2022-12-01 09:00:00',
-			'end_date'   => '2022-12-01 11:00:00',
+			'start_date' => '2022-12-01',
+			'end_date'   => '2022-12-01',
 		] );
 		$future_event = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9002,
-			'start_date' => $future . ' 09:00:00',
-			'end_date'   => $future . ' 11:00:00',
+			'start_date' => $future,
+			'end_date'   => $future,
 		] );
 
 		$context = tribe_context()->alter( [
@@ -137,13 +137,13 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 
 		$event_1 = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9101,
-			'start_date' => $same_day . ' 09:00:00',
-			'end_date'   => $same_day . ' 10:00:00',
+			'start_date' => $same_day,
+			'end_date'   => $same_day,
 		] );
 		$event_2 = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9102,
-			'start_date' => $same_day . ' 14:00:00',
-			'end_date'   => $same_day . ' 16:00:00',
+			'start_date' => $same_day,
+			'end_date'   => $same_day,
 		] );
 
 		$context = tribe_context()->alter( [
@@ -152,7 +152,7 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 			'event_display_mode' => 'list',
 		] );
 
-		$range = Title::build_post_range_title( $context, '', [ $event_1, $event_2 ] );
+		$range = Title::build_post_range_title( $context, $same_day, [ $event_1, $event_2 ] );
 
 		$this->assertSame( tribe_get_start_date( $event_1, false ), $range );
 		$this->assertStringNotContainsString( ' - ', $range );
@@ -161,13 +161,13 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	public function test_post_range_title_preserves_past_dates_in_past_mode() {
 		$older = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9201,
-			'start_date' => '2022-01-15 09:00:00',
-			'end_date'   => '2022-01-15 11:00:00',
+			'start_date' => '2022-01-15',
+			'end_date'   => '2022-01-15',
 		] );
 		$newer = $this->get_mock_event( 'events/single/1.template.json', [
 			'ID'         => 9202,
-			'start_date' => '2022-06-20 09:00:00',
-			'end_date'   => '2022-06-20 11:00:00',
+			'start_date' => '2022-06-20',
+			'end_date'   => '2022-06-20',
 		] );
 
 		$context = tribe_context()->alter( [

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
@@ -104,6 +104,86 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertMatchesSnapshot( $title->build_title() );
 	}
 
+	public function test_post_range_title_clamps_past_first_date_for_upcoming() {
+		$future       = date( 'Y-m-d', strtotime( '+30 days' ) );
+		$past_event   = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9001,
+			'start_date' => '2022-12-01 09:00:00',
+			'end_date'   => '2022-12-01 11:00:00',
+		] );
+		$future_event = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9002,
+			'start_date' => $future . ' 09:00:00',
+			'end_date'   => $future . ' 11:00:00',
+		] );
+
+		$context = tribe_context()->alter( [
+			'event_post_type'    => true,
+			'event_display'      => 'list',
+			'event_display_mode' => 'list',
+		] );
+
+		$range = Title::build_post_range_title( $context, '', [ $past_event, $future_event ] );
+
+		$expected_first = tribe_format_date( date( 'Y-m-d' ), false );
+		$expected_last  = tribe_get_start_date( $future_event, false );
+
+		$this->assertSame( "$expected_first - $expected_last", $range );
+		$this->assertStringNotContainsString( '2022', $range );
+	}
+
+	public function test_post_range_title_collapses_same_day_to_single_date() {
+		$same_day = date( 'Y-m-d', strtotime( '+5 days' ) );
+
+		$event_1 = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9101,
+			'start_date' => $same_day . ' 09:00:00',
+			'end_date'   => $same_day . ' 10:00:00',
+		] );
+		$event_2 = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9102,
+			'start_date' => $same_day . ' 14:00:00',
+			'end_date'   => $same_day . ' 16:00:00',
+		] );
+
+		$context = tribe_context()->alter( [
+			'event_post_type'    => true,
+			'event_display'      => 'list',
+			'event_display_mode' => 'list',
+		] );
+
+		$range = Title::build_post_range_title( $context, '', [ $event_1, $event_2 ] );
+
+		$this->assertSame( tribe_get_start_date( $event_1, false ), $range );
+		$this->assertStringNotContainsString( ' - ', $range );
+	}
+
+	public function test_post_range_title_preserves_past_dates_in_past_mode() {
+		$older = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9201,
+			'start_date' => '2022-01-15 09:00:00',
+			'end_date'   => '2022-01-15 11:00:00',
+		] );
+		$newer = $this->get_mock_event( 'events/single/1.template.json', [
+			'ID'         => 9202,
+			'start_date' => '2022-06-20 09:00:00',
+			'end_date'   => '2022-06-20 11:00:00',
+		] );
+
+		$context = tribe_context()->alter( [
+			'event_post_type'    => true,
+			'event_display'      => 'past',
+			'event_display_mode' => 'past',
+		] );
+
+		$range = Title::build_post_range_title( $context, '', [ $newer, $older ] );
+
+		$expected_first = tribe_get_start_date( $older, false );
+		$expected_last  = tribe_get_start_date( $newer, false );
+
+		$this->assertSame( "$expected_first - $expected_last", $range );
+	}
+
 	public function title_with_views_data_provider() {
 		$events = [
 			[


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5759](https://stellarwp.atlassian.net/browse/TEC-5759)
[Task in Linear](https://linear.app/nexcess/issue/SMTNC-262/tec-title-tagmetea-on-main-events-and-archive-calendar-page)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"The date range used in the <title> tag should not display a past date nor display a range when the start date and end date is the same."
Updated the class responsible for generating the Title and solved the past date issue.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1494" height="798" alt="Screenshot 2026-05-06 at 16 09 45" src="https://github.com/user-attachments/assets/15fe2690-ab69-45a8-bfa8-9de83860f1ca" />

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5759]: https://stellarwp.atlassian.net/browse/TEC-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ