### PR TITLE
TEC "Event Venue" block country select is too small

### DIFF
--- a/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
+++ b/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove bottom padding from "Event Venue" block to be compatible with Wordpress 7 styles. [SMTNC-1181]
+Remove bottom padding from "Event Venue" block to be compatible with Wordpress 7 styles. 

--- a/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
+++ b/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove bottom padding from "Event Venue" block to be compatible with Wordpress 7 styles. 
+Removed bottom padding from "Event Venue" block to be compatible with Wordpress 7 styles. 

--- a/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
+++ b/changelog/smtnc-1181-wp-70-beta-conflict-tec-venue-block-country-select-is-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove bottom padding from "Event Venue" block to be compatible with Wordpress 7 styles. [SMTNC-1181]

--- a/src/modules/elements/venue-form/style.pcss
+++ b/src/modules/elements/venue-form/style.pcss
@@ -42,7 +42,6 @@
 		font-family: Helvetica, Arial, sans-serif;
 		font-size: 1rem;
 		margin-bottom: 10px;
-		padding: 10px;
 		width: 100%;
 
 		&:focus {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1181](https://linear.app/nexcess/issue/SMTNC-1181/wp-70-beta-conflict-tec-venue-block-country-select-is-too-small)

### 🗒️ Description

Wordpress 7 brakes select style.
This PR fixes it by removing `padding-bottom` from it's stylesheet.

### 🎥 Artifacts

#### Before fix

<img width="1278" height="943" alt="image" src="https://github.com/user-attachments/assets/6883b1c7-f657-412e-89fe-4cc39ce1833b" />

#### After fix

<img width="1278" height="943" alt="image" src="https://github.com/user-attachments/assets/586042ea-9262-48c3-aa0b-a5e663674bb5" />

### 🧪 Testing Instructions

To be able to access the "Event Venue" block you have to active the "Activate Block Editor for Events" option (image), go to any event and try to add a new one.

<img width="2560" height="1108" alt="image" src="https://github.com/user-attachments/assets/35f21d51-c320-4100-9ae9-fe93c6c07a00" />

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[skip-phpcs]
