### PR TITLE
[SMTNC-267] Event times render in UTC instead of site timezone

### DIFF
--- a/changelog/smtnc-267-event-times-render-in-utc
+++ b/changelog/smtnc-267-event-times-render-in-utc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where event times rendered in UTC on WooCommerce order pages and emails when PHP's default timezone was changed by third-party code.

--- a/changelog/smtnc-267-multiday-all-day-end-date
+++ b/changelog/smtnc-267-multiday-all-day-end-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where multi-day all-day events displayed an incorrect end date when PHP's default timezone was changed by third-party code.

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -135,6 +135,12 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 
 		$timestamps = tribe_get_var( $cache_var_name, [] );
 
+		if ( null === $timezone ) {
+			$timezone = self::mode();
+		}
+
+		// Build the cache key after resolving the timezone mode so `null` and the
+		// resolved mode string share the same cache entry.
 		$cache_key = "{$event_id}:{$type}:{$timezone}";
 
 		if ( isset( $timestamps[ $cache_key ] ) ) {
@@ -144,10 +150,6 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 		$event    = get_post( Tribe__Events__Main::postIdHelper( $event_id ) );
 		$event_tz = get_post_meta( $event->ID, '_EventTimezone', true );
 		$site_tz  = self::wp_timezone_string();
-
-		if ( null === $timezone ) {
-			$timezone = self::mode();
-		}
 
 		// Should we use the event specific timezone or the site-wide timezone?
 		$use_event_tz = self::EVENT_TIMEZONE === $timezone;
@@ -161,7 +163,11 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 		if ( $use_event_tz || ( $use_site_tz && $site_zone_is_event_zone ) ) {
 			$datetime = get_post_meta( $event->ID, "_Event{$type}Date", true );
 
-			return $timestamps[ $cache_key ] = strtotime( $datetime );
+			$timestamps[ $cache_key ] = self::wall_clock_timestamp( $datetime );
+
+			tribe_set_var( $cache_var_name, $timestamps );
+
+			return $timestamps[ $cache_key ];
 		}
 
 		// Otherwise lets load the event's UTC time and convert it
@@ -174,11 +180,39 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 			: $timezone;
 
 		$localized = self::to_tz( $datetime, $tzstring );
-		$timestamps[ $cache_key ] = strtotime( $localized );
+		$timestamps[ $cache_key ] = self::wall_clock_timestamp( $localized );
 
 		tribe_set_var( $cache_var_name, $timestamps );
 
 		return $timestamps[ $cache_key ];
+	}
+
+	/**
+	 * Converts a wall-clock datetime string into a timestamp without depending on
+	 * PHP's default timezone.
+	 *
+	 * The returned timestamp preserves the wall-clock time of the input string by
+	 * parsing it under an explicit UTC timezone. This keeps the established contract
+	 * with `date_i18n()`, which assumes timestamps were produced with a UTC default
+	 * timezone, and makes the result immune to third-party code calling
+	 * `date_default_timezone_set()`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $datetime A datetime string representing a wall-clock time.
+	 *
+	 * @return int|false The timestamp preserving the wall-clock time of the input,
+	 *                   or `false` if the string could not be parsed.
+	 */
+	protected static function wall_clock_timestamp( $datetime ) {
+		$date = Tribe__Date_Utils::build_date_object( $datetime, 'UTC', false );
+
+		if ( false === $date ) {
+			// Fall back to the legacy behavior on unparsable input.
+			return strtotime( $datetime );
+		}
+
+		return $date->getTimestamp();
 	}
 
 	/**

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -165,8 +165,6 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 
 			$timestamps[ $cache_key ] = self::wall_clock_timestamp( $datetime );
 
-			tribe_set_var( $cache_var_name, $timestamps );
-
 			return $timestamps[ $cache_key ];
 		}
 

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -165,6 +165,8 @@ class Tribe__Events__Timezones extends Tribe__Timezones {
 
 			$timestamps[ $cache_key ] = self::wall_clock_timestamp( $datetime );
 
+			tribe_set_var( $cache_var_name, $timestamps );
+
 			return $timestamps[ $cache_key ];
 		}
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1321,9 +1321,13 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 
 					$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
 
-				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
-				$end_date_full_timestamp    = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC' )->getTimestamp();
-				$beginning_of_day_timestamp = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $end_date_full ), 'UTC' )->getTimestamp();
+			// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
+			$end_date_obj                = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
+			$end_date_full_timestamp     = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
+
+			$beginning_of_day_str        = tribe_beginning_of_day( $end_date_full );
+			$beginning_of_day_obj        = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );
+			$beginning_of_day_timestamp  = false !== $beginning_of_day_obj ? $beginning_of_day_obj->getTimestamp() : strtotime( $beginning_of_day_str );
 
 				// if the end date is <= the beginning of the day, consider it the previous day
 				if ( $end_date_full_timestamp <= $beginning_of_day_timestamp ) {

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1322,8 +1322,8 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 				$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
 
 				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
-				$end_date_obj             = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
-				$end_date_full_timestamp  = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
+				$end_date_obj            = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
+				$end_date_full_timestamp = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
 
 				$beginning_of_day_str       = tribe_beginning_of_day( $end_date_full );
 				$beginning_of_day_obj       = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1319,10 +1319,10 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 				$inner .= ( $html ? '</span>' : '' ) . $time_range_separator;
 				$inner .= $html ? '<span class="tribe-event-date-end">' : '';
 
-				$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
-				
+					$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
+
 				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
-				$end_date_full_timestamp = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC' )->getTimestamp();
+				$end_date_full_timestamp    = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC' )->getTimestamp();
 				$beginning_of_day_timestamp = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $end_date_full ), 'UTC' )->getTimestamp();
 
 				// if the end date is <= the beginning of the day, consider it the previous day

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1319,15 +1319,15 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 				$inner .= ( $html ? '</span>' : '' ) . $time_range_separator;
 				$inner .= $html ? '<span class="tribe-event-date-end">' : '';
 
-					$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
+				$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
 
-			// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
-			$end_date_obj                = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
-			$end_date_full_timestamp     = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
+				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
+				$end_date_obj                = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
+				$end_date_full_timestamp     = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
 
-			$beginning_of_day_str        = tribe_beginning_of_day( $end_date_full );
-			$beginning_of_day_obj        = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );
-			$beginning_of_day_timestamp  = false !== $beginning_of_day_obj ? $beginning_of_day_obj->getTimestamp() : strtotime( $beginning_of_day_str );
+				$beginning_of_day_str        = tribe_beginning_of_day( $end_date_full );
+				$beginning_of_day_obj        = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );
+				$beginning_of_day_timestamp  = false !== $beginning_of_day_obj ? $beginning_of_day_obj->getTimestamp() : strtotime( $beginning_of_day_str );
 
 				// if the end date is <= the beginning of the day, consider it the previous day
 				if ( $end_date_full_timestamp <= $beginning_of_day_timestamp ) {

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1322,12 +1322,12 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 				$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
 
 				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
-				$end_date_obj                = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
-				$end_date_full_timestamp     = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
+				$end_date_obj             = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC', false );
+				$end_date_full_timestamp  = false !== $end_date_obj ? $end_date_obj->getTimestamp() : strtotime( $end_date_full );
 
-				$beginning_of_day_str        = tribe_beginning_of_day( $end_date_full );
-				$beginning_of_day_obj        = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );
-				$beginning_of_day_timestamp  = false !== $beginning_of_day_obj ? $beginning_of_day_obj->getTimestamp() : strtotime( $beginning_of_day_str );
+				$beginning_of_day_str       = tribe_beginning_of_day( $end_date_full );
+				$beginning_of_day_obj       = Tribe__Date_Utils::build_date_object( $beginning_of_day_str, 'UTC', false );
+				$beginning_of_day_timestamp = false !== $beginning_of_day_obj ? $beginning_of_day_obj->getTimestamp() : strtotime( $beginning_of_day_str );
 
 				// if the end date is <= the beginning of the day, consider it the previous day
 				if ( $end_date_full_timestamp <= $beginning_of_day_timestamp ) {

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -1319,11 +1319,14 @@ function tribe_events_event_schedule_details( $event = null, $before = '', $afte
 				$inner .= ( $html ? '</span>' : '' ) . $time_range_separator;
 				$inner .= $html ? '<span class="tribe-event-date-end">' : '';
 
-				$end_date_full           = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
-				$end_date_full_timestamp = strtotime( $end_date_full );
+				$end_date_full = tribe_get_end_date( $event, true, Tribe__Date_Utils::DBDATETIMEFORMAT );
+				
+				// Use UTC so the wall-clock timestamps remain independent of PHP's default timezone.
+				$end_date_full_timestamp = Tribe__Date_Utils::build_date_object( $end_date_full, 'UTC' )->getTimestamp();
+				$beginning_of_day_timestamp = Tribe__Date_Utils::build_date_object( tribe_beginning_of_day( $end_date_full ), 'UTC' )->getTimestamp();
 
 				// if the end date is <= the beginning of the day, consider it the previous day
-				if ( $end_date_full_timestamp <= strtotime( tribe_beginning_of_day( $end_date_full ) ) ) {
+				if ( $end_date_full_timestamp <= $beginning_of_day_timestamp ) {
 					$end_date = tribe_format_date( $end_date_full_timestamp - DAY_IN_SECONDS, false, $format2ndday );
 				} else {
 					$end_date = tribe_get_end_date( $event, false, $format2ndday );

--- a/tests/_support/Testcases/Events_TestCase.php
+++ b/tests/_support/Testcases/Events_TestCase.php
@@ -36,6 +36,9 @@ class Events_TestCase extends WPTestCase {
 		foreach ( $this->implementation_backups as $alias => $value ) {
 			tribe_singleton( $alias, $value );
 		}
+
+		tribe_unset_var( 'Tribe__Events__Timezones::get_event_timestamp' );
+
 		parent::tearDown();
 	}
 

--- a/tests/_support/Testcases/TecViewTestCase.php
+++ b/tests/_support/Testcases/TecViewTestCase.php
@@ -22,4 +22,10 @@ class TecViewTestCase extends ViewTestCase {
 		);
 		parent::setUp();
 	}
+
+	public function tearDown() {
+		tribe_unset_var( 'Tribe__Events__Timezones::get_event_timestamp' );
+
+		parent::tearDown();
+	}
 }

--- a/tests/wpunit/Tribe/Events/WallClockTimestampTest.php
+++ b/tests/wpunit/Tribe/Events/WallClockTimestampTest.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace Tribe\Events;
+
+use Tribe__Events__Timezones as Timezones;
+
+/**
+ * Regression tests for the wall-clock timestamp contract of
+ * `Tribe__Events__Timezones::get_event_timestamp()`.
+ *
+ * The timestamps produced by `event_start_timestamp()` and `event_end_timestamp()`
+ * are "wall-clock" timestamps: they must equal the event local datetime string
+ * parsed as if it were UTC, regardless of the PHP default timezone in effect.
+ * Any dependence on `date_default_timezone_set()` is a regression.
+ */
+
+// phpcs:disable WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Simulating third-party code changing PHP's default timezone is the behavior under test.
+class WallClockTimestampTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @var string The PHP default timezone before the test ran.
+	 */
+	protected $php_timezone_backup;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->php_timezone_backup = date_default_timezone_get();
+
+		tribe_unset_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+		tribe_unset_var( 'Tribe__Events__Timezones::get_event_timestamp' );
+
+		tribe( 'cache' )->reset();
+	}
+
+	public function tearDown() {
+		date_default_timezone_set( $this->php_timezone_backup );
+
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The PHP default timezones covering all failure-relevant characteristics:
+	 * zero offset (control), negative offsets with northern DST, large positive
+	 * without DST, half-hour and 45-minute fractional offsets, southern DST with
+	 * fractional offset, and the extreme +14 offset past the date line.
+	 *
+	 * @return array<string>
+	 */
+	protected function php_timezones() {
+		return [
+			'UTC',                 // Control: must be byte-identical to the pre-fix behavior.
+			'America/Chicago',     // -6/-5, northern DST; the reported customer scenario.
+			'America/Los_Angeles', // -8/-7, large negative with northern DST.
+			'Asia/Tokyo',          // +9, no DST.
+			'Asia/Kolkata',        // +5:30, half-hour fractional, no DST.
+			'Asia/Kathmandu',      // +5:45, 45-minute fractional, no DST.
+			'Pacific/Chatham',     // +12:45/+13:45, fractional with southern DST.
+			'Pacific/Kiritimati',  // +14, extreme positive, crosses the date line.
+		];
+	}
+
+	/**
+	 * Fixed UTC datetimes, each exercising a distinct boundary.
+	 *
+	 * @return array<string,string>
+	 */
+	protected function boundary_dates() {
+		return [
+			'jul15-midday'        => '2024-07-15 14:00:00', // Northern summer: DST on for Chicago/LA, off for Chatham.
+			'jan15-midday'        => '2024-01-15 14:00:00', // Southern summer: DST states inverted.
+			'dec31-year-boundary' => '2024-12-31 23:30:00', // Offsets cross the year boundary in both directions.
+			'jun15-day-boundary'  => '2024-06-15 23:30:00', // Offsets cross the day boundary, isolated from the year.
+		];
+	}
+
+	/**
+	 * Computes the expected wall-clock timestamp independently of the code under test.
+	 *
+	 * @param string           $utc_datetime The event UTC datetime string.
+	 * @param string|int|float $target_tz    A timezone name, or a numeric UTC offset in hours.
+	 *
+	 * @return int The localized wall-clock string parsed as UTC.
+	 */
+	protected function wall_clock_reference( $utc_datetime, $target_tz ) {
+		$utc  = new \DateTimeZone( 'UTC' );
+		$date = new \DateTimeImmutable( $utc_datetime, $utc );
+
+		if ( is_numeric( $target_tz ) ) {
+			return $date->getTimestamp() + (int) round( $target_tz * 3600 );
+		}
+
+		$local = $date->setTimezone( new \DateTimeZone( $target_tz ) )->format( 'Y-m-d H:i:s' );
+
+		return ( new \DateTimeImmutable( $local, $utc ) )->getTimestamp();
+	}
+
+	/**
+	 * Configures the WordPress site timezone from a matrix entry.
+	 *
+	 * @param array $site_tz Either [ 'timezone_string' => name ] or [ 'gmt_offset' => hours ].
+	 */
+	protected function set_site_timezone( array $site_tz ) {
+		if ( isset( $site_tz['timezone_string'] ) ) {
+			update_option( 'timezone_string', $site_tz['timezone_string'] );
+			update_option( 'gmt_offset', 0 );
+		} else {
+			update_option( 'timezone_string', '' );
+			update_option( 'gmt_offset', $site_tz['gmt_offset'] );
+		}
+	}
+
+	/**
+	 * Resolves the expected target timezone of a site timezone matrix entry.
+	 *
+	 * @param array $site_tz Either [ 'timezone_string' => name ] or [ 'gmt_offset' => hours ].
+	 *
+	 * @return string|int|float
+	 */
+	protected function site_tz_target( array $site_tz ) {
+		return $site_tz['timezone_string'] ?? $site_tz['gmt_offset'];
+	}
+
+	/**
+	 * Creates an event through the ORM (the production creation path) and asserts
+	 * the stored UTC meta is internally consistent, failing fast on invalid setup.
+	 *
+	 * The event is intentionally created while the PHP default timezone is still
+	 * UTC: this mirrors the real-world failure mode, where events are created
+	 * normally and only rendered while a non-UTC default timezone is in effect.
+	 *
+	 * @param string $utc_datetime The event start in UTC.
+	 * @param string $event_tz     The event timezone name.
+	 *
+	 * @return int The event post ID.
+	 */
+	protected function create_event_or_fail( $utc_datetime, $event_tz ) {
+		$local_start = ( new \DateTimeImmutable( $utc_datetime, new \DateTimeZone( 'UTC' ) ) )
+			->setTimezone( new \DateTimeZone( $event_tz ) )
+			->format( 'Y-m-d H:i:s' );
+
+		$event = tribe_events()->set_args(
+			[
+				'title'      => "Wall clock test event {$utc_datetime} {$event_tz}",
+				'status'     => 'publish',
+				'start_date' => $local_start,
+				'duration'   => 7200,
+				'timezone'   => $event_tz,
+			]
+		)->create();
+
+		if ( ! $event instanceof \WP_Post ) {
+			$this->fail( "Could not create event for {$utc_datetime} ({$event_tz})." );
+		}
+
+		if ( get_post_meta( $event->ID, '_EventStartDateUTC', true ) !== $utc_datetime ) {
+			$this->fail( "ORM produced inconsistent _EventStartDateUTC meta for {$utc_datetime} ({$event_tz})." );
+		}
+
+		return $event->ID;
+	}
+
+	/**
+	 * Tier 1: PHP timezone x event timezone x boundary dates, in event timezone mode.
+	 *
+	 * @return \Generator
+	 */
+	public function event_mode_matrix() {
+		foreach ( $this->php_timezones() as $php_tz ) {
+			foreach ( [ 'UTC', 'America/Chicago' ] as $event_tz ) {
+				foreach ( $this->boundary_dates() as $date_key => $utc_datetime ) {
+					yield "php={$php_tz}|event={$event_tz}|date={$date_key}" => [ $php_tz, $event_tz, $utc_datetime ];
+				}
+			}
+		}
+	}
+
+	/**
+	 * Event start/end timestamps must be wall-clock values in the event timezone,
+	 * regardless of the PHP default timezone.
+	 *
+	 * @dataProvider event_mode_matrix
+	 */
+	public function test_event_timestamps_are_wall_clock_in_event_mode( $php_tz, $event_tz, $utc_datetime ) {
+		update_option( 'timezone_string', 'America/Chicago' );
+		tribe_update_option( 'tribe_events_timezone_mode', 'event' );
+		tribe( 'cache' )->reset();
+
+		$event_id = $this->create_event_or_fail( $utc_datetime, $event_tz );
+
+		$expected_start = $this->wall_clock_reference( $utc_datetime, $event_tz );
+		$utc_end        = gmdate( 'Y-m-d H:i:s', strtotime( $utc_datetime . ' UTC' ) + 7200 );
+		$expected_end   = $this->wall_clock_reference( $utc_end, $event_tz );
+
+		date_default_timezone_set( $php_tz );
+
+		$this->assertSame( $expected_start, Timezones::event_start_timestamp( $event_id ) );
+		$this->assertSame( $expected_end, Timezones::event_end_timestamp( $event_id ) );
+	}
+
+	/**
+	 * Tier 2: PHP timezone x site timezone configurations, in site timezone mode.
+	 *
+	 * @return \Generator
+	 */
+	public function site_mode_matrix() {
+		$site_timezones = [
+			'named-chicago' => [ 'timezone_string' => 'America/Chicago' ],
+			'named-utc'     => [ 'timezone_string' => 'UTC' ],
+			'named-kolkata' => [ 'timezone_string' => 'Asia/Kolkata' ],
+			'manual+0'      => [ 'gmt_offset' => 0 ],
+			'manual-5'      => [ 'gmt_offset' => -5 ],
+			'manual+5.5'    => [ 'gmt_offset' => 5.5 ],
+		];
+
+		foreach ( $this->php_timezones() as $php_tz ) {
+			foreach ( $site_timezones as $site_key => $site_tz ) {
+				yield "php={$php_tz}|site={$site_key}" => [ $php_tz, $site_tz ];
+			}
+		}
+	}
+
+	/**
+	 * In site timezone mode the timestamps must be wall-clock values in the site
+	 * timezone — for named timezone strings and manual UTC offsets alike —
+	 * regardless of the PHP default timezone.
+	 *
+	 * @dataProvider site_mode_matrix
+	 */
+	public function test_event_timestamps_are_wall_clock_in_site_mode( $php_tz, array $site_tz ) {
+		$utc_datetime = '2024-07-15 14:00:00';
+
+		$this->set_site_timezone( $site_tz );
+		tribe_update_option( 'tribe_events_timezone_mode', 'site' );
+		tribe( 'cache' )->reset();
+
+		$event_id = $this->create_event_or_fail( $utc_datetime, 'America/Chicago' );
+
+		$expected = $this->wall_clock_reference( $utc_datetime, $this->site_tz_target( $site_tz ) );
+
+		date_default_timezone_set( $php_tz );
+
+		$this->assertSame( $expected, Timezones::event_start_timestamp( $event_id ) );
+	}
+
+	/**
+	 * Tier 3: hand-picked boundary-stressing combinations, including negative
+	 * tests where the PHP default timezone matches the display timezone.
+	 *
+	 * @return \Generator
+	 */
+	public function targeted_boundary_matrix() {
+		$cases = [
+			// PHP tz, site tz config, event tz, UTC datetime, mode.
+			'kiritimati-year-boundary-site'    => [ 'Pacific/Kiritimati', [ 'timezone_string' => 'America/Chicago' ], 'UTC', '2024-12-31 23:30:00', 'site' ],
+			'la-year-boundary-utc-site'        => [ 'America/Los_Angeles', [ 'timezone_string' => 'UTC' ], 'UTC', '2024-12-31 23:30:00', 'site' ],
+			'chatham-vs-manual-half-hour'      => [ 'Pacific/Chatham', [ 'gmt_offset' => 5.5 ], 'UTC', '2024-01-15 14:00:00', 'site' ],
+			'kathmandu-vs-kolkata'             => [ 'Asia/Kathmandu', [ 'timezone_string' => 'Asia/Kolkata' ], 'UTC', '2024-07-15 14:00:00', 'site' ],
+			'chatham-event-manual-13-site'     => [ 'Pacific/Chatham', [ 'gmt_offset' => 13 ], 'Pacific/Chatham', '2024-06-15 23:30:00', 'site' ],
+			'kiritimati-chatham-year-event'    => [ 'Pacific/Kiritimati', [ 'timezone_string' => 'America/Chicago' ], 'Pacific/Chatham', '2024-12-31 23:30:00', 'event' ],
+			'negative-php-matches-site'        => [ 'America/Chicago', [ 'gmt_offset' => -5 ], 'UTC', '2024-06-15 23:30:00', 'site' ],
+			'tokyo-newyork-year-site'          => [ 'Asia/Tokyo', [ 'timezone_string' => 'America/Chicago' ], 'America/New_York', '2024-12-31 23:30:00', 'site' ],
+			'kiritimati-kiritimati-year-event' => [ 'Pacific/Kiritimati', [ 'timezone_string' => 'America/Chicago' ], 'Pacific/Kiritimati', '2024-12-31 23:30:00', 'event' ],
+			'chatham-kiritimati-year-event'    => [ 'Pacific/Chatham', [ 'timezone_string' => 'America/Chicago' ], 'Pacific/Kiritimati', '2024-12-31 23:30:00', 'event' ],
+			'kathmandu-chatham-year-event'     => [ 'Asia/Kathmandu', [ 'timezone_string' => 'America/Chicago' ], 'Pacific/Chatham', '2024-12-31 23:30:00', 'event' ],
+			'la-tokyo-year-event'              => [ 'America/Los_Angeles', [ 'timezone_string' => 'America/Chicago' ], 'Asia/Tokyo', '2024-12-31 23:30:00', 'event' ],
+			'la-tokyo-day-event'               => [ 'America/Los_Angeles', [ 'timezone_string' => 'America/Chicago' ], 'Asia/Tokyo', '2024-06-15 23:30:00', 'event' ],
+			'tokyo-tokyo-day-event'            => [ 'Asia/Tokyo', [ 'timezone_string' => 'America/Chicago' ], 'Asia/Tokyo', '2024-06-15 23:30:00', 'event' ],
+			'kolkata-tokyo-year-event'         => [ 'Asia/Kolkata', [ 'timezone_string' => 'America/Chicago' ], 'Asia/Tokyo', '2024-12-31 23:30:00', 'event' ],
+			'kolkata-tokyo-day-event'          => [ 'Asia/Kolkata', [ 'timezone_string' => 'America/Chicago' ], 'Asia/Tokyo', '2024-06-15 23:30:00', 'event' ],
+			'chicago-spring-forward-event'     => [ 'America/Chicago', [ 'timezone_string' => 'America/Chicago' ], 'America/Chicago', '2024-03-10 08:00:00', 'event' ],
+			'chicago-fall-back-event'          => [ 'America/Chicago', [ 'timezone_string' => 'America/Chicago' ], 'America/Chicago', '2024-11-03 06:30:00', 'event' ],
+			'tokyo-spring-forward-event'       => [ 'Asia/Tokyo', [ 'timezone_string' => 'America/Chicago' ], 'America/Chicago', '2024-03-10 08:00:00', 'event' ],
+			'utc-control-year-event'           => [ 'UTC', [ 'timezone_string' => 'America/Chicago' ], 'Pacific/Kiritimati', '2024-12-31 23:30:00', 'event' ],
+			'utc-control-manual-site'          => [ 'UTC', [ 'gmt_offset' => -5 ], 'UTC', '2024-12-31 23:30:00', 'site' ],
+			'negative-php-matches-event'       => [ 'America/Chicago', [ 'timezone_string' => 'America/Chicago' ], 'America/Chicago', '2024-06-15 23:30:00', 'event' ],
+			'kiritimati-manual-negative-site'  => [ 'Pacific/Kiritimati', [ 'gmt_offset' => -5 ], 'America/Chicago', '2024-12-31 23:30:00', 'site' ],
+		];
+
+		foreach ( $cases as $key => $case ) {
+			yield $key => $case;
+		}
+	}
+
+	/**
+	 * @dataProvider targeted_boundary_matrix
+	 */
+	public function test_event_timestamps_on_targeted_boundaries( $php_tz, array $site_tz, $event_tz, $utc_datetime, $mode ) {
+		$this->set_site_timezone( $site_tz );
+		tribe_update_option( 'tribe_events_timezone_mode', $mode );
+		tribe( 'cache' )->reset();
+
+		$event_id = $this->create_event_or_fail( $utc_datetime, $event_tz );
+
+		$target   = 'event' === $mode ? $event_tz : $this->site_tz_target( $site_tz );
+		$expected = $this->wall_clock_reference( $utc_datetime, $target );
+
+		date_default_timezone_set( $php_tz );
+
+		$this->assertSame( $expected, Timezones::event_start_timestamp( $event_id, $mode ) );
+	}
+
+	/**
+	 * A `null` timezone argument and the explicitly resolved mode must share the
+	 * same cache entry, and a mode change mid-request must not serve a stale value.
+	 */
+	public function test_get_event_timestamp_cache_key_resolves_timezone_mode() {
+		update_option( 'timezone_string', 'America/Chicago' );
+		tribe_update_option( 'tribe_events_timezone_mode', 'event' );
+		tribe( 'cache' )->reset();
+
+		$utc_datetime = '2024-07-15 14:00:00';
+		$event_id     = $this->create_event_or_fail( $utc_datetime, 'Asia/Tokyo' );
+
+		$expected_event = $this->wall_clock_reference( $utc_datetime, 'Asia/Tokyo' );
+		$expected_site  = $this->wall_clock_reference( $utc_datetime, 'America/Chicago' );
+
+		// Null argument resolves to the current ('event') mode.
+		$this->assertSame( $expected_event, Timezones::event_start_timestamp( $event_id ) );
+		// The explicit mode must return the same value from the same cache entry.
+		$this->assertSame( $expected_event, Timezones::event_start_timestamp( $event_id, Timezones::EVENT_TIMEZONE ) );
+
+		// Changing the mode mid-request must not serve the value cached for the previous mode.
+		tribe_update_option( 'tribe_events_timezone_mode', 'site' );
+
+		$this->assertSame( $expected_site, Timezones::event_start_timestamp( $event_id ) );
+	}
+}

