### PR TITLE
Fix: use timezone-aware DateTime parsing in get_event_timestamp()

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -161,7 +161,16 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 		if ( $use_event_tz || ( $use_site_tz && $site_zone_is_event_zone ) ) {
 			$datetime = get_post_meta( $event->ID, "_Event{$type}Date", true );
 
-			return $timestamps[ $cache_key ] = strtotime( $datetime );
+			// Use timezone-aware parsing: strtotime() alone interprets the local date string using
+			// PHP's default timezone (often UTC on managed hosts like Pressable), which diverges
+			// from the event/site timezone and produces an incorrect Unix timestamp.
+			$tz_string = self::generate_timezone_string_from_utc_offset( $event_tz ?: self::wp_timezone_string() );
+			try {
+				$dt = new DateTime( $datetime, new DateTimeZone( $tz_string ) );
+				return $timestamps[ $cache_key ] = $dt->getTimestamp();
+			} catch ( Exception $e ) {
+				return $timestamps[ $cache_key ] = strtotime( $datetime );
+			}
 		}
 
 		// Otherwise lets load the event's UTC time and convert it
@@ -174,7 +183,15 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 			: $timezone;
 
 		$localized = self::to_tz( $datetime, $tzstring );
-		$timestamps[ $cache_key ] = strtotime( $localized );
+
+		// Same timezone-aware parsing fix for the UTC→local conversion path.
+		$tz_string = self::generate_timezone_string_from_utc_offset( $tzstring );
+		try {
+			$dt                       = new DateTime( $localized, new DateTimeZone( $tz_string ) );
+			$timestamps[ $cache_key ] = $dt->getTimestamp();
+		} catch ( Exception $e ) {
+			$timestamps[ $cache_key ] = strtotime( $localized );
+		}
 
 		tribe_set_var( $cache_var_name, $timestamps );
 


### PR DESCRIPTION


### 🎫 Ticket

[SMTNC-267](smtnc-267-woocommerce-enhanced-templates-emails-render-event-times-in)

### 🗒️ Description

strtotime() interprets local date strings using PHP's default timezone, which is UTC on many managed hosts (e.g. Pressable) regardless of the WordPress site timezone. This caused event times to render in UTC instead of the configured site/event timezone in WooCommerce Enhanced Templates emails, including those triggered via cron/Action Scheduler.

Replace bare strtotime() calls in both code paths of get_event_timestamp() with new DateTime($datetime, new DateTimeZone($tz))->getTimestamp() so the Unix timestamp is always correct regardless of the server's PHP default TZ.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
