### PR TITLE
Fix regression in TEC 6.16.5

### DIFF
--- a/changelog/smtnc-1667-regression-in-tec-6165
+++ b/changelog/smtnc-1667-regression-in-tec-6165
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the Event Tickets registration page returned a 404 when the "Return 404 for disabled view URLs" setting was enabled.

--- a/src/Events/SEO/Headers/Controller.php
+++ b/src/Events/SEO/Headers/Controller.php
@@ -114,6 +114,10 @@ class Controller extends Controller_Contract {
 			return;
 		}
 
+		if ( $this->is_single_event_request( $wp_query ) ) {
+			return;
+		}
+
 		// 404 for any view that is currently disabled, regardless of how the URL was built.
 		// Site owners can disable this guard via Settings > Display > SEO & URL Handling.
 		if ( ! in_array( $effective_display, $enabled_views, true ) ) {
@@ -140,6 +144,36 @@ class Controller extends Controller_Contract {
 		} elseif ( 'list' === $effective_display ) {
 			$this->check_list_view( $wp_query, $enabled_views );
 		}
+	}
+
+	/**
+	 * Whether the current request targets a single event rather than an event archive.
+	 *
+	 * The disabled-view 404 guard is only meaningful for the calendar *archive* views
+	 * (list, month, day, photo, …). Single-event endpoints reuse the `eventDisplay`
+	 * query var for non-archive purposes — the Event Tickets registration page
+	 * (eventDisplay=tickets), the recurring-series `all` view and the single-event
+	 * `ical` feed — and must never be treated as a disabled archive view.
+	 *
+	 * A single event is always addressed by its slug (`name` / `tribe_events`) or its
+	 * ID (`p`) in the parsed query, which archive requests never carry. The WP
+	 * conditionals are checked first for real requests, with the raw query vars as a
+	 * fallback for early hooks or direct calls where the conditionals are not yet set.
+	 *
+	 * @since TBD
+	 *
+	 * @param \WP_Query $wp_query The global WP_Query object.
+	 *
+	 * @return bool True when the request is for a single event.
+	 */
+	private function is_single_event_request( \WP_Query $wp_query ): bool {
+		if ( $wp_query->is_single || $wp_query->is_singular ) {
+			return true;
+		}
+
+		return ! empty( $wp_query->query['name'] )
+			|| ! empty( $wp_query->query['tribe_events'] )
+			|| ! empty( $wp_query->query['p'] );
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_Disabled_View_Test.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/SEO/Headers/Controller_Disabled_View_Test.php
@@ -180,4 +180,62 @@ class Controller_Disabled_View_Test extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertFalse( $wp_query->is_404, 'When eventDisplay is absent the guard should not fire.' );
 	}
+
+	/**
+	 * The Event Tickets registration page is served at /event/{slug}/tickets and sets
+	 * eventDisplay=tickets on a *single event* request. It is not a calendar archive view,
+	 * so the disabled-view 404 guard must never fire for it — even though 'tickets' is
+	 * absent from tribeEnableViews and the "Return 404 for disabled view URLs" option is on.
+	 *
+	 * @test
+	 */
+	public function test_single_event_tickets_endpoint_does_not_404(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month', 'day' ], 10, 3 );
+		add_filter( 'tribe_get_option_tec_seo_disabled_view_404', static fn() => true, 10, 3 );
+
+		global $wp_query;
+		// Mirrors the parsed query for /event/{slug}/tickets (see Tickets_View / Series_Passes rewrite).
+		$wp_query->query = [
+			'post_type'    => 'tribe_events',
+			'tribe_events' => 'my-event',
+			'name'         => 'my-event',
+			'eventDisplay' => 'tickets',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse(
+			$wp_query->is_404,
+			'The single-event /tickets endpoint must not be 404\'d by the disabled-view guard.'
+		);
+	}
+
+	/**
+	 * A single-event request detected via the WP conditionals (is_single) must also be
+	 * skipped by the disabled-view guard, covering endpoints such as the single-event
+	 * `ical` feed and the recurring-series `all` view that reuse eventDisplay.
+	 *
+	 * @test
+	 */
+	public function test_single_event_request_via_conditional_does_not_404(): void {
+		add_filter( 'tribe_get_option_tribeEnableViews', static fn() => [ 'list', 'month', 'day' ], 10, 3 );
+		add_filter( 'tribe_get_option_tec_seo_disabled_view_404', static fn() => true, 10, 3 );
+
+		global $wp_query;
+		$wp_query->is_single   = true;
+		$wp_query->is_singular = true;
+		$wp_query->query       = [
+			'post_type'    => 'tribe_events',
+			'eventDisplay' => 'all',
+		];
+
+		tribe_register_provider( Controller::class );
+		tribe( Controller::class )->filter_headers();
+
+		$this->assertFalse(
+			$wp_query->is_404,
+			'A single-event request (is_single) must not be 404\'d by the disabled-view guard.'
+		);
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1667](https://linear.app/nexcess/issue/SMTNC-1667/regression-in-tec-6165)

### 🗒️ Description

Regression comes from https://github.com/the-events-calendar/the-events-calendar/pull/5624

The "Return 404 for disabled view URLs" guard added in 6.16.5 was returning an HTTP 404 for the Event Tickets registration page (/event/{slug}/tickets), because that endpoint sets eventDisplay=tickets on a single event and the guard treated any eventDisplay value absent from tribeEnableViews as a disabled view.

The guard is only meaningful for event archive views (list, month, day, photo…), so filter_headers() now bails for single-event requests before running the disabled-view 404 and per-view date checks, leaving /tickets (and the all/ical single-event endpoints) working while genuinely disabled archive views still 404.

+regression coverage.

### 🎥 Artifacts

https://www.loom.com/share/bc1563aa9ee24107a9f60e68e1f73612

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
