### PR TITLE
fix: remove stray 'inside' class causing double padding on Events/Organizer metabox (SOFT-3346)

### DIFF
--- a/src/Tribe/Organizer.php
+++ b/src/Tribe/Organizer.php
@@ -783,7 +783,7 @@ class Tribe__Events__Organizer extends Tribe__Events__Linked_Posts__Base {
 				border: none;
 			}
 		</style>
-		<div id='eventDetails' class="inside eventForm">
+		<div id='eventDetails' class="eventForm">
 			<table cellspacing="0" cellpadding="0" id="EventInfo" class="OrganizerInfo">
 				<?php
 				$hide_organizer_title = true;

--- a/src/admin-views/events-meta-box.php
+++ b/src/admin-views/events-meta-box.php
@@ -27,7 +27,7 @@ $events_label_plural_lowercase   = tribe_get_event_label_plural_lowercase();
 	do_action( 'tribe_events_post_errors', $event->ID, true );
 	?>
 </div>
-<div id='eventDetails' class="inside eventForm" data-datepicker_format="<?php echo esc_attr( \Tribe__Date_Utils::get_datepicker_format_index() ); ?>">
+<div id='eventDetails' class="eventForm" data-datepicker_format="<?php echo esc_attr( \Tribe__Date_Utils::get_datepicker_format_index() ); ?>">
 	<?php
 	/**
 	 * Fires inside the opening #eventDetails div of The Events Calendar meta box


### PR DESCRIPTION
[SOFT-3346](https://linear.app/nexcess/issue/SOFT-3346/rsvp-metabox-ui-has-spacing-and-alignment-inconsistencies)

## Description

The Events metabox's `#eventDetails` div (and the matching Organizer metabox markup) reused WordPress core's reserved `.inside` class name. This caused the classic wp-admin `.postbox .inside { padding: 0 12px 12px }` rule to stack on top of the block editor's outer `.postbox > .inside { padding: 0 24px 24px }` rule, giving the Events/Organizer metabox ~36px of effective left/right padding instead of the intended 24px — visibly misaligned against the Tickets/RSVP metaboxes stacked below it (event-tickets), which only ever get the 24px.

Fix: drop the stray `inside` class, leaving `class="eventForm"`. No CSS changes needed; JS references to `#eventDetails` key off the element ID or the `.eventForm` class, never `.inside`, so this is safe.

Companion PRs land the matching helper-text/spacing fixes in `event-tickets` and `event-tickets-plus`.

## Artifacts

After:
<img width="3070" height="1938" alt="SOFT-3346-AFTER" src="https://github.com/user-attachments/assets/be0175bd-5d8d-4619-b520-67a2006e0d1c" />


## Testing

- Open an event's edit screen and confirm the Events metabox's left padding now matches the Tickets/RSVP metaboxes below it.
- Open an Organizer's edit screen and confirm no visual regression in the Organizer Information metabox.

[skip-changelog]