### PR TITLE
Redirect to the guided setup wizard on single-site activation

### DIFF
--- a/changelog/feat-onboarding-activation-redirect
+++ b/changelog/feat-onboarding-activation-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: feat
+
+The Events Calendar now opens the guided setup wizard automatically after a single-site activation, so a fresh install lands straight in onboarding. Bulk plugin activations are left in place on the Plugins screen.

--- a/changelog/fix-guided-setup-dismiss-redirect
+++ b/changelog/fix-guided-setup-dismiss-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stopped the guided setup redirect from firing again once the setup screen has been dismissed.

--- a/changelog/fix-guided-setup-dismiss-redirect
+++ b/changelog/fix-guided-setup-dismiss-redirect
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Stopped the guided setup redirect from firing again once the setup screen has been dismissed.
+The guided setup redirect now also respects an explicitly dismissed setup screen.

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -213,8 +213,7 @@ class Controller extends Controller_Contract {
 
 		// Do not hijack a bulk plugin activation. WordPress adds `activate-multi` to the Plugins
 		// screen URL after several plugins are activated together, so the user stays in context.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['activate-multi'] ) ) {
+		if ( null !== tec_get_request_var( 'activate-multi' ) ) {
 			return;
 		}
 

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -88,6 +88,7 @@ class Controller extends Controller_Contract {
 	 *
 	 * @since 6.8.4
 	 * @since 6.11.0 Changed the priority of `admin_menu` to reposition menu item.
+	 * @since TBD Redirect to the Guided Setup page on a fresh activation.
 	 */
 	public function add_actions(): void {
 		add_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
@@ -96,6 +97,7 @@ class Controller extends Controller_Contract {
 		add_action( 'admin_post_' . Landing_Page::DISMISS_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		add_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
 		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
+		add_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'maybe_redirect_to_guided_setup_on_activation' ] );
 	}
 
 	/**
@@ -118,6 +120,7 @@ class Controller extends Controller_Contract {
 	 *
 	 * @since 6.8.4
 	 * @since 6.11.0 Changed the priority of `admin_menu`.
+	 * @since TBD Removed the activation redirect to the Guided Setup page.
 	 */
 	public function remove_actions(): void {
 		remove_action( 'admin_menu', [ $this, 'landing_page' ], 20 );
@@ -126,6 +129,7 @@ class Controller extends Controller_Contract {
 		remove_action( 'admin_post_' . Landing_Page::DISMISS_PAGE_ACTION, [ $this, 'handle_onboarding_page_dismiss' ] );
 		remove_action( 'admin_notices', [ $this, 'remove_all_admin_notices_in_onboarding_page' ], -1 * PHP_INT_MAX );
 		remove_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'redirect_tec_pages_to_guided_setup' ] );
+		remove_action( 'tec_admin_headers_about_to_be_sent', [ $this, 'maybe_redirect_to_guided_setup_on_activation' ] );
 	}
 
 	/**
@@ -174,6 +178,48 @@ class Controller extends Controller_Contract {
 		);
 
 		if ( ! in_array( $post_type, $post_types, true ) ) {
+			return;
+		}
+
+		if ( ! $this->should_redirect_to_guided_setup() ) {
+			return;
+		}
+
+		// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit, StellarWP.CodeAnalysis.RedirectAndDie.Error
+		wp_safe_redirect( $this->get_guided_setup_url() );
+		tribe_exit();
+	}
+
+	/**
+	 * Redirects to the Guided Setup page right after the plugin is activated on its own.
+	 *
+	 * A single (non-bulk) activation of The Events Calendar sets the
+	 * `_tribe_events_activation_redirect` transient in Tribe__Events__Main::activate(). On the
+	 * next admin page load we consume that transient and send the user to the Guided Setup page,
+	 * mirroring how sister plugins greet a new install.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_to_guided_setup_on_activation(): void {
+		// Set on activation in Tribe__Events__Main::activate(). Absent means this is a normal page load.
+		if ( ! get_transient( '_tribe_events_activation_redirect' ) ) {
+			return;
+		}
+
+		// Only ever act on it once, regardless of what happens below.
+		delete_transient( '_tribe_events_activation_redirect' );
+
+		// Do not hijack a bulk plugin activation. WordPress adds `activate-multi` to the Plugins
+		// screen URL after several plugins are activated together, so the user stays in context.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['activate-multi'] ) ) {
+			return;
+		}
+
+		// Do not redirect users who cannot access the Guided Setup page.
+		if ( ! current_user_can( tribe( Landing_Page::class )->required_capability() ) ) {
 			return;
 		}
 

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -153,18 +153,6 @@ class Controller extends Controller_Contract {
 			return;
 		}
 
-		/**
-		 * Allows bypassing the checks for if we've don't need to/have already visited the Guided Setup page.
-		 * Still respects the post type checks.
-		 *
-		 * @since 6.13.0
-		 *
-		 * @param bool $force Whether to force the redirect to the Guided Setup page.
-		 *
-		 * @return bool
-		 */
-		$force = (bool) apply_filters( 'tec_events_onboarding_force_redirect_to_guided_setup', false );
-
 		// Do not redirect if the target is not The Events Calendar-related admin pages.
 		$post_type = tec_get_request_var( 'post_type' );
 
@@ -189,36 +177,76 @@ class Controller extends Controller_Contract {
 			return;
 		}
 
-		if ( ! $force ) {
-			// Do not redirect if they have been to the Guided Setup page already.
-			if ( (bool) tribe_get_option( 'tec_onboarding_wizard_visited_guided_setup', false ) ) {
-				return;
-			}
-
-			// Do not redirect if they dismissed the Guided Setup page.
-			if ( Landing_Page::is_dismissed() ) {
-				return;
-			}
-
-			// Do not redirect if they have older versions and are probably already set up.
-			$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
-			if ( count( $tec_versions ) > 1 ) {
-				return;
-			}
+		if ( ! $this->should_redirect_to_guided_setup() ) {
+			return;
 		}
 
-		// If we're still here, redirect to the Guided Setup page.
-		$setup_url = add_query_arg(
+		// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit, StellarWP.CodeAnalysis.RedirectAndDie.Error
+		wp_safe_redirect( $this->get_guided_setup_url() );
+		tribe_exit();
+	}
+
+	/**
+	 * Whether the user should be sent to the Guided Setup page.
+	 *
+	 * Shared by the on-visit redirect and the on-activation redirect so both honor the same
+	 * conditions: skip if the page was already visited or dismissed, or if this is an upgraded
+	 * install (more than one recorded version) rather than a fresh one.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the redirect should happen.
+	 */
+	protected function should_redirect_to_guided_setup(): bool {
+		/**
+		 * Allows bypassing the checks for whether we need to/have already visited the Guided Setup page.
+		 *
+		 * @since 6.13.0
+		 *
+		 * @param bool $force Whether to force the redirect to the Guided Setup page.
+		 *
+		 * @return bool
+		 */
+		$force = (bool) apply_filters( 'tec_events_onboarding_force_redirect_to_guided_setup', false );
+
+		if ( $force ) {
+			return true;
+		}
+
+		// Do not redirect if they have been to the Guided Setup page already.
+		if ( (bool) tribe_get_option( 'tec_onboarding_wizard_visited_guided_setup', false ) ) {
+			return false;
+		}
+
+		// Do not redirect if they dismissed the Guided Setup page.
+		if ( Landing_Page::is_dismissed() ) {
+			return false;
+		}
+
+		// Do not redirect if they have older versions and are probably already set up.
+		$tec_versions = (array) tribe_get_option( 'previous_ecp_versions', [] );
+		if ( count( $tec_versions ) > 1 ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds the URL of the Guided Setup page.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The Guided Setup page URL.
+	 */
+	protected function get_guided_setup_url(): string {
+		return add_query_arg(
 			[
 				'post_type' => 'tribe_events',
 				'page'      => Landing_Page::$slug,
 			],
 			admin_url( 'edit.php' )
 		);
-
-		// phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit, StellarWP.CodeAnalysis.RedirectAndDie.Error
-		wp_safe_redirect( $setup_url );
-		tribe_exit();
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -208,19 +208,25 @@ class Controller extends Controller_Contract {
 			return;
 		}
 
-		// Only ever act on it once, regardless of what happens below.
-		delete_transient( '_tribe_events_activation_redirect' );
-
 		// Do not hijack a bulk plugin activation. WordPress adds `activate-multi` to the Plugins
 		// screen URL after several plugins are activated together, so the user stays in context.
+		// Consume the flag here too: the answer is settled for this activation, and leaving it
+		// behind would redirect the user on their very next admin page load instead.
 		if ( null !== tec_get_request_var( 'activate-multi' ) ) {
+			delete_transient( '_tribe_events_activation_redirect' );
+
 			return;
 		}
 
-		// Do not redirect users who cannot access the Guided Setup page.
+		// Do not redirect users who cannot access the Guided Setup page. Leave the flag in place:
+		// it is site-wide and short-lived, so a user who can see the page should still be greeted
+		// if they are the next one to land in the admin.
 		if ( ! current_user_can( tribe( Landing_Page::class )->required_capability() ) ) {
 			return;
 		}
+
+		// From here on the activation has been handled, whether or not we end up redirecting.
+		delete_transient( '_tribe_events_activation_redirect' );
 
 		if ( ! $this->should_redirect_to_guided_setup() ) {
 			return;

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -264,8 +264,10 @@ class Controller extends Controller_Contract {
 			return false;
 		}
 
-		// Do not redirect if they dismissed the Guided Setup page.
-		if ( Landing_Page::is_dismissed() ) {
+		// Do not redirect if they dismissed the Guided Setup page. Read the option directly:
+		// the page opts out of Abstract_Admin_Page::$is_dismissible, so is_dismissed() always
+		// returns false, and dismissing should stop the redirect without hiding the menu item.
+		if ( (bool) tribe_get_option( Landing_Page::DISMISS_PAGE_OPTION, false ) ) {
 			return false;
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -2915,7 +2915,10 @@ if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 				self::clear_ct1_activation_state();
 			}
 
-			if ( ! is_network_admin() && ! isset( $_GET['activate-multi'] ) ) {
+			// Flag a single-site activation so we can redirect to the onboarding wizard on the next
+			// admin load. Bulk activations are filtered out there, where WordPress exposes the
+			// `activate-multi` flag; it is not yet set while this activation hook runs.
+			if ( ! is_network_admin() ) {
 				set_transient( '_tribe_events_activation_redirect', 1, 30 );
 			}
 		}

--- a/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
@@ -10,6 +10,7 @@ namespace TEC\Events\Admin\Onboarding;
 
 use Tribe\Tests\Traits\With_Uopz;
 use Codeception\TestCase\WPTestCase;
+use Tribe__Settings_Manager;
 
 /**
  * Class Controller_Activation_Redirect_Test
@@ -44,9 +45,16 @@ class Controller_Activation_Redirect_Test extends WPTestCase {
 		// The person doing the activation can access the Guided Setup page.
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
-		// Clean, first-run state: not visited, not an upgraded install.
+		// Prevent option state from leaking between tests. The tribe options live in both the WP
+		// object cache (read by get_option) and a tribe var; neither is rolled back with the DB, so
+		// clear both before establishing a known state.
+		wp_cache_flush();
+		tribe_unset_var( Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+
+		// Clean, first-run state: not visited, not dismissed, not an upgraded install.
 		delete_transient( self::ACTIVATION_TRANSIENT );
 		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', false );
+		tribe_update_option( Landing_Page::DISMISS_PAGE_OPTION, false );
 		tribe_update_option( 'previous_ecp_versions', [] );
 	}
 

--- a/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Tests the on-activation redirect to the Guided Setup page.
+ *
+ * @package TEC\Events\Admin\Onboarding
+ * @since   TBD
+ */
+
+namespace TEC\Events\Admin\Onboarding;
+
+use Tribe\Tests\Traits\With_Uopz;
+use Codeception\TestCase\WPTestCase;
+
+/**
+ * Class Controller_Activation_Redirect_Test
+ *
+ * @since TBD
+ */
+class Controller_Activation_Redirect_Test extends WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * The transient set by Tribe__Events__Main::activate() on a single activation.
+	 *
+	 * @var string
+	 */
+	const ACTIVATION_TRANSIENT = '_tribe_events_activation_redirect';
+
+	/**
+	 * Stored $_GET so we can restore it after each test.
+	 *
+	 * @var array
+	 */
+	protected $get_vars = [];
+
+	/**
+	 * Set up a clean, "fresh install" state before each test.
+	 *
+	 * @before
+	 */
+	public function set_up_state(): void {
+		$this->get_vars = $_GET;
+
+		// The person doing the activation can access the Guided Setup page.
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Clean, first-run state: not visited, not an upgraded install.
+		delete_transient( self::ACTIVATION_TRANSIENT );
+		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', false );
+		tribe_update_option( 'previous_ecp_versions', [] );
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @after
+	 */
+	public function tear_down_state(): void {
+		$_GET = $this->get_vars;
+		delete_transient( self::ACTIVATION_TRANSIENT );
+	}
+
+	/**
+	 * Register redirect capture and neuter the exit so the method returns.
+	 *
+	 * @param array $store Populated with every captured redirect.
+	 *
+	 * @return void
+	 */
+	protected function capture_redirects( array &$store ): void {
+		$this->set_fn_return(
+			'wp_safe_redirect',
+			function ( $url, $status = 302, $redirect_by = '' ) use ( &$store ) {
+				$store[] = $url;
+
+				return true;
+			},
+			true
+		);
+
+		$this->set_fn_return( 'tribe_exit', fn() => true, true );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_redirect_to_guided_setup_on_a_fresh_single_activation(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 1, $store, 'A fresh single activation should redirect once.' );
+		$this->assertStringContainsString( 'page=' . Landing_Page::$slug, $store[0] );
+		$this->assertFalse( get_transient( self::ACTIVATION_TRANSIENT ), 'The transient should be consumed.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_during_a_bulk_activation(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+		// WordPress adds this to the Plugins screen URL after a bulk activate.
+		$_GET['activate-multi'] = 'true';
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'A bulk activation should not redirect.' );
+		$this->assertFalse( get_transient( self::ACTIVATION_TRANSIENT ), 'The transient should still be consumed.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_without_the_activation_transient(): void {
+		// No transient set: this is a normal admin page load.
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'A normal page load should not redirect.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_when_the_guided_setup_was_already_visited(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', true );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'An already-visited setup should not redirect again.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_on_an_upgraded_install(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+		// More than one recorded version means an established install, not a fresh one.
+		tribe_update_option( 'previous_ecp_versions', [ '6.0.0', '6.1.0' ] );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'An upgraded install should not redirect.' );
+	}
+}

--- a/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
@@ -125,6 +125,25 @@ class Controller_Activation_Redirect_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_redirect_a_user_who_cannot_see_the_guided_setup(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'A user without the capability should not be redirected.' );
+		$this->assertNotFalse(
+			get_transient( self::ACTIVATION_TRANSIENT ),
+			'The transient should survive so a capable user can still be greeted.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_not_redirect_without_the_activation_transient(): void {
 		// No transient set: this is a normal admin page load.
 		$store = [];
@@ -163,6 +182,10 @@ class Controller_Activation_Redirect_Test extends WPTestCase {
 		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
 
 		$this->assertCount( 0, $store, 'A dismissed setup should not redirect.' );
+		$this->assertFalse(
+			get_transient( self::ACTIVATION_TRANSIENT ),
+			'The transient should be consumed once a capable user has been evaluated.'
+		);
 	}
 
 	/**

--- a/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Controller_Activation_Redirect_Test.php
@@ -145,6 +145,21 @@ class Controller_Activation_Redirect_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_redirect_when_the_guided_setup_was_dismissed(): void {
+		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
+		tribe_update_option( Landing_Page::DISMISS_PAGE_OPTION, true );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->maybe_redirect_to_guided_setup_on_activation();
+
+		$this->assertCount( 0, $store, 'A dismissed setup should not redirect.' );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_not_redirect_on_an_upgraded_install(): void {
 		set_transient( self::ACTIVATION_TRANSIENT, 1, 30 );
 		// More than one recorded version means an established install, not a fresh one.

--- a/tests/integration/TEC/Events/Admin/Onboarding/Controller_Guided_Setup_Redirect_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Controller_Guided_Setup_Redirect_Test.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Characterizes the on-visit redirect to the Guided Setup page.
+ *
+ * @package TEC\Events\Admin\Onboarding
+ * @since   TBD
+ */
+
+namespace TEC\Events\Admin\Onboarding;
+
+use Tribe\Tests\Traits\With_Uopz;
+use Codeception\TestCase\WPTestCase;
+use Tribe__Events__Main as TEC;
+use Tribe__Settings_Manager;
+
+/**
+ * Class Controller_Guided_Setup_Redirect_Test
+ *
+ * Locks the behavior of redirect_tec_pages_to_guided_setup() so the shared-guard
+ * refactor cannot silently change it.
+ *
+ * @since TBD
+ */
+class Controller_Guided_Setup_Redirect_Test extends WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * Stored request globals so we can restore them after each test.
+	 *
+	 * @var array
+	 */
+	protected $get_vars = [];
+
+	/**
+	 * Stored request globals so we can restore them after each test.
+	 *
+	 * @var array
+	 */
+	protected $request_vars = [];
+
+	/**
+	 * Set up a clean, "fresh install" state before each test.
+	 *
+	 * @before
+	 */
+	public function set_up_state(): void {
+		$this->get_vars     = $_GET;
+		$this->request_vars = $_REQUEST;
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		// Prevent option state from leaking between tests. The tribe options live in both the WP
+		// object cache (read by get_option) and a tribe var; neither is rolled back with the DB, so
+		// clear both before establishing a known state.
+		wp_cache_flush();
+		tribe_unset_var( Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME );
+
+		// Clean, first-run state: not visited, not dismissed, not an upgraded install.
+		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', false );
+		tribe_update_option( Landing_Page::DISMISS_PAGE_OPTION, false );
+		tribe_update_option( 'previous_ecp_versions', [] );
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @after
+	 */
+	public function tear_down_state(): void {
+		$_GET     = $this->get_vars;
+		$_REQUEST = $this->request_vars;
+		remove_all_filters( 'tec_events_onboarding_force_redirect_to_guided_setup' );
+	}
+
+	/**
+	 * Simulate the request being on the given admin page.
+	 *
+	 * @param array $vars The request vars to set.
+	 *
+	 * @return void
+	 */
+	protected function set_request( array $vars ): void {
+		foreach ( $vars as $key => $value ) {
+			$_GET[ $key ]     = $value;
+			$_REQUEST[ $key ] = $value;
+		}
+	}
+
+	/**
+	 * Register redirect capture and neuter the exit so the method returns.
+	 *
+	 * @param array $store Populated with every captured redirect.
+	 *
+	 * @return void
+	 */
+	protected function capture_redirects( array &$store ): void {
+		$this->set_fn_return(
+			'wp_safe_redirect',
+			function ( $url, $status = 302, $redirect_by = '' ) use ( &$store ) {
+				$store[] = $url;
+
+				return true;
+			},
+			true
+		);
+
+		$this->set_fn_return( 'tribe_exit', fn() => true, true );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_redirect_on_a_tec_admin_page_for_a_fresh_install(): void {
+		$this->set_request( [ 'post_type' => TEC::POSTTYPE ] );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->redirect_tec_pages_to_guided_setup();
+
+		$this->assertCount( 1, $store, 'A fresh install on a TEC page should redirect.' );
+		$this->assertStringContainsString( 'page=' . Landing_Page::$slug, $store[0] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_when_already_on_the_setup_page(): void {
+		$this->set_request(
+			[
+				'post_type' => TEC::POSTTYPE,
+				'page'      => Landing_Page::$slug,
+			]
+		);
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->redirect_tec_pages_to_guided_setup();
+
+		$this->assertCount( 0, $store, 'The setup page itself should not redirect (no loop).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_on_a_non_tec_page(): void {
+		$this->set_request( [ 'post_type' => 'page' ] );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->redirect_tec_pages_to_guided_setup();
+
+		$this->assertCount( 0, $store, 'A non-TEC admin page should not redirect.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_redirect_when_already_visited(): void {
+		$this->set_request( [ 'post_type' => TEC::POSTTYPE ] );
+		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', true );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->redirect_tec_pages_to_guided_setup();
+
+		$this->assertCount( 0, $store, 'An already-visited setup should not redirect again.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_redirect_when_forced_even_if_visited(): void {
+		$this->set_request( [ 'post_type' => TEC::POSTTYPE ] );
+		// Visited would normally block, but the force filter must bypass that check.
+		tribe_update_option( 'tec_onboarding_wizard_visited_guided_setup', true );
+		add_filter( 'tec_events_onboarding_force_redirect_to_guided_setup', '__return_true' );
+
+		$store = [];
+		$this->capture_redirects( $store );
+
+		tribe( Controller::class )->redirect_tec_pages_to_guided_setup();
+
+		$this->assertCount( 1, $store, 'The force filter should bypass the visited check.' );
+	}
+}


### PR DESCRIPTION
## Summary

When The Events Calendar is activated on its own, it now redirects to the **Guided Setup** wizard (`first-time-setup`), the way sister plugins like LearnDash behave on a new install. Bulk plugin activations are deliberately left alone.

https://www.loom.com/share/20921ceb62324738ac56bf6adc4c4a46

Previously the activation-redirect path was dead: `Tribe__Events__Main::activate()` still set the `_tribe_events_activation_redirect` transient, but its only consumer (`activation_page()` → `Tribe__Admin__Activation_Page`) was deprecated in 6.8.2 and is never called. The modern redirect only fired when a user *navigated* to a TEC admin page. This reconnects a consumer to that existing transient — no new transient, no change to the activation callback beyond removing a dead guard.

🎫 SMTNC-1826

## Behavior

| Scenario | Result |
|---|---|
| Activate TEC on its own (fresh install) | → redirect to Guided Setup |
| Bulk-activate TEC with other plugins | stays on the Plugins screen |
| Already visited / dismissed the setup screen | no redirect |
| Upgraded install (more than one recorded version) | no redirect |
| User lacks the page capability | no redirect |

### On bulk activation
The `activate-multi` guard belongs in the **consumer**, not the activation hook: WordPress only appends `activate-multi` to the Plugins-screen URL on the request *after* activation, so the flag isn't set while the activation hook runs. The consumer checks it on that next load, where it's actually present.

## What's in here (7 commits)

- **refactor:** extract `should_redirect_to_guided_setup()` + `get_guided_setup_url()` so the on-visit and on-activation paths share one guard. No behavior change.
- **feat:** `maybe_redirect_to_guided_setup_on_activation()` + hook wiring + integration tests.
- **fix:** honor a dismissed setup screen in the redirect. `Landing_Page` opts out of `Abstract_Admin_Page::$is_dismissible`, so `is_dismissed()` always returned false; the guard now reads the dismiss option directly — **without** hiding the Setup Guide menu item (deliberate: dismiss stops the redirect only).
- **tweak:** drop the no-op `activate-multi` guard from `Main::activate()` (see above).
- **test:** on-visit characterization coverage + a cross-test option-cache isolation fix (see Testing).
- **tweak:** changelog wording.
- **tweak:** read the `activate-multi` flag through `tec_get_request_var()` instead of a raw `$_GET` + `phpcs:ignore` (review feedback from @bordoni). Same presence check, one less local ignore.

## Testing

Integration suite via `slic`: **18 tests, 38 assertions — green, deterministic across runs.**

- Activation redirect: fresh single activation redirects; bulk / no-transient / already-visited / dismissed / upgraded-install do not. Bulk guard mutation-tested (breaking it fails the test).
- On-visit redirect characterized: slug gate, post-type gate, visited guard, force-filter bypass, happy path.
- **Isolation fix:** adding the on-visit test surfaced a real cross-test leak — the tribe options sit in both the WP object cache and a tribe var, neither rolled back with the DB, so `previous_ecp_versions` bled between test files (the activation suite was passing only by test ordering). Fixed with `wp_cache_flush()` + `tribe_unset_var()` in both files' setup.

## Notes / follow-ups (not in this PR)

- `Landing_Page::is_dismissed()` is inert because the page doesn't override `$is_dismissible` (defaults false) — so the base-class menu gate never treats it as dismissed. Left as-is by design here (we did not want dismiss to remove the menu item). Worth a separate decision.
- A StellarWP phpcs sniff (`StellarWP.Whitespace.DocCommentSpacing`) crashes on a pre-existing `@see` docblock in `Main.php` — unrelated, but it breaks full-file phpcs runs on that file.

Changelog entries: `feat` (activation redirect) + `fix` (dismiss).

Ref: SMTNC-1826
