### PR TITLE
fix(tests): guard Action Scheduler load in CT1 fixtures

### DIFF
--- a/tests/_support/Traits/CT1/CT1_Fixtures.php
+++ b/tests/_support/Traits/CT1/CT1_Fixtures.php
@@ -198,6 +198,10 @@ trait CT1_Fixtures {
 	}
 
 	private function given_action_scheduler_is_loaded() {
+		if ( function_exists( 'as_enqueue_async_action' ) ) {
+			return;
+		}
+
 		tribe( Provider::class )->load_action_scheduler_late();
 	}
 


### PR DESCRIPTION
The common bump moved Action Scheduler to vendor/vendor-prefixed and now loads it during normal bootstrap. The deprecated `Provider::load_action_scheduler_late()` still hard-requires the removed old path, so calling it unconditionally fataled the ct1_migration suite (and fail-fast-canceled the other matrix suites).

Match ET's approach: short-circuit when as_enqueue_async_action() already exists so the deprecated dead-path require is never reached.

[skip-changelog]