--- a/tests/wpunit/Tribe/Events/WallClockTimestampTest.php
+++ b/tests/wpunit/Tribe/Events/WallClockTimestampTest.php
@@ -39,6 +39,13 @@ class WallClockTimestampTest extends \Codeception\TestCase\WPTestCase {
 		update_option( 'timezone_string', '' );
 		update_option( 'gmt_offset', 0 );
 
+		// Flush the request-lifetime caches so options and timestamps mutated by
+		// this test are not served to unrelated tests after the DB rollback.
+		tribe_unset_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+		tribe_unset_var( 'Tribe__Events__Timezones::get_event_timestamp' );
+
+		tribe( 'cache' )->reset();
+
 		parent::tearDown();
 	}
 

--- a/tests/wpunit/functions/template-tags/__snapshots__/scheduleDetailsTimezoneTest__test_multiday_all_day_schedule_details_html_snapshot__1.php
+++ b/tests/wpunit/functions/template-tags/__snapshots__/scheduleDetailsTimezoneTest__test_multiday_all_day_schedule_details_html_snapshot__1.php
@@ -1,0 +1,1 @@
+<?php return '<span class="tribe-event-date-start">July 22, 2050</span> - <span class="tribe-event-date-end">July 24, 2050</span>';

--- a/tests/wpunit/functions/template-tags/__snapshots__/scheduleDetailsTimezoneTest__test_single_day_schedule_details_html_snapshot__1.php
+++ b/tests/wpunit/functions/template-tags/__snapshots__/scheduleDetailsTimezoneTest__test_single_day_schedule_details_html_snapshot__1.php
@@ -1,0 +1,1 @@
+<?php return '<span class="tribe-event-date-start">July 22, 2050 @ 11:30 am</span> - <span class="tribe-event-time">1:00 pm</span>';

