### PR TITLE
[SMTNC-270] Category filtering fails to highlight events and over-highlights other events

### DIFF
--- a/changelog/ECP-2016-Category-filtering-fails-to-highlight-events-and-over-highlights-other-events
+++ b/changelog/ECP-2016-Category-filtering-fails-to-highlight-events-and-over-highlights-other-events
@@ -1,1 +1,4 @@
+Significance: patch
+Type: fix
+
 Resolved an issue where the category legend superpowers filter would not apply in a day with multiple events from different categories. [ECP-2016]

--- a/changelog/fix-category-color-filter-multi-event-day
+++ b/changelog/fix-category-color-filter-multi-event-day
@@ -1,4 +1,1 @@
-Significance: patch
-Type: fix
-
-Corrected the legend superpowers filter so that days with multiple events from different categories evaluate every event when deciding whether to dim the day cell, instead of relying on the first event only. [ECP-2016]
+Resolved an issue where the category legend superpowers filter would not apply in a day with multiple events from different categories. [ECP-2016]

--- a/changelog/fix-category-color-filter-multi-event-day
+++ b/changelog/fix-category-color-filter-multi-event-day
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected the legend superpowers filter so that days with multiple events from different categories evaluate every event when deciding whether to dim the day cell, instead of relying on the first event only. [ECP-2016]

--- a/src/resources/js/views/category-color-selector.js
+++ b/src/resources/js/views/category-color-selector.js
@@ -378,21 +378,33 @@ tribe.events.categoryColors.categoryPicker = ( function () {
 
 	/**
 	 * Updates event visibility based on selected categories.
+	 *
+	 * When the parent container does not itself carry a category class (e.g. day cells
+	 * containing multiple events), every category-bearing descendant is checked, not just
+	 * the first one. The container is filtered only when none of its descendants match.
+	 *
 	 * @since 6.14.0
+	 * @since TBD Check all category-bearing descendants instead of only the first match,
+	 *            so day cells with multiple events filter correctly.
 	 * @return {void}
 	 */
 	const updateEventVisibility = () => {
 		const selectedArray = [ ...selectedCategories ];
 
 		getEventParentElements().forEach( ( eventContainer ) => {
-			let categoryElement = eventContainer;
+			const ownHasCategoryClass = [ ...eventContainer.classList ].some(
+				( cls ) => cls.startsWith( 'tribe_events_cat-' )
+			);
 
-			// If the parent doesn't have a category class, check children
-			if ( ! [ ...categoryElement.classList ].some( ( cls ) => cls.startsWith( 'tribe_events_cat-' ) ) ) {
-				categoryElement = eventContainer.querySelector( '[class*="tribe_events_cat-"]' );
+			let hasMatch = false;
+			if ( ownHasCategoryClass ) {
+				hasMatch = eventHasMatchingCategory( eventContainer, selectedArray );
+			} else {
+				const categoryElements = eventContainer.querySelectorAll( '[class*="tribe_events_cat-"]' );
+				hasMatch = [ ...categoryElements ].some(
+					( el ) => eventHasMatchingCategory( el, selectedArray )
+				);
 			}
-
-			const hasMatch = categoryElement ? eventHasMatchingCategory( categoryElement, selectedArray ) : false;
 
 			eventContainer.classList.toggle( SELECTORS.filteredHide, selectedArray.length > 0 && ! hasMatch );
 		} );


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-270](https://linear.app/nexcess/issue/SMTNC-270/category-filtering-fails-to-highlight-events-and-over-highlights-other)

### 🎥 Artifacts <!-- if applicable-->
[https://www.loom.com/share/ac1436cde1c748439acf66a63b895590](https://www.loom.com/share/ac1436cde1c748439acf66a63b895590)

### 🗒️ Description

Fixed the "Legend Superpowers" category filter on Month View so days with multiple events from different categories filter correctly. Previously, the filter relied on the first event in each day cell to decide whether to dim the cell, causing matching events to disappear (when first event didn't match) or non-matching events to look highlighted (when first event did match).

### ⚠️ Blockers
None.

### 🧪 Testing Instructions for QA

1. Activate **The Events Calendar** (≥6.15.9) and **Events Calendar Pro** (≥7.7.9). Ensure V2 Views are enabled.
2. **WP Admin → Events → Settings → Display**: enable **"Activate category colors"** AND **"Activate legend superpowers (filter events on click)"**. Save.
3. Create two event categories with distinct colors: **Category A** and **Category B**.
4. On the same future date, create:
   - **Event 1** at 2:00 PM, assigned **only** to Category A.
   - **Event 2** at 7:00 PM, assigned **only** to Category B.
5. Front-end → **Month View** → locate the test day (shows two stacked events).
6. Select **both** Category A and Category B.
   - **Expected:** day cell and both events fully shown / highlighted.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[skip-phpcs]

[ECP-2016]: https://stellarwp.atlassian.net/browse/ECP-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