### PR TITLE
[SMTNC-231] recurring events show duplicated incorrect entries when ECP is deactive

### DIFF
--- a/changelog/fix-smtnc-231-tec-recurring-events-show-duplicatedincorrect-entries-when
+++ b/changelog/fix-smtnc-231-tec-recurring-events-show-duplicatedincorrect-entries-when
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where recurring events showed duplicated entries when "The Events Calendar Pro" was deactivated.

--- a/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Custom_Tables_Query.php
@@ -128,6 +128,25 @@ class Custom_Tables_Query extends WP_Query {
 	}
 
 	/**
+	 * Determines whether an active add-on has wired up genuine support for rendering multiple
+	 * Occurrences of the same Event (e.g. each date of a recurring series) as distinct entries.
+	 *
+	 * This is determined by checking whether anything has hooked the
+	 * `tec_events_custom_tables_v1_occurrence_select_fields` filter: the extension point an add-on
+	 * must use to redirect the query `SELECT` to per-Occurrence identifiers. Declaring support
+	 * without implementing that redirection, and the post and meta hydration that depends on it,
+	 * has no functional effect: every row would still resolve back to the same Event post and the
+	 * same static post meta. This intentionally cannot be toggled by declaring support alone.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether an active add-on supports rendering multiple Occurrences of the same Event.
+	 */
+	public static function recurring_occurrences_supported(): bool {
+		return (bool) has_filter( 'tec_events_custom_tables_v1_occurrence_select_fields' );
+	}
+
+	/**
 	 * Overrides the base method to replace the Meta Query with one that will redirect
 	 * to the plugin custom tables.
 	 *
@@ -150,8 +169,9 @@ class Custom_Tables_Query extends WP_Query {
 		// While not ideal, this is the only way to intervene on `GROUP BY` in the `get_posts()` method.
 		add_filter( 'posts_groupby', [ $this, 'group_posts_by_occurrence_id' ], 10, 2 );
 		add_filter( 'posts_where', [ $this, 'filter_by_date' ], 10, 2 );
-		add_filter( 'posts_where', [ $this, 'filter_where' ], 10, 2 );
+		add_filter( 'posts_where', [ $this, 'filter_where' ], 20, 2 );
 		add_filter( 'posts_join', [ $this, 'join_occurrences_table' ], 10, 2 );
+		add_filter( 'the_posts', [ $this, 'deduplicate_posts_when_pro_inactive' ], 5, 2 );
 		// This is the last filter in the `WP_Query` class: use this as an action to clean up.
 		add_filter( 'the_posts', [ $this, 'remove_late_filters' ], 10, 2 );
 		add_filter( 'posts_orderby', [ $this, 'redirect_posts_orderby' ], 200, 2 );
@@ -323,6 +343,12 @@ class Custom_Tables_Query extends WP_Query {
 		}
 
 		remove_filter( 'posts_groupby', [ $this, 'group_posts_by_occurrence_id' ] );
+
+		if ( ! self::recurring_occurrences_supported() ) {
+			// Without an add-on able to render each Occurrence as a distinct entry, group by the
+			// Event post ID so only one row per Event is returned, instead of one row per Occurrence.
+			return $groupby;
+		}
 
 		$occurrences = Occurrences::table_name( true );
 		global $wpdb;
@@ -617,9 +643,59 @@ class Custom_Tables_Query extends WP_Query {
 		remove_filter( 'posts_where', [ $this, 'filter_by_date' ] );
 		remove_filter( 'posts_where', [ $this, 'filter_where' ] );
 		remove_filter( 'posts_join', [ $this, 'join_occurrences_table' ] );
+		remove_filter( 'the_posts', [ $this, 'deduplicate_posts_when_pro_inactive' ], 5 );
 		remove_filter( 'the_posts', [ $this, 'remove_late_filters' ] );
 		remove_filter( 'found_posts', [ $this, 'hydrate_posts_on_found_rows' ], 0 );
 		remove_filter( 'posts_orderby', [ $this, 'redirect_posts_orderby' ], 200 );
+	}
+
+	/**
+	 * Deduplicates posts by post_id when no active add-on knows how to render multiple
+	 * Occurrences of the same Event.
+	 *
+	 * The occurrences table can contain multiple rows per post_id (e.g. each date of a recurring
+	 * series). Without an add-on able to correctly render each Occurrence as a distinct entry, the
+	 * same Event post would otherwise appear multiple times in the results. This filter keeps only
+	 * the first Occurrence of each post_id (respecting the query's ORDER BY).
+	 *
+	 * @since TBD
+	 *
+	 * @param array    $posts The posts returned by the query.
+	 * @param WP_Query $query The WP_Query instance.
+	 *
+	 * @return array The deduplicated posts array.
+	 */
+	public function deduplicate_posts_when_pro_inactive( $posts, $query ) {
+		if ( $query !== $this ) {
+			// Only target this class' own instance.
+			return $posts;
+		}
+
+		remove_filter( 'the_posts', [ $this, 'deduplicate_posts_when_pro_inactive' ], 5 );
+
+		if ( self::recurring_occurrences_supported() ) {
+			return $posts;
+		}
+
+		if ( empty( $posts ) || ! is_array( $posts ) ) {
+			return $posts;
+		}
+
+		$seen     = [];
+		$filtered = [];
+
+		foreach ( $posts as $post ) {
+			$post_id = $post instanceof WP_Post ? $post->ID : (int) $post;
+
+			if ( isset( $seen[ $post_id ] ) ) {
+				continue;
+			}
+
+			$seen[ $post_id ] = true;
+			$filtered[]       = $post;
+		}
+
+		return $filtered;
 	}
 
 	/**

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -321,6 +321,12 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 
 		$this->redirect();
 
+		if ( ! Custom_Tables_Query::recurring_occurrences_supported() ) {
+			// Without an add-on able to render each Occurrence as a distinct entry, keep grouping by
+			// the Event post ID so only one row per Event is returned, instead of one row per Occurrence.
+			return $groupby;
+		}
+
 		global $wpdb;
 
 		return str_replace(

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Custom_Tables_QueryTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Custom_Tables_QueryTest.php
@@ -2,11 +2,56 @@
 
 namespace TEC\Events\Custom_Tables\V1\WP_Query;
 
+use DateTimeImmutable;
 use Spatie\Snapshots\MatchesSnapshots;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use Tribe__Events__Main as TEC;
 
 class Custom_Tables_QueryTest extends \Codeception\TestCase\WPTestCase {
 	use MatchesSnapshots;
+
+	/**
+	 * Creates an Event with 2 additional Occurrences (3 total), all sharing the same post_id.
+	 *
+	 * @return \WP_Post The Event post the additional Occurrences were created for.
+	 */
+	private function given_an_event_with_multiple_occurrences(): \WP_Post {
+		$post = tribe_events()->set_args( [
+			'post_title'  => 'Recurring Event',
+			'post_status' => 'publish',
+			'start_date'  => '+1 day 10 am',
+			'duration'    => 2 * HOUR_IN_SECONDS,
+		] )->create();
+
+		$first = Occurrence::where( 'post_id', '=', $post->ID )->first();
+		$proto  = [
+			'event_id'       => $first->event_id,
+			'post_id'        => $first->post_id,
+			'start_date'     => $first->start_date,
+			'start_date_utc' => $first->start_date_utc,
+			'end_date'       => $first->end_date,
+			'end_date_utc'   => $first->end_date_utc,
+			'duration'       => $first->duration,
+			'hash'           => $first->hash,
+			'updated_at'     => $first->updated_at,
+		];
+
+		foreach ( [ '+1 week', '+2 weeks' ] as $offset ) {
+			$start = ( new DateTimeImmutable( $proto['start_date'] ) )->modify( $offset );
+			$end   = ( new DateTimeImmutable( $proto['end_date'] ) )->modify( $offset );
+			Occurrence::insert( array_merge( $proto, [
+				'start_date'     => $start->format( 'Y-m-d H:i:s' ),
+				'start_date_utc' => $start->format( 'Y-m-d H:i:s' ),
+				'end_date'       => $end->format( 'Y-m-d H:i:s' ),
+				'end_date_utc'   => $end->format( 'Y-m-d H:i:s' ),
+				'hash'           => sha1( microtime() . $offset ),
+			] ) );
+		}
+
+		$this->assertEquals( 3, Occurrence::where( 'post_id', '=', $post->ID )->count() );
+
+		return $post;
+	}
 
 	/**
 	 * @before
@@ -185,6 +230,60 @@ class Custom_Tables_QueryTest extends \Codeception\TestCase\WPTestCase {
 		// We do not really care about the ORDER here, just the set nature.
 		$this->assertEqualsCanonicalizing( $events, $found );
 		$this->assertMatchesSnapshot( $logged_queries );
+	}
+
+	/**
+	 * It should deduplicate multiple Occurrences of the same Event by default
+	 *
+	 * @test
+	 */
+	public function should_deduplicate_multiple_occurrences_of_same_event_by_default(): void {
+		$post = $this->given_an_event_with_multiple_occurrences();
+
+		$wp_query = new \WP_Query();
+		$found    = $wp_query->query( [
+			'fields'    => 'ids',
+			'post_type' => TEC::POSTTYPE,
+			'post__in'  => [ $post->ID ],
+		] );
+
+		$this->assertEquals(
+			[ $post->ID ],
+			$found,
+			'Without an add-on declaring support for recurring Occurrences, only one row per Event should be returned.'
+		);
+	}
+
+	/**
+	 * It should not deduplicate multiple Occurrences of the same Event when an add-on declares support
+	 *
+	 * @test
+	 */
+	public function should_not_deduplicate_multiple_occurrences_when_addon_declares_support(): void {
+		$post = $this->given_an_event_with_multiple_occurrences();
+
+		// Simulate an add-on wiring up real per-Occurrence SELECT redirection.
+		$identity = static function ( $select_fields ) {
+			return $select_fields;
+		};
+		add_filter( 'tec_events_custom_tables_v1_occurrence_select_fields', $identity );
+
+		try {
+			$wp_query = new \WP_Query();
+			$found    = $wp_query->query( [
+				'fields'    => 'ids',
+				'post_type' => TEC::POSTTYPE,
+				'post__in'  => [ $post->ID ],
+			] );
+		} finally {
+			remove_filter( 'tec_events_custom_tables_v1_occurrence_select_fields', $identity );
+		}
+
+		$this->assertCount(
+			3,
+			$found,
+			'When an add-on declares support for recurring Occurrences, one row per Occurrence should be returned.'
+		);
 	}
 
 	public function orderby_data_provider(): \Generator {

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_FiltersTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_FiltersTest.php
@@ -2,6 +2,8 @@
 
 namespace TEC\Events\Custom_Tables\V1\WP_Query\Repository;
 
+use DateTimeImmutable;
+use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use TEC\Events\Custom_Tables\V1\Tables\Occurrences;
 use Tribe__Repository__Decorator as Repository_Decorator;
 use Tribe__Events__Main as TEC;
@@ -153,6 +155,93 @@ class Custom_Tables_Query_FiltersTest extends \Codeception\TestCase\WPTestCase {
 			"JOIN $occurrences ON test_posts.ID = $occurrences.post_id",
 			$filtered_join_3,
 			'On third filtering, the JOIN clause on Occurrences should not be added a 2nd time.'
+		);
+	}
+
+	/**
+	 * Creates an Event with 2 additional Occurrences (3 total), all sharing the same post_id.
+	 *
+	 * @return \WP_Post The Event post the additional Occurrences were created for.
+	 */
+	private function given_an_event_with_multiple_occurrences(): \WP_Post {
+		$post = tribe_events()->set_args( [
+			'post_title'  => 'Recurring Event',
+			'post_status' => 'publish',
+			'start_date'  => '+1 day 10 am',
+			'duration'    => 2 * HOUR_IN_SECONDS,
+		] )->create();
+
+		$first = Occurrence::where( 'post_id', '=', $post->ID )->first();
+		$proto = [
+			'event_id'       => $first->event_id,
+			'post_id'        => $first->post_id,
+			'start_date'     => $first->start_date,
+			'start_date_utc' => $first->start_date_utc,
+			'end_date'       => $first->end_date,
+			'end_date_utc'   => $first->end_date_utc,
+			'duration'       => $first->duration,
+			'hash'           => $first->hash,
+			'updated_at'     => $first->updated_at,
+		];
+
+		foreach ( [ '+1 week', '+2 weeks' ] as $offset ) {
+			$start = ( new DateTimeImmutable( $proto['start_date'] ) )->modify( $offset );
+			$end   = ( new DateTimeImmutable( $proto['end_date'] ) )->modify( $offset );
+			Occurrence::insert( array_merge( $proto, [
+				'start_date'     => $start->format( 'Y-m-d H:i:s' ),
+				'start_date_utc' => $start->format( 'Y-m-d H:i:s' ),
+				'end_date'       => $end->format( 'Y-m-d H:i:s' ),
+				'end_date_utc'   => $end->format( 'Y-m-d H:i:s' ),
+				'hash'           => sha1( microtime() . $offset ),
+			] ) );
+		}
+
+		$this->assertEquals( 3, Occurrence::where( 'post_id', '=', $post->ID )->count() );
+
+		return $post;
+	}
+
+	/**
+	 * It should group repository results by Event post ID by default
+	 *
+	 * @test
+	 */
+	public function should_group_repository_results_by_post_id_by_default(): void {
+		$post = $this->given_an_event_with_multiple_occurrences();
+
+		$found = tribe_events()->where( 'post__in', [ $post->ID ] )->fields( 'ids' )->all();
+
+		$this->assertEquals(
+			[ $post->ID ],
+			$found,
+			'Without an add-on declaring support for recurring Occurrences, only one row per Event should be returned.'
+		);
+	}
+
+	/**
+	 * It should group repository results by Occurrence ID when an add-on declares support
+	 *
+	 * @test
+	 */
+	public function should_group_repository_results_by_occurrence_id_when_addon_declares_support(): void {
+		$post = $this->given_an_event_with_multiple_occurrences();
+
+		// Simulate an add-on wiring up real per-Occurrence SELECT redirection.
+		$identity = static function ( $select_fields ) {
+			return $select_fields;
+		};
+		add_filter( 'tec_events_custom_tables_v1_occurrence_select_fields', $identity );
+
+		try {
+			$found = tribe_events()->where( 'post__in', [ $post->ID ] )->fields( 'ids' )->all();
+		} finally {
+			remove_filter( 'tec_events_custom_tables_v1_occurrence_select_fields', $identity );
+		}
+
+		$this->assertCount(
+			3,
+			$found,
+			'When an add-on declares support for recurring Occurrences, one row per Occurrence should be returned.'
 		);
 	}
 }

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set ID__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set ID__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set REST API like query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set REST API like query__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order and order by__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order and order by__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order by__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order by__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set SQL injection on order__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by ASC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by ASC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by DESC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by DESC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDate meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDate meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.end_date DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDateUTC meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventEndDateUTC meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.end_date_utc DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDate meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDate meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDateUTC meta_value__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by _EventStartDateUTC meta_value__1.php
@@ -4,6 +4,6 @@
   test_tec_occurrences.post_id IS NOT NULL
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date_utc DESC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by invalid order type__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by invalid order type__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested ASC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested ASC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested DESC__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested DESC__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested invalid order type__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set by nested invalid order type__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID ASC, test_tec_occurrences.occurrence_id ASC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date DESC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date_utc__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_date_utc__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date_utc DESC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_duration__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set event_duration__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.duration DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set no orderby specified__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set no orderby specified__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set relevance__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set relevance__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set wp_posts.ID__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_correctly_order_events_by_different_order_by_criteria with data set wp_posts.ID__1.php
@@ -6,6 +6,6 @@
   test_tec_occurrences.end_date >= \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY ID DESC, test_tec_occurrences.occurrence_id DESC, test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/__snapshots__/Custom_Tables_QueryTest__should_not_run_found_rows_query_twice_per_single_query__1.php
