### PR TITLE
[SMTNC-327] Resolve symlinks before validating CSV import path

### DIFF
--- a/changelog/fix-SMTNC-327-symlinked-uploads-csv-error
+++ b/changelog/fix-SMTNC-327-symlinked-uploads-csv-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected CSV imports that failed to show any records on sites with a symlinked uploads folder.

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -310,6 +310,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 	 *
 	 * @since 4.6.15
 	 * @since 6.15.17.1 Strengthen file type and location checks during aggregator imports.
+	 * @since TBD Resolve symlinks before validating the path so imports work on symlinked uploads directories.
 	 *
 	 * @return bool|false|string Either the absolute path to the CSV file or `false` on failure.
 	 */
@@ -321,6 +322,9 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		}
 
 		if ( $file_path ) {
+			// Resolve symlinks (e.g. a symlinked uploads directory) so the path can be compared against the uploads base below.
+			$file_path = realpath( $file_path ) ?: $file_path;
+
 			// Only allow CSV files — reject any other extension to prevent file disclosure.
 			$filetype = wp_check_filetype( $file_path );
 			if ( empty( $filetype['ext'] ) || 'csv' !== strtolower( $filetype['ext'] ) ) {

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/CSVTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/CSVTest.php
@@ -32,6 +32,9 @@ class CSVTest extends Events_TestCase {
 	/** @var string[] Symlinks created during a test; cleaned up in tearDown. */
 	private $temp_links = [];
 
+	/** @var string[] Directories created during a test; cleaned up in tearDown. */
+	private $temp_dirs = [];
+
 	// -------------------------------------------------------------------------
 	// Set-up / tear-down
 	// -------------------------------------------------------------------------
@@ -53,6 +56,11 @@ class CSVTest extends Events_TestCase {
 		foreach ( $this->temp_links as $link ) {
 			if ( is_link( $link ) ) {
 				@unlink( $link );
+			}
+		}
+		foreach ( $this->temp_dirs as $dir ) {
+			if ( is_dir( $dir ) ) {
+				@rmdir( $dir );
 			}
 		}
 		parent::tearDown();
@@ -330,6 +338,7 @@ class CSVTest extends Events_TestCase {
 		$link = untrailingslashit( sys_get_temp_dir() ) . '/tec-link-uploads-' . uniqid();
 
 		wp_mkdir_p( $real );
+		$this->temp_dirs[] = $real;
 
 		if ( ! @symlink( $real, $link ) ) {
 			$this->markTestSkipped( 'Symlinks are not supported on this host.' );

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/CSVTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/CSVTest.php
@@ -11,8 +11,8 @@ use Tribe__Events__Aggregator__Record__CSV as CSV_Record;
  * Verifies that the method correctly validates file paths before use:
  *   1. Extension check  – only .csv files are permitted.
  *   2. Directory check  – the resolved path must be inside wp-content/uploads/.
- *   3. Reverse lookup   – if the file is outside uploads, an attachment DB lookup
- *                         is attempted via attachment_url_to_postid() before giving up.
+ *   3. Symlink support  – paths are resolved with realpath() before the directory
+ *                         check so symlinked uploads directories still import.
  *
  * Numeric values are treated as attachment IDs and resolved via get_attached_file().
  * Both the numeric and string-path routes go through the same filetype guard.
@@ -28,6 +28,9 @@ class CSVTest extends Events_TestCase {
 
 	/** @var string[] Temporary files created during a test; cleaned up in tearDown. */
 	private $temp_files = [];
+
+	/** @var string[] Symlinks created during a test; cleaned up in tearDown. */
+	private $temp_links = [];
 
 	// -------------------------------------------------------------------------
 	// Set-up / tear-down
@@ -45,6 +48,11 @@ class CSVTest extends Events_TestCase {
 		foreach ( $this->temp_files as $path ) {
 			if ( file_exists( $path ) ) {
 				@unlink( $path );
+			}
+		}
+		foreach ( $this->temp_links as $link ) {
+			if ( is_link( $link ) ) {
+				@unlink( $link );
 			}
 		}
 		parent::tearDown();
@@ -303,5 +311,63 @@ class CSVTest extends Events_TestCase {
 			$this->call_get_file_path( $record ),
 			'get_file_path() must return false for a numeric attachment ID whose file does not have a .csv extension.'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Symlinked uploads: valid .csv reached through a symlinked uploads dir
+	//
+	// Regression test: get_attached_file() returns the unresolved (symlinked)
+	// basedir path, while the directory check resolves the uploads base with
+	// realpath(). Without resolving the file path too the prefix comparison
+	// fails and a valid import is rejected as "no records to import".
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @test
+	 */
+	public function it_allows_valid_csv_reached_through_a_symlinked_uploads_directory() {
+		$real = untrailingslashit( sys_get_temp_dir() ) . '/tec-real-uploads-' . uniqid();
+		$link = untrailingslashit( sys_get_temp_dir() ) . '/tec-link-uploads-' . uniqid();
+
+		wp_mkdir_p( $real );
+
+		if ( ! @symlink( $real, $link ) ) {
+			$this->markTestSkipped( 'Symlinks are not supported on this host.' );
+		}
+		$this->temp_links[] = $link;
+
+		// Point the uploads directory at the symlink, mirroring a symlinked uploads setup.
+		$filter = static function ( $dir ) use ( $link ) {
+			$dir['basedir'] = $link;
+			$dir['path']    = $link;
+			return $dir;
+		};
+		add_filter( 'upload_dir', $filter );
+
+		try {
+			// The CSV is created through the symlinked path, exactly as an upload would be.
+			$csv_path = trailingslashit( $link ) . 'tec-symlinked-import.csv';
+			$this->create_file( $csv_path );
+
+			$attachment_id = wp_insert_attachment(
+				[
+					'post_mime_type' => 'text/csv',
+					'post_title'     => 'tec-symlinked-import',
+					'post_status'    => 'inherit',
+				],
+				$csv_path
+			);
+			update_attached_file( $attachment_id, $csv_path );
+
+			$record = $this->make_record( (string) $attachment_id );
+
+			$this->assertSame(
+				realpath( $csv_path ),
+				$this->call_get_file_path( $record ),
+				'get_file_path() must resolve and accept a valid .csv reached through a symlinked uploads directory.'
+			);
+		} finally {
+			remove_filter( 'upload_dir', $filter );
+		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[[SMTNC-327]](https://linear.app/nexcess/issue/SMTNC-327/csv-imports-broken-on-server-with-symlinked-uploads-after-update)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

CSV imports stopped working on sites whose `uploads` directory is a symlink after the hardening added to `Tribe__Events__Aggregator__Record__CSV`
(6.15.17.1+). The preview showed "Your preview doesn't have any records to import" and the import failed.

**Cause:** In `get_file_path()`, the file path came from `get_attached_file()` (which returns the configured, unresolved uploads path) while the uploads base was resolved with `realpath()`. On a symlinked uploads directory the two paths differ, so the `strpos()` prefix check failed and `get_file_path()` returned `false`.

**Fix:** Resolve the file path with `realpath()` before the uploads-directory check so both sides are canonicalized. The CSV extension guard and the path-traversal protection are unchanged.

Types of changes: Bug fix (non-breaking change which fixes an issue).

### Artifacts

**Before:**
<img width="1046" height="642" alt="Screenshot 2026-07-07 at 10 34 14 AM" src="https://github.com/user-attachments/assets/f4bb9e08-f58d-4b95-842e-84082000255d" />

Loom video: Located in the task link.


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.