### PR TITLE
test: phpcs CI — no PHP changes [DO NOT MERGE]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,7 +25,7 @@ jobs:
   phpcs:
     needs: check
     if: needs.check.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-xargs-exit-code
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,7 +25,7 @@ jobs:
   phpcs:
     needs: check
     if: needs.check.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@main
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — Test PR only.

Validates the fix from [stellarwp/github-actions#22](https://github.com/stellarwp/github-actions/pull/22) before it merges to `main`.

**Scenario:** No PHP files are changed in this PR — only the CI workflow reference is temporarily updated.

**Expected CI result:** The `phpcs` job should **pass** and skip all phpcs-related steps (setup-php, composer-install, reviewdog) because no PHP files were changed. Previously, this scenario caused an exit code 1 because phpcs was invoked with no file arguments and output a non-JSON error string instead of a JSON report.

---
_Temporarily points `.github/workflows/phpcs.yml` to `fix/phpcs-empty-changed-files` to validate the fix before merge._