--- a/tests/wpunit/functions/template-tags/scheduleDetailsTimezoneTest.php
+++ b/tests/wpunit/functions/template-tags/scheduleDetailsTimezoneTest.php
@@ -46,6 +46,10 @@ class scheduleDetailsTimezoneTest extends WPTestCase {
 		update_option( 'gmt_offset', 0 );
 		tribe_update_option( 'multiDayCutoff', '00:00' );
 
+		// Flush the request-lifetime caches so options and rendered details mutated
+		// by this test are not served to unrelated tests after the DB rollback.
+		$this->flush_date_caches();
+
 		parent::tearDown();
 	}
 

--- a/tests/wpunit/functions/template-tags/scheduleDetailsTimezoneTest.php
+++ b/tests/wpunit/functions/template-tags/scheduleDetailsTimezoneTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace TEC\Test\functions\template_tags;
+
+use Codeception\TestCase\WPTestCase;
+use Spatie\Snapshots\MatchesSnapshots;
+use tad\WP\Snapshots\WPHtmlOutputDriver;
+
+/**
+ * Regression tests ensuring `tribe_events_event_schedule_details()` renders the
+ * same schedule regardless of the PHP default timezone in effect.
+ */
+
+// phpcs:disable WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- Simulating third-party code changing PHP's default timezone is the behavior under test.
+class scheduleDetailsTimezoneTest extends WPTestCase {
+
+	use MatchesSnapshots;
+
+	/**
+	 * @var string The PHP default timezone before the test ran.
+	 */
+	protected $php_timezone_backup;
+
+	/**
+	 * @var WPHtmlOutputDriver
+	 */
+	protected $driver;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->php_timezone_backup = date_default_timezone_get();
+
+		update_option( 'timezone_string', 'America/Chicago' );
+		tribe_update_option( 'tribe_events_timezone_mode', 'event' );
+
+		$this->driver = new WPHtmlOutputDriver( home_url(), 'http://tribe.dev' );
+
+		$this->flush_date_caches();
+	}
+
+	public function tearDown() {
+		date_default_timezone_set( $this->php_timezone_backup );
+
+		update_option( 'timezone_string', '' );
+		update_option( 'gmt_offset', 0 );
+		tribe_update_option( 'multiDayCutoff', '00:00' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Flushes every request-lifetime cache sitting between an event and its
+	 * rendered schedule details, so back-to-back renders re-run the date math.
+	 */
+	protected function flush_date_caches() {
+		tribe_set_var( 'tribe_events_event_schedule_details', [] );
+		tribe_set_var( 'tribe_get_start_date', [] );
+		tribe_set_var( 'tribe_get_end_date', [] );
+		tribe_unset_var( 'Tribe__Events__Timezones::get_event_timestamp' );
+		tribe_unset_var( \Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+		tribe( 'cache' )->reset();
+	}
+
+	/**
+	 * Renders the plain-text schedule details of an event with cold caches.
+	 *
+	 * @param int $event_id The event post ID.
+	 *
+	 * @return string
+	 */
+	protected function render_schedule_details( $event_id ) {
+		$this->flush_date_caches();
+
+		return wp_strip_all_tags( tribe_events_event_schedule_details( $event_id ) );
+	}
+
+	/**
+	 * The same failure-relevant PHP default timezones exercised by
+	 * WallClockTimestampTest.
+	 *
+	 * @return \Generator
+	 */
+	public function php_timezones() {
+		$timezones = [
+			'UTC',
+			'America/Chicago',
+			'America/Los_Angeles',
+			'Asia/Tokyo',
+			'Asia/Kolkata',
+			'Asia/Kathmandu',
+			'Pacific/Chatham',
+			'Pacific/Kiritimati',
+		];
+
+		foreach ( $timezones as $timezone ) {
+			yield "php={$timezone}" => [ $timezone ];
+		}
+	}
+
+	/**
+	 * Creates the single-day event backing the reported bug: July 22, 2050,
+	 * 11:30 am - 1:00 pm America/Chicago.
+	 *
+	 * @return int The event post ID.
+	 */
+	protected function create_single_day_event() {
+		$event = tribe_events()->set_args(
+			[
+				'title'      => 'Timezone regression single day event',
+				'status'     => 'publish',
+				'start_date' => '2050-07-22 11:30:00',
+				'end_date'   => '2050-07-22 13:00:00',
+				'timezone'   => 'America/Chicago',
+			]
+		)->create();
+
+		if ( ! $event instanceof \WP_Post ) {
+			$this->fail( 'Could not create the single-day event.' );
+		}
+
+		return $event->ID;
+	}
+
+	/**
+	 * Creates a multiday all-day event with a 06:00 multiday cutoff. The ORM
+	 * normalizes all-day events to cutoff-aligned storage (end date
+	 * `2050-07-25 05:59:59`), which sits below the beginning-of-day boundary, so
+	 * the displayed end date must roll back to July 24.
+	 *
+	 * @return int The event post ID.
+	 */
+	protected function create_multiday_all_day_event() {
+		tribe_update_option( 'multiDayCutoff', '06:00' );
+
+		$event = tribe_events()->set_args(
+			[
+				'title'      => 'Timezone regression multiday all-day event',
+				'status'     => 'publish',
+				'start_date' => '2050-07-22 00:00:00',
+				'end_date'   => '2050-07-24 05:00:00',
+				'all_day'    => true,
+				'timezone'   => 'America/Chicago',
+			]
+		)->create();
+
+		if ( ! $event instanceof \WP_Post ) {
+			$this->fail( 'Could not create the multiday all-day event.' );
+		}
+
+		return $event->ID;
+	}
+
+	/**
+	 * A single-day schedule must render identically under any PHP default
+	 * timezone, and must show the event wall-clock time — not a UTC-shifted one.
+	 *
+	 * @dataProvider php_timezones
+	 */
+	public function test_single_day_schedule_details_ignore_php_default_timezone( $php_tz ) {
+		$event_id = $this->create_single_day_event();
+
+		date_default_timezone_set( 'UTC' );
+		$baseline = $this->render_schedule_details( $event_id );
+
+		if ( false === strpos( $baseline, '11:30 am' ) || false === strpos( $baseline, '1:00 pm' ) ) {
+			$this->fail( "Baseline render does not show the event wall-clock time: {$baseline}" );
+		}
+
+		date_default_timezone_set( $php_tz );
+
+		$this->assertSame( $baseline, $this->render_schedule_details( $event_id ) );
+	}
+
+	/**
+	 * A multiday all-day event stores its end at one second before the multiday
+	 * cutoff (here `2050-07-25 05:59:59` with a 06:00 cutoff), so the displayed
+	 * end date must roll back to July 24 under any PHP default timezone: a
+	 * positive UTC offset used to push the end date off by one day.
+	 *
+	 * @dataProvider php_timezones
+	 */
+	public function test_multiday_all_day_cutoff_end_date_ignores_php_default_timezone( $php_tz ) {
+		$event_id = $this->create_multiday_all_day_event();
+
+		date_default_timezone_set( 'UTC' );
+		$baseline = $this->render_schedule_details( $event_id );
+
+		if ( false === strpos( $baseline, 'July 24' ) || false !== strpos( $baseline, 'July 25' ) ) {
+			$this->fail( "Baseline render does not roll the end date back to July 24: {$baseline}" );
+		}
+
+		date_default_timezone_set( $php_tz );
+
+		$rendered = $this->render_schedule_details( $event_id );
+
+		$this->assertSame( $baseline, $rendered );
+		$this->assertContains( 'July 24', $rendered );
+		$this->assertNotContains( 'July 25', $rendered );
+	}
+
+	/**
+	 * Snapshot of the single-day schedule details HTML rendered under a UTC and
+	 * under a non-UTC PHP default timezone: both must match the same snapshot.
+	 */
+	public function test_single_day_schedule_details_html_snapshot() {
+		$event_id = $this->create_single_day_event();
+
+		date_default_timezone_set( 'UTC' );
+		$this->flush_date_caches();
+		$utc_html = tribe_events_event_schedule_details( $event_id );
+
+		date_default_timezone_set( 'America/Chicago' );
+		$this->flush_date_caches();
+		$chicago_html = tribe_events_event_schedule_details( $event_id );
+
+		$this->assertSame( $utc_html, $chicago_html );
+		$this->assertMatchesSnapshot( $utc_html, $this->driver );
+	}
+
+	/**
+	 * Snapshot of the multiday all-day schedule details HTML rendered under a UTC
+	 * and under a non-UTC PHP default timezone: both must match the same snapshot.
+	 */
+	public function test_multiday_all_day_schedule_details_html_snapshot() {
+		$event_id = $this->create_multiday_all_day_event();
+
+		date_default_timezone_set( 'UTC' );
+		$this->flush_date_caches();
+		$utc_html = tribe_events_event_schedule_details( $event_id );
+
+		date_default_timezone_set( 'Asia/Tokyo' );
+		$this->flush_date_caches();
+		$tokyo_html = tribe_events_event_schedule_details( $event_id );
+
+		$this->assertSame( $utc_html, $tokyo_html );
+		$this->assertMatchesSnapshot( $utc_html, $this->driver );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-267](https://linear.app/nexcess/issue/SMTNC-267/woocommerce-enhanced-templates-emails-render-event-times-in-utc)

### Commom part

https://github.com/the-events-calendar/tribe-common/pull/2948

### 🗒️ Description

When talking about timezone in this context we have...
- **WP Timezone** - That we set on admin panel and is native from WP.
- **Server-timezone** - Normally configured by the host, in the php.ini or by `date_default_timezone_set()`

Default PHP functions "guess the timezone" based on server-timezone and in our case TEC expects it to be UTC, but when it's not it shifts the timezone twice, which give us a incorrect result.

*Solution here is to not rely on `strtotime` and use UTC timezone.*

### 🧪 Testing Instructions

In a clean install you probably will not be able to reproduce it. So create a 1line plugin with `date_default_timezone_set("America/Chicago");`. That way you can mimic this behavior.

To undertand the timezone example. try this:

```bash
lando wp --path=wordpress eval 'echo strip_tags( tribe_events_event_schedule_details( EVENT_ID ) ) . "\n";'
# → July 22 @ 11:30 am - 1:00 pm  (PHP tz = UTC)

lando wp --path=wordpress eval 'date_default_timezone_set("America/Chicago"); echo strip_tags( tribe_events_event_schedule_details( EVENT_ID ) ) . "\n";'
# → July 22 @ 4:30 pm - 6:00 pm   (PHP tz != UTC → BUG)
```

---

Helper plugin:

```php
<?php
/**
 * Plugin Name: SMTNC-267 Repro - TZ override
 * Description: Simulates a plugin/snippet that sets PHP default timezone to the site timezone (like the customer's workaround).
 */
date_default_timezone_set( 'America/Chicago' );
```

### 🎥 Artifacts <!-- if applicable-->

https://www.loom.com/share/af125ff0bba4415b8493beb6b9c6c151

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
