### PR TITLE
[SMTNC-1797] fix: _load_textdomain_just_in_time notice bug

### DIFF
--- a/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
+++ b/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the _load_textdomain_just_in_time notice was triggered because the cron schedule label was translated before the init hook fired.

--- a/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
+++ b/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved an issue where the `_load_textdomain_just_in_time` notice could be triggered on the site.
+Resolved an issue where the `_load_textdomain_just_in_time` notice could be triggered on the site by deferring registration of the Event Aggregator `cron_schedules` filter until the `init` hook fires.

--- a/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
+++ b/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved an issue where the _load_textdomain_just_in_time notice was triggered because the cron schedule label was translated before the init hook fired.
+Resolved an issue where the `_load_textdomain_just_in_time` notice could be triggered on the site.

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -206,10 +206,14 @@ class Tribe__Events__Aggregator__Cron {
 		// Ensure schedules is an array.
 		$schedules = is_array( $schedules ) ? $schedules : [];
 
+		$display = ( did_action( 'init' ) || doing_action( 'init' ) )
+			? esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' )
+			: 'Every 15 minutes'; // fallback, avoids translating before init
+
 		// Adds the Min frequency to WordPress cron schedules
 		$schedules['tribe-every15mins'] = [
 			'interval' => MINUTE_IN_SECONDS * 15,
-			'display'  => esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
+			'display'  => $display,
 		];
 
 		return $schedules;

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -60,8 +60,11 @@ class Tribe__Events__Aggregator__Cron {
 		// Register the base cron schedule
 		add_action( 'init', [ $this, 'action_register_cron' ] );
 
-		// Register the Required Cron Schedules
-		add_filter( 'cron_schedules', [ $this, 'filter_add_cron_schedules' ] );
+		// Register the Required Cron Schedules, but never before `init` (this filter fires on
+		// any wp_schedule_event()/wp_get_schedules() call, including from unrelated plugins
+		// bootstrapping on `plugins_loaded`, which would otherwise force esc_html_x() to run
+		// too early and trigger a "translation loaded too early" notice).
+		tribe_run_on_action( 'init', [ $this, 'register_cron_schedules_filter' ], 0 );
 
 		// Check for imports on cron action
 		add_action( self::$action, [ $this, 'run' ] );
@@ -194,6 +197,18 @@ class Tribe__Events__Aggregator__Cron {
 	}
 
 	/**
+	 * Registers the cron_schedules filter. Deferred until `init` via `tribe_run_on_action()`
+	 * in the constructor, so this never fires (and never translates its label) too early.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_cron_schedules_filter() {
+		add_filter( 'cron_schedules', [ $this, 'filter_add_cron_schedules' ] );
+	}
+
+	/**
 	 * Adds the Frequency to WP cron schedules
 	 * Instead of having cron be scheduled to specific times, we will check every 30 minutes
 	 * to make sure we can insert without having to expire cache.
@@ -206,14 +221,10 @@ class Tribe__Events__Aggregator__Cron {
 		// Ensure schedules is an array.
 		$schedules = is_array( $schedules ) ? $schedules : [];
 
-		$display = ( did_action( 'init' ) || doing_action( 'init' ) )
-			? esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' )
-			: 'Every 15 minutes'; // fallback, avoids translating before init.
-
-		// Adds the Min frequency to WordPress cron schedules
+		// Adds the Min frequency to WordPress cron schedules.
 		$schedules['tribe-every15mins'] = [
 			'interval' => MINUTE_IN_SECONDS * 15,
-			'display'  => $display,
+			'display'  => esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
 		];
 
 		return $schedules;

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -208,7 +208,7 @@ class Tribe__Events__Aggregator__Cron {
 
 		$display = ( did_action( 'init' ) || doing_action( 'init' ) )
 			? esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' )
-			: 'Every 15 minutes'; // fallback, avoids translating before init
+			: 'Every 15 minutes'; // fallback, avoids translating before init.
 
 		// Adds the Min frequency to WordPress cron schedules
 		$schedules['tribe-every15mins'] = [

--- a/src/Tribe/Aggregator/Cron.php
+++ b/src/Tribe/Aggregator/Cron.php
@@ -60,11 +60,11 @@ class Tribe__Events__Aggregator__Cron {
 		// Register the base cron schedule
 		add_action( 'init', [ $this, 'action_register_cron' ] );
 
-		// Register the Required Cron Schedules, but never before `init` (this filter fires on
-		// any wp_schedule_event()/wp_get_schedules() call, including from unrelated plugins
+		// Register the Required Cron Schedules on `init`, not here: this filter fires on any
+		// wp_schedule_event()/wp_get_schedules() call, including from unrelated plugins
 		// bootstrapping on `plugins_loaded`, which would otherwise force esc_html_x() to run
-		// too early and trigger a "translation loaded too early" notice).
-		tribe_run_on_action( 'init', [ $this, 'register_cron_schedules_filter' ], 0 );
+		// too early and trigger a "translation loaded too early" notice.
+		add_action( 'init', [ $this, 'register_cron_schedules_filter' ], 0 );
 
 		// Check for imports on cron action
 		add_action( self::$action, [ $this, 'run' ] );
@@ -197,8 +197,8 @@ class Tribe__Events__Aggregator__Cron {
 	}
 
 	/**
-	 * Registers the cron_schedules filter. Deferred until `init` via `tribe_run_on_action()`
-	 * in the constructor, so this never fires (and never translates its label) too early.
+	 * Registers the cron_schedules filter. Hooked to `init` from the constructor, instead of
+	 * registered directly, so this never fires (and never translates its label) too early.
 	 *
 	 * @since TBD
 	 *

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -622,6 +622,11 @@ class CronTest extends Aggregator_TestCase {
 			'The cron_schedules filter should not be registered before init has fired.'
 		);
 
+		$this->assertNotFalse(
+			has_action( 'init', [ $cron, 'register_cron_schedules_filter' ] ),
+			'register_cron_schedules_filter must be hooked to init.'
+		);
+
 		// Simulate `init` firing for this hook, without triggering the global `init` action.
 		$cron->register_cron_schedules_filter();
 

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -604,6 +604,13 @@ class CronTest extends Aggregator_TestCase {
 	 * (and therefore the global `cron_schedules` filter) during its own early `plugins_loaded`
 	 * bootstrap never invokes our callback, and never triggers a premature translation call.
 	 *
+	 * Note: this does not fire `do_action( 'init' )` directly. By the time wp-browser boots the
+	 * test suite, WordPress has already fired `init` for real, so re-firing it globally here
+	 * would re-run every other callback hooked to `init` in the process (WP core, other TEC
+	 * bootstrapping, etc.), potentially multiple times. Instead, it invokes the specific
+	 * callback the constructor hooked to `init`, which is what firing `init` would trigger for
+	 * this class.
+	 *
 	 * @see https://github.com/the-events-calendar/the-events-calendar/pull/5701
 	 * @test
 	 */
@@ -615,7 +622,8 @@ class CronTest extends Aggregator_TestCase {
 			'The cron_schedules filter should not be registered before init has fired.'
 		);
 
-		do_action( 'init' );
+		// Simulate `init` firing for this hook, without triggering the global `init` action.
+		$cron->register_cron_schedules_filter();
 
 		$this->assertNotFalse(
 			has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] ),
@@ -628,21 +636,32 @@ class CronTest extends Aggregator_TestCase {
 	 * `tribe-every15mins` schedule already exists by the time `action_register_cron` (also
 	 * hooked to `init`, at the default priority) tries to use it.
 	 *
+	 * Note: rather than firing `do_action( 'init' )` (which would re-run every other `init`
+	 * callback registered in the process), this compares the registered hook priorities
+	 * directly. `has_action()` returns the priority a callback is hooked at (or `false` if it
+	 * isn't hooked), which is enough to prove the ordering guarantee without executing anything.
+	 *
 	 * @test
 	 */
 	public function should_register_cron_schedules_filter_before_action_register_cron_runs_on_init() {
 		$cron = $this->make_real_instance();
 
-		$filter_registered_by_priority_5 = null;
-		add_action( 'init', function () use ( $cron, &$filter_registered_by_priority_5 ) {
-			$filter_registered_by_priority_5 = (bool) has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] );
-		}, 5 );
+		$register_cron_schedules_filter_priority = has_action( 'init', [ $cron, 'register_cron_schedules_filter' ] );
+		$action_register_cron_priority           = has_action( 'init', [ $cron, 'action_register_cron' ] );
 
-		do_action( 'init' );
+		$this->assertNotFalse(
+			$register_cron_schedules_filter_priority,
+			'register_cron_schedules_filter should be hooked to init.'
+		);
+		$this->assertNotFalse(
+			$action_register_cron_priority,
+			'action_register_cron should be hooked to init.'
+		);
 
-		$this->assertTrue(
-			$filter_registered_by_priority_5,
-			'The cron_schedules filter should already be registered by init priority 5, before action_register_cron runs at the default priority 10.'
+		$this->assertLessThan(
+			$action_register_cron_priority,
+			$register_cron_schedules_filter_priority,
+			'The cron_schedules filter should be registered at an earlier init priority than action_register_cron runs at.'
 		);
 	}
 

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -7,14 +7,12 @@ use Tribe\Events\Test\Traits\Aggregator\AggregatorMaker;
 use Tribe\Events\Test\Traits\Aggregator\RecordMaker;
 use Prophecy\Argument;
 use Tribe\Events\Test\Factories\Aggregator\V1\Service;
-use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Events__Aggregator__Cron as Cron;
 use Tribe__Events__Aggregator__Records as Records;
 
 class CronTest extends Aggregator_TestCase {
 	use RecordMaker;
 	use AggregatorMaker;
-	use With_Uopz;
 
 	/**
 	 * @test
@@ -610,14 +608,7 @@ class CronTest extends Aggregator_TestCase {
 	 * @test
 	 */
 	public function should_defer_cron_schedules_filter_registration_until_init() {
-		// Simulate `init` not having fired (and not currently firing) yet.
-		$unset_did_action   = $this->set_fn_return( 'did_action', 0 );
-		$unset_doing_action = $this->set_fn_return( 'doing_action', false );
-
 		$cron = $this->make_real_instance();
-
-		$unset_did_action();
-		$unset_doing_action();
 
 		$this->assertFalse(
 			has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] ),
@@ -640,13 +631,7 @@ class CronTest extends Aggregator_TestCase {
 	 * @test
 	 */
 	public function should_register_cron_schedules_filter_before_action_register_cron_runs_on_init() {
-		$unset_did_action   = $this->set_fn_return( 'did_action', 0 );
-		$unset_doing_action = $this->set_fn_return( 'doing_action', false );
-
 		$cron = $this->make_real_instance();
-
-		$unset_did_action();
-		$unset_doing_action();
 
 		$filter_registered_by_priority_5 = null;
 		add_action( 'init', function () use ( $cron, &$filter_registered_by_priority_5 ) {

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -35,6 +35,10 @@ class CronTest extends Aggregator_TestCase {
 		} );
 	}
 
+	public function _after() {
+		$this->reset_cron_singleton();
+	}
+
 	/**
 	 * @return Cron
 	 */
@@ -44,6 +48,25 @@ class CronTest extends Aggregator_TestCase {
 				// no side-effects constructor
 			}
 		};
+	}
+
+	/**
+	 * Builds a real, singleton-backed Cron instance (constructor side effects included), so
+	 * hook-registration timing can be exercised. Resets the private static instance first, since
+	 * `Cron::instance()` memoizes and TEC's own bootstrap has already constructed one for real.
+	 *
+	 * @return Cron
+	 */
+	private function make_real_instance() {
+		$this->reset_cron_singleton();
+
+		return Cron::instance();
+	}
+
+	private function reset_cron_singleton() {
+		$instance_property = ( new \ReflectionClass( Cron::class ) )->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null, null );
 	}
 
 	/**
@@ -578,36 +601,64 @@ class CronTest extends Aggregator_TestCase {
 	}
 
 	/**
-	 * It should not trigger a "translation loaded too early" notice when the cron
-	 * schedules filter runs before `init` has fired.
+	 * It should defer registering the `cron_schedules` filter until `init` fires, instead of
+	 * registering it directly in the constructor - so a plugin that triggers wp_schedule_event()
+	 * (and therefore the global `cron_schedules` filter) during its own early `plugins_loaded`
+	 * bootstrap never invokes our callback, and never triggers a premature translation call.
 	 *
 	 * @see https://github.com/the-events-calendar/the-events-calendar/pull/5701
 	 * @test
 	 */
-	public function should_not_trigger_translation_notice_when_filtering_schedules_before_init() {
+	public function should_defer_cron_schedules_filter_registration_until_init() {
 		// Simulate `init` not having fired (and not currently firing) yet.
 		$unset_did_action   = $this->set_fn_return( 'did_action', 0 );
 		$unset_doing_action = $this->set_fn_return( 'doing_action', false );
 
-		// Force the next translation lookup for our domain to go through the just-in-time loader.
-		unload_textdomain( 'the-events-calendar', true );
-
-		$notice_triggered = false;
-		add_action( 'doing_it_wrong_run', function () use ( &$notice_triggered ) {
-			$notice_triggered = true;
-		} );
-
-		$cron      = $this->make_instance();
-		$schedules = $cron->filter_add_cron_schedules( [] );
+		$cron = $this->make_real_instance();
 
 		$unset_did_action();
 		$unset_doing_action();
 
 		$this->assertFalse(
-			$notice_triggered,
-			'Filtering cron schedules before init fired should not trigger a "doing it wrong" translation notice.'
+			has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] ),
+			'The cron_schedules filter should not be registered before init has fired.'
 		);
-		$this->assertSame( 'Every 15 minutes', $schedules['tribe-every15mins']['display'] );
+
+		do_action( 'init' );
+
+		$this->assertNotFalse(
+			has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] ),
+			'The cron_schedules filter should be registered once init fires.'
+		);
+	}
+
+	/**
+	 * It should register the `cron_schedules` filter early enough on `init` that the
+	 * `tribe-every15mins` schedule already exists by the time `action_register_cron` (also
+	 * hooked to `init`, at the default priority) tries to use it.
+	 *
+	 * @test
+	 */
+	public function should_register_cron_schedules_filter_before_action_register_cron_runs_on_init() {
+		$unset_did_action   = $this->set_fn_return( 'did_action', 0 );
+		$unset_doing_action = $this->set_fn_return( 'doing_action', false );
+
+		$cron = $this->make_real_instance();
+
+		$unset_did_action();
+		$unset_doing_action();
+
+		$filter_registered_by_priority_5 = null;
+		add_action( 'init', function () use ( $cron, &$filter_registered_by_priority_5 ) {
+			$filter_registered_by_priority_5 = (bool) has_filter( 'cron_schedules', [ $cron, 'filter_add_cron_schedules' ] );
+		}, 5 );
+
+		do_action( 'init' );
+
+		$this->assertTrue(
+			$filter_registered_by_priority_5,
+			'The cron_schedules filter should already be registered by init priority 5, before action_register_cron runs at the default priority 10.'
+		);
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/CronTest.php
@@ -7,13 +7,14 @@ use Tribe\Events\Test\Traits\Aggregator\AggregatorMaker;
 use Tribe\Events\Test\Traits\Aggregator\RecordMaker;
 use Prophecy\Argument;
 use Tribe\Events\Test\Factories\Aggregator\V1\Service;
-use Tribe\Events\Virtual\Tests\Traits\With_Uopz;
+use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Events__Aggregator__Cron as Cron;
 use Tribe__Events__Aggregator__Records as Records;
 
 class CronTest extends Aggregator_TestCase {
 	use RecordMaker;
 	use AggregatorMaker;
+	use With_Uopz;
 
 	/**
 	 * @test
@@ -574,6 +575,57 @@ class CronTest extends Aggregator_TestCase {
 			'23k'         => [ 23000, 22000 ],
 			'empty value' => [ '', 100 ],
 		];
+	}
+
+	/**
+	 * It should not trigger a "translation loaded too early" notice when the cron
+	 * schedules filter runs before `init` has fired.
+	 *
+	 * @see https://github.com/the-events-calendar/the-events-calendar/pull/5701
+	 * @test
+	 */
+	public function should_not_trigger_translation_notice_when_filtering_schedules_before_init() {
+		// Simulate `init` not having fired (and not currently firing) yet.
+		$unset_did_action   = $this->set_fn_return( 'did_action', 0 );
+		$unset_doing_action = $this->set_fn_return( 'doing_action', false );
+
+		// Force the next translation lookup for our domain to go through the just-in-time loader.
+		unload_textdomain( 'the-events-calendar', true );
+
+		$notice_triggered = false;
+		add_action( 'doing_it_wrong_run', function () use ( &$notice_triggered ) {
+			$notice_triggered = true;
+		} );
+
+		$cron      = $this->make_instance();
+		$schedules = $cron->filter_add_cron_schedules( [] );
+
+		$unset_did_action();
+		$unset_doing_action();
+
+		$this->assertFalse(
+			$notice_triggered,
+			'Filtering cron schedules before init fired should not trigger a "doing it wrong" translation notice.'
+		);
+		$this->assertSame( 'Every 15 minutes', $schedules['tribe-every15mins']['display'] );
+	}
+
+	/**
+	 * It should still translate the cron schedule label once `init` has fired.
+	 *
+	 * @test
+	 */
+	public function should_translate_schedule_label_once_init_has_fired() {
+		// The WP test suite has already fired `init` by the time tests run.
+		$this->assertGreaterThan( 0, did_action( 'init' ) );
+
+		$cron      = $this->make_instance();
+		$schedules = $cron->filter_add_cron_schedules( [] );
+
+		$this->assertSame(
+			esc_html_x( 'Every 15 minutes', 'aggregator schedule frequency', 'the-events-calendar' ),
+			$schedules['tribe-every15mins']['display']
+		);
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1797](https://linear.app/nexcess/issue/SMTNC-1797/global-load-textdomain-notice-flooding-logs)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We are having a bug with `_load_textdomain_just_in_time` being triggered when some plugins are installed with TEC.
This fix address to prevent the user log to be flooded by these notice messages.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/0c3a7f49e2724b2182b52f02e0ddf404

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