@@ -5,7 +5,7 @@
   test_tec_occurrences.start_date > \'2022-10-01 08:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\' 
 OR test_posts.post_status = \'private\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_posts.post_date DESC
 					 LIMIT 0, 10',
   1 => 'SELECT FOUND_ROWS()',

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_an_event_query__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_an_event_query__1.php
@@ -5,6 +5,6 @@
   AND 
   test_tec_occurrences.end_date >= \'2022-09-28 13:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';

--- a/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_main_events_query__1.php
+++ b/tests/ct1_integration/__snapshots__/Tribe__Events__Query_CT1_Test__should_filter_and_order_main_events_query__1.php
@@ -5,6 +5,6 @@
   AND 
   test_tec_occurrences.end_date >= \'2022-09-28 13:00:00\'
 ) AND ((test_posts.post_type = \'tribe_events\' AND (test_posts.post_status = \'publish\' OR test_posts.post_status = \'tribe-ea-success\' OR test_posts.post_status = \'tribe-ea-failed\' OR test_posts.post_status = \'tribe-ea-schedule\' OR test_posts.post_status = \'tribe-ea-pending\' OR test_posts.post_status = \'tribe-ea-draft\')))
-					 GROUP BY test_tec_occurrences.occurrence_id
+					 GROUP BY test_posts.ID
 					 ORDER BY test_tec_occurrences.start_date ASC, test_posts.post_date ASC
 					 LIMIT 0, 10';


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-231](https://linear.app/nexcess/issue/SMTNC-231/tec-recurring-events-show-duplicatedincorrect-entries-when-pro-is)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We had a bug where, when the user created an event and then deactivated it, the events kept repeating, and it shouldn't have happened. The right behavior was to show only the original event.

To avoid checking if the premium plugin class exists, the solution was to check if the filter `tec_events_custom_tables_v1_occurrence_select_fields` exists, and using a static method, we can check if the functionality exists or not.

We have a test suite to it on ECP as well https://github.com/the-events-calendar/events-pro/pull/3067

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/986bdd2d99e94d5b99793341e158918f

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
