### PR TITLE
Fix: avoid eager translation in Aggregator cron_schedules filter (WP 6.8 early-textdomain)

### DIFF
--- a/changelog/fix-defer-aggregator-cron-schedule-translation
+++ b/changelog/fix-defer-aggregator-cron-schedule-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid translating the Event Aggregator cron schedule label before `init` to prevent `_doing_it_wrong` notices for early textdomain loading on WordPress 6.8+.

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -209,7 +209,10 @@ class Tribe__Events__Aggregator__Cron {
 		// Adds the Min frequency to WordPress cron schedules
 		$schedules['tribe-every15mins'] = [
 			'interval' => MINUTE_IN_SECONDS * 15,
-			'display'  => esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
+			// Core can fire `cron_schedules` before `init`; translating then triggers a `_doing_it_wrong` on WP 6.8+.
+			'display'  => did_action( 'init' )
+				? esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' )
+				: 'Every 15 minutes',
 		];
 
 		return $schedules;


### PR DESCRIPTION
## Bug #2 (hardening) of the WP 6.8 early-translation regression

`Tribe__Events__Aggregator__Cron::filter_add_cron_schedules()` translates schedule labels (`esc_html_x( 'Every 15 minutes', … )`) inside the core `cron_schedules` filter. Core can fire that filter before `init` (any plugin scheduling a cron event early), which on **WP 6.8** triggers a `_load_textdomain_just_in_time` notice → output mid-bootstrap → broken REST/redirect responses.

The companion Events Pro PR stops ECP from scheduling cron during `plugins_loaded` (the trigger we hit). **This PR hardens TEC itself** so the filter no longer translates eagerly, protecting against any other early cron caller.

> Note: no changelog entry on this branch yet — add one before merge if TEC's process requires it.