### PR TITLE
Promoter - Fix TEC REST endpoints to give better errors

### DIFF
--- a/changelog/fix-rest-api-validation
+++ b/changelog/fix-rest-api-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve REST API error handling by providing specific error messages for trashed events and ensuring invalid or non-existent event ID parameters in archive endpoints return proper 400 errors.

--- a/changelog/fix-rest-api-validation
+++ b/changelog/fix-rest-api-validation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve REST API error handling by providing specific error messages for trashed events and ensuring invalid or non-existent event ID parameters in archive endpoints return proper 400 errors.
+Improve REST API error handling by providing specific error messages for trashed events and ensuring invalid or non-existent event ID parameters in archive endpoints return proper 400 errors. [TEC-5737]

--- a/changelog/fix-rest-api-validation
+++ b/changelog/fix-rest-api-validation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Improve REST API error handling by providing specific error messages for trashed events and ensuring invalid or non-existent event ID parameters in archive endpoints return proper 400 errors. [TEC-5737]
+Improve REST API error handling by providing specific error messages for trashed events and ensuring invalid or non-existent event ID parameters in archive endpoints return proper 400 errors.

--- a/src/Tribe/REST/V1/Endpoints/Archive_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Base.php
@@ -44,6 +44,45 @@ abstract class Tribe__Events__REST__V1__Endpoints__Archive_Base
 	}
 
 	/**
+	 * Validates that an event ID parameter is a valid, existing event.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed  $value      The parameter value to validate.
+	 * @param string $param_name The parameter name, used in error messages.
+	 *
+	 * @return true|WP_Error True if valid, or WP_Error on failure.
+	 */
+	protected function validate_event_id_param( $value, $param_name ) {
+		if ( ! $this->validator->is_event_id_format( $value ) ) {
+			return new WP_Error(
+				'rest-invalid-event-id',
+				sprintf(
+					/* translators: %s: The parameter name. */
+					__( 'The "%s" parameter must be a valid numeric event ID.', 'the-events-calendar' ),
+					$param_name
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$event = get_post( (int) $value );
+		if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+			return new WP_Error(
+				'rest-invalid-event-id',
+				sprintf(
+					/* translators: %s: The parameter name. */
+					__( 'The specified ID for the "%s" parameter is not a valid event.', 'the-events-calendar' ),
+					$param_name
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Parses the `per_page` argument from the request.
 	 *
 	 * @param int $per_page The `per_page` param provided by the request.

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -53,6 +53,8 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 	/**
 	 * Handles GET requests on the endpoint.
 	 *
+	 * @since TBD Added validation for post_parent parameter.
+	 *
 	 * @param WP_REST_Request $request
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -58,6 +58,26 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
 	public function get( WP_REST_Request $request ) {
+		// Validate post_parent parameter if provided.
+		if ( isset( $request['post_parent'] ) && null !== $request['post_parent'] ) {
+			$validation = $this->validator->is_event_id( $request['post_parent'] );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+			// Check if event exists and is correct post type.
+			if ( true === $validation ) {
+				$event = get_post( $request['post_parent'] );
+				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+					$message = $this->messages->get_message( 'rest-invalid-event-id' );
+					return new WP_Error(
+						'rest_invalid_event_id',
+						sprintf( $message, $request['post_parent'], $event ? $event->post_type : 'none' ),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
 		$args        = [];
 		$date_format = Tribe__Date_Utils::DBDATETIMEFORMAT;
 		$relative_dates = false;

--- a/src/Tribe/REST/V1/Endpoints/Archive_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Event.php
@@ -62,21 +62,9 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Event
 	public function get( WP_REST_Request $request ) {
 		// Validate post_parent parameter if provided.
 		if ( isset( $request['post_parent'] ) && null !== $request['post_parent'] ) {
-			$validation = $this->validator->is_event_id( $request['post_parent'] );
+			$validation = $this->validate_event_id_param( $request['post_parent'], 'post_parent' );
 			if ( is_wp_error( $validation ) ) {
 				return $validation;
-			}
-			// Check if event exists and is correct post type.
-			if ( true === $validation ) {
-				$event = get_post( $request['post_parent'] );
-				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
-					$message = $this->messages->get_message( 'rest-invalid-event-id' );
-					return new WP_Error(
-						'rest_invalid_event_id',
-						sprintf( $message, $request['post_parent'], $event ? $event->post_type : 'none' ),
-						[ 'status' => 400 ]
-					);
-				}
 			}
 		}
 

--- a/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
@@ -85,6 +85,26 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	 * @since 4.6
 	 */
 	public function get( WP_REST_Request $request ) {
+		// Validate event parameter if provided.
+		if ( isset( $request['event'] ) && null !== $request['event'] ) {
+			$validation = $this->validator->is_event_id( $request['event'] );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+			// Check if event exists and is correct post type.
+			if ( true === $validation ) {
+				$event = get_post( $request['event'] );
+				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+					$message = $this->messages->get_message( 'rest-invalid-event-id' );
+					return new WP_Error(
+						'rest_invalid_event_id',
+						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
 		$args = [
 			'posts_per_page' => $request['per_page'],
 			'paged'          => $request['page'],

--- a/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
@@ -83,6 +83,7 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 *
 	 * @since 4.6
+	 * @since TBD Added validation for event parameter.
 	 */
 	public function get( WP_REST_Request $request ) {
 		// Validate event parameter if provided.

--- a/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Organizer.php
@@ -88,21 +88,9 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Organizer
 	public function get( WP_REST_Request $request ) {
 		// Validate event parameter if provided.
 		if ( isset( $request['event'] ) && null !== $request['event'] ) {
-			$validation = $this->validator->is_event_id( $request['event'] );
+			$validation = $this->validate_event_id_param( $request['event'], 'event' );
 			if ( is_wp_error( $validation ) ) {
 				return $validation;
-			}
-			// Check if event exists and is correct post type.
-			if ( true === $validation ) {
-				$event = get_post( $request['event'] );
-				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
-					$message = $this->messages->get_message( 'rest-invalid-event-id' );
-					return new WP_Error(
-						'rest_invalid_event_id',
-						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
-						[ 'status' => 400 ]
-					);
-				}
 			}
 		}
 

--- a/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
@@ -81,6 +81,7 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Venue
 	 *
 	 * @since 4.6
 	 * @since 6.15.3 Added password protection check.
+	 * @since TBD Added validation for event parameter.
 	 */
 	public function get( WP_REST_Request $request ) {
 		// Validate event parameter if provided.

--- a/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
@@ -83,6 +83,26 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Venue
 	 * @since 6.15.3 Added password protection check.
 	 */
 	public function get( WP_REST_Request $request ) {
+		// Validate event parameter if provided.
+		if ( isset( $request['event'] ) && null !== $request['event'] ) {
+			$validation = $this->validator->is_event_id( $request['event'] );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+			// Check if event exists and is correct post type.
+			if ( true === $validation ) {
+				$event = get_post( $request['event'] );
+				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+					$message = $this->messages->get_message( 'rest-invalid-event-id' );
+					return new WP_Error(
+						'rest_invalid_event_id',
+						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
 		$args = array(
 			'posts_per_page' => $request['per_page'],
 			'paged'          => $request['page'],

--- a/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
+++ b/src/Tribe/REST/V1/Endpoints/Archive_Venue.php
@@ -86,21 +86,9 @@ class Tribe__Events__REST__V1__Endpoints__Archive_Venue
 	public function get( WP_REST_Request $request ) {
 		// Validate event parameter if provided.
 		if ( isset( $request['event'] ) && null !== $request['event'] ) {
-			$validation = $this->validator->is_event_id( $request['event'] );
+			$validation = $this->validate_event_id_param( $request['event'], 'event' );
 			if ( is_wp_error( $validation ) ) {
 				return $validation;
-			}
-			// Check if event exists and is correct post type.
-			if ( true === $validation ) {
-				$event = get_post( $request['event'] );
-				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
-					$message = $this->messages->get_message( 'rest-invalid-event-id' );
-					return new WP_Error(
-						'rest_invalid_event_id',
-						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
-						[ 'status' => 400 ]
-					);
-				}
 			}
 		}
 

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -109,9 +109,9 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	protected function validate_event_accessible( $event, WP_REST_Request $request ) {
 		// Check if the event is trashed and return a specific message.
 		if ( 'trash' === $event->post_status ) {
-			$message = $this->messages->get_message( 'event-no-longer-available' );
+			$message = $this->messages->get_message( 'event-is-trashed' );
 			return new WP_Error(
-				'event-no-longer-available',
+				'event-is-trashed',
 				$message,
 				[ 'status' => 403 ]
 			);

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -101,7 +101,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since TBD
 	 *
-	 * @param WP_Post          $event   The event post object.
+	 * @param WP_Post         $event   The event post object.
 	 * @param WP_REST_Request $request The REST request object.
 	 *
 	 * @return true|WP_Error True if accessible, or WP_Error on failure.
@@ -138,7 +138,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since TBD
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The REST request object.
 	 *
 	 * @return WP_REST_Response|WP_Error An array containing the data on success or a WP_Error instance on failure.
 	 */

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -572,19 +572,23 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since 4.6
 	 * @since 6.15.16.1 Add more logic to check if the user can delete the event.
+	 * @since TBD Add fallback to general capability when the post doesn't exist.
 	 *
 	 * @param $request WP_REST_Request The request object.
 	 *
 	 * @return bool
 	 */
 	public function can_delete( ?WP_REST_Request $request = null ) {
-		$id = $request['id'] ?? null;
+		$cap = get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap;
+		$id  = $request['id'] ?? null;
 
-		if ( ! $id ) {
-			return current_user_can( get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->delete_posts );
+		// Fall back to the general capability when the post doesn't exist so the
+		// request reaches the handler, which returns a proper 404.
+		if ( ! $id || ! get_post( $id ) ) {
+			return current_user_can( $cap->delete_posts );
 		}
 
-		return current_user_can( get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->delete_post, $id );
+		return current_user_can( $cap->delete_post, $id );
 	}
 
 	/**
@@ -652,19 +656,23 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since 4.6
 	 * @since 6.15.16.1 Add more logic to check if the user can edit the event.
+	 * @since TBD Add fallback to general capability when the post doesn't exist.
 	 *
 	 * @param $request WP_REST_Request The request object.
 	 *
 	 * @return bool Whether the current user can update or not.
 	 */
 	public function can_edit( ?WP_REST_Request $request = null ) {
-		$id = $request['id'] ?? null;
+		$cap = get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap;
+		$id  = $request['id'] ?? null;
 
-		if ( ! $id ) {
-			return current_user_can( get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->edit_posts );
+		// Fall back to the general capability when the post doesn't exist so the
+		// request reaches the handler, which returns a proper 404.
+		if ( ! $id || ! get_post( $id ) ) {
+			return current_user_can( $cap->edit_posts );
 		}
 
-		return current_user_can( get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->edit_post, $id );
+		return current_user_can( $cap->edit_post, $id );
 	}
 
 	/**

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -62,17 +62,63 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	}
 
 	/**
-	 * @param WP_REST_Request $request
+	 * Validates that an event exists and is the correct post type.
 	 *
-	 * @return WP_REST_Response|WP_Error An array containing the data on success or a WP_Error instance on failure.
+	 * @since TBD
+	 *
+	 * @param int $event_id The event ID to validate.
+	 *
+	 * @return WP_Post|WP_Error The event post object on success, or WP_Error on failure.
 	 */
-	public function get( WP_REST_Request $request ) {
-		$this->serving = $request;
+	protected function validate_event_exists( $event_id ) {
+		$event = get_post( $event_id );
 
-		$event = get_post( $request['id'] );
+		// Check if the post exists.
+		if ( empty( $event ) ) {
+			$message = $this->messages->get_message( 'rest-event-not-found' );
+			return new WP_Error(
+				'rest_event_not_found',
+				sprintf( $message, $event_id ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// Check if the post is the correct post type.
+		if ( Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+			$message = $this->messages->get_message( 'rest-invalid-event-id' );
+			return new WP_Error(
+				'rest_invalid_event_id',
+				sprintf( $message, $event_id, $event->post_type ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return $event;
+	}
+
+	/**
+	 * Validates that an event is accessible for reading.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post          $event   The event post object.
+	 * @param WP_REST_Request $request The REST request object.
+	 *
+	 * @return true|WP_Error True if accessible, or WP_Error on failure.
+	 */
+	protected function validate_event_accessible( $event, WP_REST_Request $request ) {
+		// Check if the event is trashed and return a specific message.
+		if ( 'trash' === $event->post_status ) {
+			$message = $this->messages->get_message( 'event-no-longer-available' );
+			return new WP_Error(
+				'event-no-longer-available',
+				$message,
+				[ 'status' => 403 ]
+			);
+		}
 
 		$cap = get_post_type_object( Tribe__Events__Main::POSTTYPE )->cap->read_post;
-		if ( ! ( 'publish' === $event->post_status || current_user_can( $cap, $request['id'] ) ) ) {
+		if ( ! ( 'publish' === $event->post_status || current_user_can( $cap, $event->ID ) ) ) {
 			$message = $this->messages->get_message( 'event-not-accessible' );
 
 			return new WP_Error( 'event-not-accessible', $message, [ 'status' => 403 ] );
@@ -84,7 +130,36 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 			return new WP_Error( 'event-password-protected', $message, [ 'status' => 403 ] );
 		}
 
-		$data = $this->post_repository->get_event_data( $request['id'], 'single' );
+		return true;
+	}
+
+	/**
+	 * GET request via API.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_REST_Response|WP_Error An array containing the data on success or a WP_Error instance on failure.
+	 */
+	public function get( WP_REST_Request $request ) {
+		$this->serving = $request;
+
+		$event_id = $request['id'];
+
+		// Validate event exists and is correct post type.
+		$event = $this->validate_event_exists( $event_id );
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		// Validate event is accessible.
+		$accessible = $this->validate_event_accessible( $event, $request );
+		if ( is_wp_error( $accessible ) ) {
+			return $accessible;
+		}
+
+		$data = $this->post_repository->get_event_data( $event_id, 'single' );
 
 		/**
 		 * Filters the data that will be returned for a single event request.
@@ -454,7 +529,11 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	public function delete( WP_REST_Request $request ) {
 		$event_id = $request['id'];
 
-		$event = get_post( $event_id );
+		// Validate event exists and is correct post type.
+		$event = $this->validate_event_exists( $event_id );
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
 
 		if ( 'trash' === $event->post_status ) {
 			$message = $this->messages->get_message( 'event-is-in-trash' );
@@ -519,13 +598,21 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	public function update( WP_REST_Request $request ) {
 		$this->serving = $request;
 
+		$event_id = $request['id'];
+
+		// Validate event exists and is correct post type.
+		$event = $this->validate_event_exists( $event_id );
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
 		$postarr = $this->prepare_postarr( $request );
 
 		if ( is_wp_error( $postarr ) ) {
 			return $postarr;
 		}
 
-		$id = Tribe__Events__API::updateEvent( $request['id'], $postarr );
+		$id = Tribe__Events__API::updateEvent( $event_id, $postarr );
 
 		if ( is_wp_error( $id ) ) {
 			/** @var WP_Error $id */

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -289,7 +289,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 				'type'              => 'integer',
 				'description'       => __( 'the event post ID', 'the-events-calendar' ),
 				'required'          => true,
-				'validate_callback' => [ $this->validator, 'is_event_id' ],
+				'validate_callback' => [ $this->validator, 'is_event_id_format' ],
 			],
 			'password' => [
 				'in'                => 'path',

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -71,13 +71,13 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 * @return WP_Post|WP_Error The event post object on success, or WP_Error on failure.
 	 */
 	protected function validate_event_exists( $event_id ) {
-		$event = get_post( $event_id );
+		$event = get_post( (int) $event_id );
 
 		// Check if the post exists.
 		if ( empty( $event ) ) {
 			$message = $this->messages->get_message( 'rest-event-not-found' );
 			return new WP_Error(
-				'rest_event_not_found',
+				'rest-event-not-found',
 				sprintf( $message, $event_id ),
 				[ 'status' => 404 ]
 			);
@@ -87,8 +87,8 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 		if ( Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
 			$message = $this->messages->get_message( 'rest-invalid-event-id' );
 			return new WP_Error(
-				'rest_invalid_event_id',
-				sprintf( $message, $event_id, $event->post_type ),
+				'rest-invalid-event-id',
+				$message,
 				[ 'status' => 400 ]
 			);
 		}
@@ -572,7 +572,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since 4.6
 	 * @since 6.15.16.1 Add more logic to check if the user can delete the event.
-	 * @since TBD Add fallback to general capability when the post doesn't exist.
+	 * @since TBD Fall back to general capability for non-existent posts.
 	 *
 	 * @param $request WP_REST_Request The request object.
 	 *
@@ -584,7 +584,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 
 		// Fall back to the general capability when the post doesn't exist so the
 		// request reaches the handler, which returns a proper 404.
-		if ( ! $id || ! get_post( $id ) ) {
+		if ( ! $id || ! get_post( (int) $id ) ) {
 			return current_user_can( $cap->delete_posts );
 		}
 
@@ -656,7 +656,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	 *
 	 * @since 4.6
 	 * @since 6.15.16.1 Add more logic to check if the user can edit the event.
-	 * @since TBD Add fallback to general capability when the post doesn't exist.
+	 * @since TBD Fall back to general capability for non-existent posts.
 	 *
 	 * @param $request WP_REST_Request The request object.
 	 *
@@ -668,7 +668,7 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 
 		// Fall back to the general capability when the post doesn't exist so the
 		// request reaches the handler, which returns a proper 404.
-		if ( ! $id || ! get_post( $id ) ) {
+		if ( ! $id || ! get_post( (int) $id ) ) {
 			return current_user_can( $cap->edit_posts );
 		}
 

--- a/src/Tribe/REST/V1/Endpoints/Single_Event.php
+++ b/src/Tribe/REST/V1/Endpoints/Single_Event.php
@@ -109,9 +109,9 @@ class Tribe__Events__REST__V1__Endpoints__Single_Event
 	protected function validate_event_accessible( $event, WP_REST_Request $request ) {
 		// Check if the event is trashed and return a specific message.
 		if ( 'trash' === $event->post_status ) {
-			$message = $this->messages->get_message( 'event-is-trashed' );
+			$message = $this->messages->get_message( 'event-no-longer-available' );
 			return new WP_Error(
-				'event-is-trashed',
+				'event-no-longer-available',
 				$message,
 				[ 'status' => 403 ]
 			);

--- a/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
@@ -44,6 +44,46 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Archive_Base
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
 	public function get( WP_REST_Request $request ) {
+		// Validate post parameter if provided.
+		if ( isset( $request['post'] ) && null !== $request['post'] ) {
+			$validation = $this->validator->is_event_id( $request['post'] );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+			// Check if event exists and is correct post type.
+			if ( true === $validation ) {
+				$event = get_post( $request['post'] );
+				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+					$message = $this->messages->get_message( 'rest-invalid-event-id' );
+					return new WP_Error(
+						'rest_invalid_event_id',
+						sprintf( $message, $request['post'], $event ? $event->post_type : 'none' ),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
+		// Validate event parameter if provided (alias of post).
+		if ( isset( $request['event'] ) && null !== $request['event'] ) {
+			$validation = $this->validator->is_event_id( $request['event'] );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+			// Check if event exists and is correct post type.
+			if ( true === $validation ) {
+				$event = get_post( $request['event'] );
+				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
+					$message = $this->messages->get_message( 'rest-invalid-event-id' );
+					return new WP_Error(
+						'rest_invalid_event_id',
+						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
 		$request_params = [];
 
 		foreach ( $this->supported_query_vars as $origin => $destination ) {

--- a/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
@@ -39,6 +39,8 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Archive_Base
 	/**
 	 * Handles GET requests on the endpoint.
 	 *
+	 * @since TBD Added validation for post and event parameters.
+	 *
 	 * @param WP_REST_Request $request
 	 *
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.

--- a/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Term_Archive_Base.php
@@ -46,42 +46,12 @@ abstract class Tribe__Events__REST__V1__Endpoints__Term_Archive_Base
 	 * @return WP_Error|WP_REST_Response An array containing the data on success or a WP_Error instance on failure.
 	 */
 	public function get( WP_REST_Request $request ) {
-		// Validate post parameter if provided.
-		if ( isset( $request['post'] ) && null !== $request['post'] ) {
-			$validation = $this->validator->is_event_id( $request['post'] );
-			if ( is_wp_error( $validation ) ) {
-				return $validation;
-			}
-			// Check if event exists and is correct post type.
-			if ( true === $validation ) {
-				$event = get_post( $request['post'] );
-				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
-					$message = $this->messages->get_message( 'rest-invalid-event-id' );
-					return new WP_Error(
-						'rest_invalid_event_id',
-						sprintf( $message, $request['post'], $event ? $event->post_type : 'none' ),
-						[ 'status' => 400 ]
-					);
-				}
-			}
-		}
-
-		// Validate event parameter if provided (alias of post).
-		if ( isset( $request['event'] ) && null !== $request['event'] ) {
-			$validation = $this->validator->is_event_id( $request['event'] );
-			if ( is_wp_error( $validation ) ) {
-				return $validation;
-			}
-			// Check if event exists and is correct post type.
-			if ( true === $validation ) {
-				$event = get_post( $request['event'] );
-				if ( empty( $event ) || Tribe__Events__Main::POSTTYPE !== $event->post_type ) {
-					$message = $this->messages->get_message( 'rest-invalid-event-id' );
-					return new WP_Error(
-						'rest_invalid_event_id',
-						sprintf( $message, $request['event'], $event ? $event->post_type : 'none' ),
-						[ 'status' => 400 ]
-					);
+		// Validate post/event parameter if provided (event is an alias of post).
+		foreach ( [ 'post', 'event' ] as $param ) {
+			if ( isset( $request[ $param ] ) && null !== $request[ $param ] ) {
+				$validation = $this->validate_event_id_param( $request[ $param ], $param );
+				if ( is_wp_error( $validation ) ) {
+					return $validation;
 				}
 			}
 		}

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -121,7 +121,7 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 				'the-events-calendar'
 			),
 			/* translators: %1$d: Post ID, %2$s: Post type. */
-			'rest-invalid-event-id'             => __(
+			'rest-invalid-event-id'            => __(
 				'Post ID %1$d is not an event (post type: %2$s).',
 				'the-events-calendar'
 			),

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -129,6 +129,10 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 				'This event is no longer available',
 				'the-events-calendar'
 			),
+			'event-is-trashed'                 => __(
+				'The event is trashed',
+				'the-events-calendar'
+			),
 		];
 	}
 

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -115,6 +115,20 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 				'The requested event term archive page does not exist',
 				'the-events-calendar'
 			),
+			/* translators: %d: Event ID. */
+			'rest-event-not-found'             => __(
+				'Event with ID %d does not exist.',
+				'the-events-calendar'
+			),
+			/* translators: %1$d: Post ID, %2$s: Post type. */
+			'rest-invalid-event-id'             => __(
+				'Post ID %1$d is not an event (post type: %2$s).',
+				'the-events-calendar'
+			),
+			'event-no-longer-available'        => __(
+				'This event is no longer available',
+				'the-events-calendar'
+			),
 		];
 	}
 

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -120,13 +120,8 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 				'Event with ID %d does not exist.',
 				'the-events-calendar'
 			),
-			/* translators: %1$d: Post ID, %2$s: Post type. */
 			'rest-invalid-event-id'            => __(
-				'Post ID %1$d is not an event (post type: %2$s).',
-				'the-events-calendar'
-			),
-			'event-no-longer-available'        => __(
-				'This event is no longer available',
+				'The specified ID is not a valid event.',
 				'the-events-calendar'
 			),
 			'event-is-trashed'                 => __(

--- a/src/Tribe/REST/V1/Messages.php
+++ b/src/Tribe/REST/V1/Messages.php
@@ -124,8 +124,8 @@ class Tribe__Events__REST__V1__Messages implements Tribe__REST__Messages_Interfa
 				'The specified ID is not a valid event.',
 				'the-events-calendar'
 			),
-			'event-is-trashed'                 => __(
-				'The event is trashed',
+			'event-no-longer-available'        => __(
+				'This event is no longer available',
 				'the-events-calendar'
 			),
 		];

--- a/src/Tribe/Validator/Base.php
+++ b/src/Tribe/Validator/Base.php
@@ -78,30 +78,48 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 	/**
 	 * Whether the value is the post ID of an existing event or not.
 	 *
+	 * Note: This method validates the format and type of the ID, but does not check
+	 * if the event actually exists. Existence checks should be done in the request handler
+	 * to allow proper 404 responses instead of 400 validation errors.
+	 *
+	 * @since TBD Added WP_Error if ID is empty, or an invalid number.
 	 * @since 4.6
 	 *
 	 * @param int|string $event_id
 	 *
-	 * @return bool
+	 * @return bool|WP_Error True if valid format, false or WP_Error if invalid format.
 	 */
 	public function is_event_id( $event_id ) {
-		if ( empty( $event_id ) ) {
-			return false;
+		// Check if empty, but allow 0 as a valid numeric value.
+		if ( $event_id === null || $event_id === false || $event_id === '' ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'Event ID cannot be empty.', 'the-events-calendar' ),
+				[ 'status' => 400 ]
+			);
 		}
 
-		$event = get_post( $event_id );
+		// Only validate that it's a numeric value, not that the event exists.
+		// Existence checks are done in the request handler to allow proper 404 responses.
+		if ( ! is_numeric( $event_id ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				sprintf( __( 'Event ID must be a number, got: %s.', 'the-events-calendar' ), gettype( $event_id ) ),
+				[ 'status' => 400 ]
+			);
+		}
 
-		$is_event_id = ! empty( $event ) && Tribe__Events__Main::POSTTYPE === $event->post_type;
+		$is_event_id = true;
 
 		/**
 		 * Validator filter to define if is a valid event_id.
 		 *
-		 * @param bool $is_event_id
-		 * @param \WP_Post|array|null $event
+		 * @param bool|WP_Error $is_event_id True if valid format, false or WP_Error if invalid format.
+		 * @param int|string $event_id The event ID being validated.
 		 *
 		 * @since 4.9.4
 		 */
-		return apply_filters( 'tribe_events_validator_is_event_id', $is_event_id, $event );
+		return apply_filters( 'tribe_events_validator_is_event_id', $is_event_id, $event_id );
 	}
 
 	/**
@@ -228,7 +246,14 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 		$sep    = is_string( $sep ) ? $sep : ',';
 		$events = Tribe__Utils__Array::list_to_array( $events, $sep );
 
-		$valid = array_filter( $events, [ $this, 'is_event_id' ] );
+		$valid = array_filter(
+			$events,
+			function( $event_id ) {
+				$result = $this->is_event_id( $event_id );
+				// Return true only if the result is exactly true (not WP_Error).
+				return $result === true;
+			}
+		);
 
 		return ! empty( $events ) && count( $valid ) === count( $events );
 	}

--- a/src/Tribe/Validator/Base.php
+++ b/src/Tribe/Validator/Base.php
@@ -104,6 +104,7 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 		if ( ! is_numeric( $event_id ) ) {
 			return new WP_Error(
 				'rest_invalid_param',
+				/* translators: %s: The PHP data type of the invalid event ID value. */
 				sprintf( __( 'Event ID must be a number, got: %s.', 'the-events-calendar' ), gettype( $event_id ) ),
 				[ 'status' => 400 ]
 			);
@@ -118,6 +119,7 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 		 * @param int|string $event_id The event ID being validated.
 		 *
 		 * @since 4.9.4
+		 * @since TBD Use $event_id instead of $event.
 		 */
 		return apply_filters( 'tribe_events_validator_is_event_id', $is_event_id, $event_id );
 	}
@@ -248,7 +250,7 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 
 		$valid = array_filter(
 			$events,
-			function( $event_id ) {
+			function ( $event_id ) {
 				$result = $this->is_event_id( $event_id );
 				// Return true only if the result is exactly true (not WP_Error).
 				return $result === true;

--- a/src/Tribe/Validator/Base.php
+++ b/src/Tribe/Validator/Base.php
@@ -78,50 +78,51 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 	/**
 	 * Whether the value is the post ID of an existing event or not.
 	 *
-	 * Note: This method validates the format and type of the ID, but does not check
-	 * if the event actually exists. Existence checks should be done in the request handler
-	 * to allow proper 404 responses instead of 400 validation errors.
-	 *
-	 * @since TBD Added WP_Error if ID is empty, or an invalid number.
 	 * @since 4.6
 	 *
 	 * @param int|string $event_id
 	 *
-	 * @return bool|WP_Error True if valid format, false or WP_Error if invalid format.
+	 * @return bool
 	 */
 	public function is_event_id( $event_id ) {
-		// Check if empty, but allow 0 as a valid numeric value.
-		if ( $event_id === null || $event_id === false || $event_id === '' ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'Event ID cannot be empty.', 'the-events-calendar' ),
-				[ 'status' => 400 ]
-			);
+		if ( empty( $event_id ) ) {
+			return false;
 		}
 
-		// Only validate that it's a numeric value, not that the event exists.
-		// Existence checks are done in the request handler to allow proper 404 responses.
-		if ( ! is_numeric( $event_id ) ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				/* translators: %s: The PHP data type of the invalid event ID value. */
-				sprintf( __( 'Event ID must be a number, got: %s.', 'the-events-calendar' ), gettype( $event_id ) ),
-				[ 'status' => 400 ]
-			);
-		}
+		$event = get_post( (int) $event_id );
 
-		$is_event_id = true;
+		$is_event_id = ! empty( $event ) && Tribe__Events__Main::POSTTYPE === $event->post_type;
 
 		/**
 		 * Validator filter to define if is a valid event_id.
 		 *
-		 * @param bool|WP_Error $is_event_id True if valid format, false or WP_Error if invalid format.
-		 * @param int|string $event_id The event ID being validated.
+		 * @param bool              $is_event_id
+		 * @param \WP_Post|array|null $event
 		 *
 		 * @since 4.9.4
-		 * @since TBD Use $event_id instead of $event.
 		 */
-		return apply_filters( 'tribe_events_validator_is_event_id', $is_event_id, $event_id );
+		return apply_filters( 'tribe_events_validator_is_event_id', $is_event_id, $event );
+	}
+
+	/**
+	 * Whether the value is a valid event ID format (numeric and non-empty).
+	 *
+	 * This method only validates the format, not existence. Use this in REST
+	 * endpoint handlers where existence checks need to return proper HTTP
+	 * status codes (e.g. 404) rather than validation errors (400).
+	 *
+	 * @since TBD
+	 *
+	 * @param int|string $event_id
+	 *
+	 * @return bool True if valid format, false otherwise.
+	 */
+	public function is_event_id_format( $event_id ) {
+		if ( $event_id === null || $event_id === false || $event_id === '' ) {
+			return false;
+		}
+
+		return is_numeric( $event_id );
 	}
 
 	/**
@@ -248,14 +249,7 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 		$sep    = is_string( $sep ) ? $sep : ',';
 		$events = Tribe__Utils__Array::list_to_array( $events, $sep );
 
-		$valid = array_filter(
-			$events,
-			function ( $event_id ) {
-				$result = $this->is_event_id( $event_id );
-				// Return true only if the result is exactly true (not WP_Error).
-				return $result === true;
-			}
-		);
+		$valid = array_filter( $events, [ $this, 'is_event_id' ] );
 
 		return ! empty( $events ) && count( $valid ) === count( $events );
 	}

--- a/src/Tribe/Validator/Base.php
+++ b/src/Tribe/Validator/Base.php
@@ -113,7 +113,7 @@ class Tribe__Events__Validator__Base extends Tribe__Validator__Base
 	 *
 	 * @since TBD
 	 *
-	 * @param int|string $event_id
+	 * @param int|string $event_id A numeric event ID or string representation of a numeric event ID.
 	 *
 	 * @return bool True if valid format, false otherwise.
 	 */

--- a/src/Tribe/Validator/Interface.php
+++ b/src/Tribe/Validator/Interface.php
@@ -52,6 +52,17 @@ interface Tribe__Events__Validator__Interface extends Tribe__Validator__Interfac
 	public function is_event_id( $event_id );
 
 	/**
+	 * Whether the value is a valid event ID format (numeric and non-empty).
+	 *
+	 * @since TBD
+	 *
+	 * @param int|string $event_id
+	 *
+	 * @return bool
+	 */
+	public function is_event_id_format( $event_id );
+
+	/**
 	 * Whether the value is the post name of an existing event or not.
 	 *
 	 * @param string $event_slug

--- a/src/Tribe/Validator/Interface.php
+++ b/src/Tribe/Validator/Interface.php
@@ -56,7 +56,7 @@ interface Tribe__Events__Validator__Interface extends Tribe__Validator__Interfac
 	 *
 	 * @since TBD
 	 *
-	 * @param int|string $event_id
+	 * @param int|string $event_id A numeric event ID or string representation of a numeric event ID.
 	 *
 	 * @return bool
 	 */

--- a/tests/restv1/EventDeletionCest.php
+++ b/tests/restv1/EventDeletionCest.php
@@ -6,14 +6,16 @@ use Tribe__Timezones as Timezones;
 
 class EventDeletionCest extends BaseRestCest {
 	/**
-	 * It should return 400 if trying to delete event passing bad event ID
+	 * It should return 404 if trying to delete event passing non-existent event ID
 	 * @test
 	 */
 	public function it_should_return_400_if_trying_to_delete_event_passing_bad_event_id( Tester $I ) {
+		$I->generate_nonce_for_role( 'administrator' );
+
 		// pass an ID that does not exist
 		$I->sendDELETE( $this->events_url . "/23" );
 
-		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseCodeIs( 404 );
 		$I->seeResponseIsJson();
 	}
 

--- a/tests/restv1/EventDeletionCest.php
+++ b/tests/restv1/EventDeletionCest.php
@@ -9,7 +9,7 @@ class EventDeletionCest extends BaseRestCest {
 	 * It should return 404 if trying to delete event passing non-existent event ID
 	 * @test
 	 */
-	public function it_should_return_404_if_trying_to_delete_event_passing_non_existent_event_id( Tester $I ) {
+	public function it_should_return_404_if_trying_to_delete_non_existent_event_id( Tester $I ) {
 		$I->generate_nonce_for_role( 'administrator' );
 
 		// pass an ID that does not exist

--- a/tests/restv1/EventDeletionCest.php
+++ b/tests/restv1/EventDeletionCest.php
@@ -9,7 +9,7 @@ class EventDeletionCest extends BaseRestCest {
 	 * It should return 404 if trying to delete event passing non-existent event ID
 	 * @test
 	 */
-	public function it_should_return_400_if_trying_to_delete_event_passing_bad_event_id( Tester $I ) {
+	public function it_should_return_404_if_trying_to_delete_event_passing_non_existent_event_id( Tester $I ) {
 		$I->generate_nonce_for_role( 'administrator' );
 
 		// pass an ID that does not exist

--- a/tests/restv1/EventUpdateCest.php
+++ b/tests/restv1/EventUpdateCest.php
@@ -234,7 +234,7 @@ class EventUpdateCest extends BaseRestCest {
 	}
 
 	/**
-	 * It should mark bad request if id is bad
+	 * It should mark not found if id does not exist
 	 *
 	 * @test
 	 */
@@ -249,7 +249,7 @@ class EventUpdateCest extends BaseRestCest {
 
 		$I->sendPOST( $this->events_url . '/2389', $params );
 
-		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseCodeIs( 404 );
 	}
 
 	/**

--- a/tests/restv1/EventUpdateCest.php
+++ b/tests/restv1/EventUpdateCest.php
@@ -238,7 +238,7 @@ class EventUpdateCest extends BaseRestCest {
 	 *
 	 * @test
 	 */
-	public function it_should_mark_bad_request_if_id_is_bad( Tester $I ) {
+	public function it_should_mark_not_found_if_id_does_not_exist( Tester $I ) {
 		$I->generate_nonce_for_role( 'administrator' );
 
 		$params = [

--- a/tests/restv1/SingleEventCest.php
+++ b/tests/restv1/SingleEventCest.php
@@ -3,25 +3,25 @@
 
 class SingleEventCest extends BaseRestCest {
 	/**
-	 * It should return bad request if event ID is 0
+	 * It should return not found if event ID is 0
 	 *
 	 * @test
 	 */
 	public function it_should_return_bad_request_if_event_id_is_0(Restv1Tester $I) {
 		$I->sendGET( $this->events_url . '/0' );
 
-		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseCodeIs( 404 );
 		$I->seeResponseIsJson();
 	}
 
 	/**
 	 * @test
-	 * it should return bad request if hitting a non existing single event endpoint
+	 * it should return not found if hitting a non existing single event endpoint
 	 */
 	public function it_should_return_bad_request_if_hitting_a_non_existing_single_event_endpoint( Restv1Tester $I ) {
 		$I->sendGET( $this->events_url . '/13' );
 
-		$I->seeResponseCodeIs( 400 );
+		$I->seeResponseCodeIs( 404 );
 		$I->seeResponseIsJson();
 	}
 

--- a/tests/restv1/SingleEventCest.php
+++ b/tests/restv1/SingleEventCest.php
@@ -7,7 +7,7 @@ class SingleEventCest extends BaseRestCest {
 	 *
 	 * @test
 	 */
-	public function it_should_return_bad_request_if_event_id_is_0(Restv1Tester $I) {
+	public function it_should_return_not_found_if_event_id_is_0(Restv1Tester $I) {
 		$I->sendGET( $this->events_url . '/0' );
 
 		$I->seeResponseCodeIs( 404 );
@@ -18,7 +18,7 @@ class SingleEventCest extends BaseRestCest {
 	 * @test
 	 * it should return not found if hitting a non existing single event endpoint
 	 */
-	public function it_should_return_bad_request_if_hitting_a_non_existing_single_event_endpoint( Restv1Tester $I ) {
+	public function it_should_return_not_found_if_hitting_a_non_existing_single_event_endpoint( Restv1Tester $I ) {
 		$I->sendGET( $this->events_url . '/13' );
 
 		$I->seeResponseCodeIs( 404 );

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
@@ -90,6 +90,134 @@ class Single_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 
 	/**
 	 * @test
+	 * it should return 404 for permanently deleted event
+	 */
+	public function it_should_return_404_for_permanently_deleted_event() {
+		$event_id = $this->factory()->event->create();
+		wp_delete_post( $event_id, true ); // Permanently delete.
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'rest_event_not_found', $response->get_error_code() );
+		$this->assertStringContainsString( 'does not exist', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 404, $error_data['status'] );
+	}
+
+	/**
+	 * @test
+	 * it should return 403 with specific message for trashed event
+	 */
+	public function it_should_return_403_with_specific_message_for_trashed_event() {
+		$event_id = $this->factory()->event->create();
+		wp_trash_post( $event_id );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'event-no-longer-available', $response->get_error_code() );
+		$this->assertSame( 'This event is no longer available', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 403, $error_data['status'] );
+	}
+
+	/**
+	 * @test
+	 * it should return 403 with event-not-accessible for draft event
+	 */
+	public function it_should_return_403_with_event_not_accessible_for_draft_event() {
+		$event_id = $this->factory()->event->create( [ 'post_status' => 'draft' ] );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'event-not-accessible', $response->get_error_code() );
+		$this->assertSame( 'The requested event is not accessible', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 403, $error_data['status'] );
+	}
+
+	/**
+	 * @test
+	 * it should return 403 with event-not-accessible for pending review event
+	 */
+	public function it_should_return_403_with_event_not_accessible_for_pending_review_event() {
+		$event_id = $this->factory()->event->create( [ 'post_status' => 'pending' ] );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'event-not-accessible', $response->get_error_code() );
+		$this->assertSame( 'The requested event is not accessible', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 403, $error_data['status'] );
+	}
+
+	/**
+	 * @test
+	 * it should return 403 with event-password-protected for password protected event
+	 */
+	public function it_should_return_403_with_event_password_protected_for_password_protected_event() {
+		$event_id = $this->factory()->event->create( [ 'post_password' => 'test-password' ] );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'event-password-protected', $response->get_error_code() );
+		$this->assertSame( 'The requested event is not accessible without a password', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 403, $error_data['status'] );
+	}
+
+	/**
+	 * @test
+	 * it should return 403 with event-not-accessible for private event
+	 */
+	public function it_should_return_403_with_event_not_accessible_for_private_event() {
+		$event_id = $this->factory()->event->create( [ 'post_status' => 'private' ] );
+
+		$request = new \WP_REST_Request( 'GET', '' );
+		$request->set_param( 'id', $event_id );
+
+		$sut = $this->make_instance();
+		$response = $sut->get( $request );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'event-not-accessible', $response->get_error_code() );
+		$this->assertSame( 'The requested event is not accessible', $response->get_error_message() );
+		$error_data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $error_data );
+		$this->assertSame( 403, $error_data['status'] );
+	}
+
+	/**
+	 * @test
 	 * it should return event data if event accessible
 	 */
 	public function it_should_return_event_data_if_event_accessible() {

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
@@ -125,8 +125,8 @@ class Single_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 		$response = $sut->get( $request );
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'event-no-longer-available', $response->get_error_code() );
-		$this->assertSame( 'This event is no longer available', $response->get_error_message() );
+		$this->assertSame( 'event-is-trashed', $response->get_error_code() );
+		$this->assertSame( 'The event is trashed', $response->get_error_message() );
 		$error_data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $error_data );
 		$this->assertSame( 403, $error_data['status'] );

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
@@ -103,7 +103,7 @@ class Single_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 		$response = $sut->get( $request );
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'rest_event_not_found', $response->get_error_code() );
+		$this->assertSame( 'rest-event-not-found', $response->get_error_code() );
 		$this->assertStringContainsString( 'does not exist', $response->get_error_message() );
 		$error_data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $error_data );

--- a/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
+++ b/tests/wpunit/Tribe/Events/REST/V1/Endpoints/Single_EventTest.php
@@ -125,8 +125,8 @@ class Single_EventTest extends \Codeception\TestCase\WPRestApiTestCase {
 		$response = $sut->get( $request );
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'event-is-trashed', $response->get_error_code() );
-		$this->assertSame( 'The event is trashed', $response->get_error_message() );
+		$this->assertSame( 'event-no-longer-available', $response->get_error_code() );
+		$this->assertSame( 'This event is no longer available', $response->get_error_message() );
 		$error_data = $response->get_error_data();
 		$this->assertArrayHasKey( 'status', $error_data );
 		$this->assertSame( 403, $error_data['status'] );

--- a/tests/wpunit/Tribe/Events/Validator/BaseTest.php
+++ b/tests/wpunit/Tribe/Events/Validator/BaseTest.php
@@ -270,12 +270,14 @@ class BaseTest extends \Codeception\TestCase\WPTestCase {
 			[ false ],
 			[ 'foo' ],
 			[ "{PHP_INT_MAX}" ],
-			// Note: PHP_INT_MAX, 0, and '0' are now valid (numeric format check only).
+			[ PHP_INT_MAX ],
+			[ 0 ],
+			[ '0' ],
 		];
 	}
 
 	/**
-	 * Test is_event_id with bad inputs (non-numeric values)
+	 * Test is_event_id with bad inputs
 	 *
 	 * @test
 	 * @dataProvider post_id_bad_inputs
@@ -283,27 +285,7 @@ class BaseTest extends \Codeception\TestCase\WPTestCase {
 	public function test_is_event_id_with_bad_inputs( $input ) {
 		$sut = $this->make_instance();
 
-		$result = $sut->is_event_id( $input );
-		// Should return WP_Error for invalid format inputs, not true.
-		$this->assertNotTrue( $result );
-		if ( is_wp_error( $result ) ) {
-			$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
-		}
-	}
-
-	/**
-	 * Test is_event_id accepts numeric values (format validation only)
-	 *
-	 * @test
-	 */
-	public function test_is_event_id_accepts_numeric_values() {
-		$sut = $this->make_instance();
-
-		// Numeric values should return true (format validation only, not existence).
-		$this->assertTrue( $sut->is_event_id( PHP_INT_MAX ) );
-		$this->assertTrue( $sut->is_event_id( 0 ) );
-		$this->assertTrue( $sut->is_event_id( '0' ) );
-		$this->assertTrue( $sut->is_event_id( 999999 ) );
+		$this->assertFalse( $sut->is_event_id( $input ) );
 	}
 
 	/**
@@ -321,35 +303,34 @@ class BaseTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * Test is_event_id validates format only (not existence)
+	 * Test is_event_id_format with valid numeric values
 	 *
 	 * @test
 	 */
-	public function test_is_event_id_validates_format_only() {
+	public function test_is_event_id_format_accepts_numeric_values() {
 		$sut = $this->make_instance();
 
-		// Should return true for any numeric value, even if event doesn't exist.
-		$non_existent_id = 999999;
-		$result = $sut->is_event_id( $non_existent_id );
-
-		$this->assertTrue( $result );
+		$this->assertTrue( $sut->is_event_id_format( 123 ) );
+		$this->assertTrue( $sut->is_event_id_format( '123' ) );
+		$this->assertTrue( $sut->is_event_id_format( 0 ) );
+		$this->assertTrue( $sut->is_event_id_format( '0' ) );
+		$this->assertTrue( $sut->is_event_id_format( PHP_INT_MAX ) );
+		$this->assertTrue( $sut->is_event_id_format( 999999 ) );
 	}
 
 	/**
-	 * Test is_event_id returns WP_Error for non-numeric values
+	 * Test is_event_id_format with invalid values
 	 *
 	 * @test
 	 */
-	public function test_is_event_id_returns_wp_error_for_non_numeric() {
+	public function test_is_event_id_format_rejects_invalid_values() {
 		$sut = $this->make_instance();
 
-		$result = $sut->is_event_id( 'not-a-number' );
-
-		$this->assertWPError( $result );
-		$this->assertSame( 'rest_invalid_param', $result->get_error_code() );
-		$this->assertStringContainsString( 'must be a number', $result->get_error_message() );
-		$this->assertArrayHasKey( 'status', $result->get_error_data() );
-		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertFalse( $sut->is_event_id_format( null ) );
+		$this->assertFalse( $sut->is_event_id_format( false ) );
+		$this->assertFalse( $sut->is_event_id_format( '' ) );
+		$this->assertFalse( $sut->is_event_id_format( 'foo' ) );
+		$this->assertFalse( $sut->is_event_id_format( 'not-a-number' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes [SMTNC-249](https://linear.app/nexcess/issue/SMTNC-249/rest-api-giving-wrong-responses): the REST API single-event endpoint currently returns a generic `rest_invalid_param` / 400 for deleted, trashed, draft, pending, private, and password-protected events, which breaks Promoter's error handling and causes unwarranted soft-blocking.

This is a rebase of the previously-approved, unmerged work from #5540 / #5608 (originally targeting release branches that have since shipped), plus two small follow-ups:
- The trashed-event error now uses `event-no-longer-available` / "This event is no longer available" to match the SMTNC-249 spec exactly (the original branches used `event-is-trashed`).
- Changelog entry no longer references a specific ticket number, per current changelog procedure.

`GET /events/{id}` now returns:
- 404 `rest-event-not-found` for permanently deleted/non-existent events
- 403 `event-no-longer-available` for trashed events
- 403 `event-not-accessible` for draft/pending/private events (unchanged)
- 403 `event-password-protected` for password-protected events (unchanged)

Archive endpoints (`Archive_Event`, `Archive_Organizer`, `Archive_Venue`, `Term_Archive_Base`) now validate event ID params and return proper 400s for malformed/non-existent IDs instead of surfacing errors downstream.

`is_event_id()` behavior and the public `tribe_events_validator_is_event_id` filter signature are unchanged (no breaking change); a new `is_event_id_format()` method handles format-only validation for the REST `id` param's `validate_callback`.

## Artifact
https://www.loom.com/share/94716b0f53e544bda7a1d5cf803223d0
