### PR TITLE
Add license activation to guided setup and the Setup Guide

### DIFF
--- a/changelog/feat-smtnc-1833-onboarding-activate-license-button
+++ b/changelog/feat-smtnc-1833-onboarding-activate-license-button
@@ -1,4 +1,4 @@
 Significance: minor
-Type: feat
+Type: tweak
 
-Added an "Activate license" button to the first step of the guided setup, and a matching "License activated" step to the Setup Guide checklist. Both send the user to the Liquid Web portal to activate, and bring them back where they left off once they are done. The wizard button is hidden after the calendar is licensed and activated on the site. The checklist step stays on show, marked as complete, and offers a "Manage license" link to the portal instead.
+Improved the unified licensing page experience.

--- a/changelog/feat-smtnc-1833-onboarding-activate-license-button
+++ b/changelog/feat-smtnc-1833-onboarding-activate-license-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: feat
 
-Added an "Activate license" button to the first step of the guided setup, and a matching "License activated" step to the Setup Guide checklist. Both send the user to the Liquid Web portal and return them to where they left off. The wizard button is hidden once the calendar is licensed and activated on the site; the checklist step stays on show and is marked as complete.
+Added an "Activate license" button to the first step of the guided setup, and a matching "License activated" step to the Setup Guide checklist. Both send the user to the Liquid Web portal to activate, and bring them back where they left off once they are done. The wizard button is hidden after the calendar is licensed and activated on the site. The checklist step stays on show, marked as complete, and offers a "Manage license" link to the portal instead.

--- a/changelog/feat-smtnc-1833-onboarding-activate-license-button
+++ b/changelog/feat-smtnc-1833-onboarding-activate-license-button
@@ -1,4 +1,4 @@
 Significance: minor
-Type: tweak
+Type: feat
 
 Improved the unified licensing page experience.

--- a/changelog/feat-smtnc-1833-onboarding-activate-license-button
+++ b/changelog/feat-smtnc-1833-onboarding-activate-license-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: feat
 
-Added an "Activate license" button to the first step of the guided setup, sending the user to the Liquid Web portal and returning them to where they left off. The button is hidden when the calendar is already licensed and activated on the site.
+Added an "Activate license" button to the first step of the guided setup, and a matching "License activated" step to the Setup Guide checklist. Both send the user to the Liquid Web portal and return them to where they left off. The wizard button is hidden once the calendar is licensed and activated on the site; the checklist step stays on show and is marked as complete.

--- a/changelog/feat-smtnc-1833-onboarding-activate-license-button
+++ b/changelog/feat-smtnc-1833-onboarding-activate-license-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: feat
+
+Added an "Activate license" button to the first step of the guided setup, sending the user to the Liquid Web portal and returning them to where they left off. The button is hidden when the calendar is already licensed and activated on the site.

--- a/src/Events/Admin/Onboarding/Controller.php
+++ b/src/Events/Admin/Onboarding/Controller.php
@@ -16,6 +16,7 @@ use TEC\Events\Admin\Onboarding\Steps\Venue;
 use TEC\Events\Admin\Onboarding\Steps\Tickets;
 use TEC\Events\Admin\Onboarding\Data;
 use TEC\Events\Admin\Onboarding\Landing_Page;
+use TEC\Events\Admin\Onboarding\License_Data;
 use TEC\Common\StellarWP\Assets\Config;
 use Tribe__Events__Main;
 
@@ -56,6 +57,7 @@ class Controller extends Controller_Contract {
 
 		$this->container->singleton( Landing_Page::class );
 		$this->container->singleton( Data::class );
+		$this->container->singleton( License_Data::class );
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -14,6 +14,10 @@ use TEC\Common\StellarWP\Installer\Installer;
 use TEC\Common\Admin\Abstract_Admin_Page;
 use TEC\Common\Admin\Traits\Is_Events_Page;
 use TEC\Common\Asset;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
+use TEC\Common\LiquidWeb\Harbor\Portal\Activation_Url;
 use Tribe__Events__Main as TEC;
 
 /**
@@ -43,6 +47,15 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @var string
 	 */
 	const DISMISS_PAGE_OPTION = 'tec_events_onboarding_page_dismissed';
+
+	/**
+	 * The product slug this plugin is licensed under in the Liquid Web catalog.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const LICENSE_PRODUCT_SLUG = 'the-events-calendar';
 
 	/**
 	 * The slug for the admin menu.
@@ -523,6 +536,8 @@ class Landing_Page extends Abstract_Admin_Page {
 			'timezones'               => tribe( Data::class )->get_timezone_list(),
 			'countries'               => tribe( Data::class )->get_country_list(),
 			'currencies'              => tribe( Data::class )->get_currency_list(),
+			/* Licensing */
+			'activationUrl'           => $this->get_license_activation_url(),
 		];
 
 
@@ -537,6 +552,108 @@ class Landing_Page extends Abstract_Admin_Page {
 		 * @return array
 		 */
 		return (array) apply_filters( 'tribe_events_onboarding_wizard_initial_data', $initial_data, $this );
+	}
+
+	/**
+	 * Get the URL that sends the user to the Liquid Web portal to activate a license.
+	 *
+	 * The portal returns the user to this page once they are done, so they pick
+	 * the wizard back up where they left it.
+	 *
+	 * When the stored license already covers this product, the URL is scoped to
+	 * the product and tier so the portal pre-selects the right subscription.
+	 * Otherwise the user lands on their subscription list and picks it
+	 * themselves, which is the best we can do without knowing what they hold.
+	 *
+	 * Returns an empty string when there is nothing for the user to do: either
+	 * the bundled Harbor library predates the activation URL API, or the site
+	 * already holds a valid activated license for this product. The wizard
+	 * treats an empty string as "hide the button".
+	 *
+	 * @since TBD
+	 *
+	 * @return string The activation URL, or an empty string when unavailable.
+	 */
+	public function get_license_activation_url(): string {
+		if ( ! class_exists( Activation_Url::class ) ) {
+			return '';
+		}
+
+		if ( $this->has_activated_license() ) {
+			return '';
+		}
+
+		$builder     = tribe( Activation_Url::class );
+		$return_url  = admin_url( 'edit.php?post_type=tribe_events&page=' . static::$slug );
+		$entitlement = $this->get_licensed_entry();
+
+		if ( ! $entitlement instanceof Product_Entry ) {
+			return $builder->get_base( $return_url );
+		}
+
+		return $builder->for_product(
+			$entitlement->get_product_slug(),
+			$entitlement->get_tier(),
+			$return_url
+		);
+	}
+
+	/**
+	 * Get the licensed entry for the calendar, whatever its activation state.
+	 *
+	 * Used to scope the activation URL. The tier is known as soon as the key
+	 * covers the product, well before it has been activated on this domain, so
+	 * this deliberately does not filter on activation.
+	 *
+	 * Returns the first entry when a key covers several tiers. Picking between
+	 * them is the portal's job, and it still receives the product either way.
+	 *
+	 * @since TBD
+	 *
+	 * @return Product_Entry|null The entry, or null when the key does not cover this product.
+	 */
+	protected function get_licensed_entry(): ?Product_Entry {
+		if ( ! class_exists( License_Repository::class ) ) {
+			return null;
+		}
+
+		$products = tribe( License_Repository::class )->get_products();
+
+		if ( ! $products instanceof Product_Collection ) {
+			return null;
+		}
+
+		$entries = $products->get_all_by_slug( self::LICENSE_PRODUCT_SLUG );
+
+		return $entries ? reset( $entries ) : null;
+	}
+
+	/**
+	 * Whether this site already holds a valid, activated license for the calendar.
+	 *
+	 * Mirrors the check Harbor's own license UI makes: an entry counts only when
+	 * it is activated against this domain and its entitlement is currently
+	 * valid. A key that exists but has not been activated here does not count,
+	 * because the user still has something to do in the portal.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the calendar is licensed and activated on this site.
+	 */
+	protected function has_activated_license(): bool {
+		if ( ! class_exists( License_Repository::class ) ) {
+			return false;
+		}
+
+		$products = tribe( License_Repository::class )->get_products();
+
+		if ( ! $products instanceof Product_Collection ) {
+			return false;
+		}
+
+		$entry = $products->get_activated_entry( self::LICENSE_PRODUCT_SLUG );
+
+		return $entry instanceof Product_Entry && $entry->is_valid();
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -214,7 +214,7 @@ class Landing_Page extends Abstract_Admin_Page {
 		}
 
 		// Once the license is activated there is nothing left to activate, so the
-		// step points at the portal for managing it instead.
+		// step points at the in-WP license manager instead.
 		$license_link_url  = $license_activated ? $license->get_management_url() : $license_url;
 		$license_link_text = $license_activated
 			? __( 'Manage license', 'the-events-calendar' )
@@ -247,24 +247,19 @@ class Landing_Page extends Abstract_Admin_Page {
 						</div>
 						<?php if ( $license_link_url ) : ?>
 						<div class="step-list__item-right">
-							<span class="tec-admin-page__link--external">
+							<?php
+							/*
+							 * Before activation the link leaves wp-admin for the portal, so it
+							 * carries the external affordance; the management link stays in
+							 * wp-admin and so does not. Neither opens a new tab: the activation
+							 * URL carries a return address, and the in-WP manager has the browser
+							 * back button.
+							 */
+							?>
+							<span class="<?php echo esc_attr( $license_activated ? '' : 'tec-admin-page__link--external' ); ?>">
 								<a
 									href="<?php echo esc_url( $license_link_url ); ?>"
 									class="tec-admin-page__link"
-									<?php
-									/*
-									 * Only the management link opens in a new tab. The activation URL
-									 * carries a return address, and sending that round trip to a tab
-									 * the user has left behind would strand them on this page with a
-									 * stale step. Managing a license has no return trip, so keeping
-									 * this page open is the only way back.
-									 */
-									if ( $license_activated ) :
-										?>
-										target="_blank" rel="nofollow noopener"
-										<?php
-									endif;
-									?>
 								>
 									<?php echo esc_html( $license_link_text ); ?>
 								</a>

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -248,7 +248,7 @@ class Landing_Page extends Abstract_Admin_Page {
 						<?php
 						tec_classes(
 							[
-								'step-list__item' => true,
+								'step-list__item'                            => true,
 								'tec-admin-page__onboarding-step--completed' => $license_activated,
 							]
 						);

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -14,6 +14,7 @@ use TEC\Common\StellarWP\Installer\Installer;
 use TEC\Common\Admin\Abstract_Admin_Page;
 use TEC\Common\Admin\Traits\Is_Events_Page;
 use TEC\Common\Asset;
+use TEC\Common\LiquidWeb\Harbor\Config;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
@@ -194,6 +195,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *
 	 * @since 6.8.4
 	 * @since 6.11.1 Fixed a typo.
+	 * @since TBD Added the license activation step.
 	 *
 	 * @return void
 	 */
@@ -214,6 +216,23 @@ class Landing_Page extends Abstract_Admin_Page {
 			isset( $completed_tabs[4] ) || ! empty( $organizer_data ),
 			isset( $completed_tabs[5] ) || ! empty( $venue_data ),
 		];
+
+		// An empty URL means the bundled Harbor library cannot build one, so there is no step to show.
+		$license_url       = $this->build_license_activation_url();
+		$license_activated = $this->has_activated_license();
+
+		// Order here only feeds the tally below. The steps are laid out in the markup.
+		if ( $license_url ) {
+			$condition[] = $license_activated;
+		}
+
+		// Once the license is activated there is nothing left to activate, so the
+		// step points at the portal for managing it instead.
+		$license_link_url  = $license_activated ? $this->get_license_management_url() : $license_url;
+		$license_link_text = $license_activated
+			? __( 'Manage license', 'the-events-calendar' )
+			: __( 'Activate license', 'the-events-calendar' );
+
 		$count_complete = count( array_filter( $condition ) );
 		?>
 			<div class="tec-admin-page__content-section">
@@ -223,6 +242,31 @@ class Landing_Page extends Abstract_Admin_Page {
 				</div>
 				<div class="tec-admin-page__content-section-subheader"><?php echo esc_html( $count_complete ) . '/' . esc_html( count( $condition ) ) . ' ' . esc_html__( 'steps completed', 'the-events-calendar' ); ?></div>
 				<ul class="tec-admin-page__content-step-list">
+					<?php if ( $license_url ) : ?>
+					<li
+						id="tec-events-onboarding-wizard-license-item"
+						<?php
+						tec_classes(
+							[
+								'step-list__item' => true,
+								'tec-admin-page__onboarding-step--completed' => $license_activated,
+							]
+						);
+						?>
+					>
+						<div class="step-list__item-left">
+							<span class="step-list__item-icon" role="presentation"></span>
+							<?php esc_html_e( 'License activated', 'the-events-calendar' ); ?>
+						</div>
+						<?php if ( $license_link_url ) : ?>
+						<div class="step-list__item-right">
+							<a href="<?php echo esc_url( $license_link_url ); ?>" class="tec-admin-page__link">
+								<?php echo esc_html( $license_link_text ); ?>
+							</a>
+						</div>
+						<?php endif; ?>
+					</li>
+					<?php endif; ?>
 					<li
 						id="tec-events-onboarding-wizard-views-item"
 						<?php
@@ -557,14 +601,6 @@ class Landing_Page extends Abstract_Admin_Page {
 	/**
 	 * Get the URL that sends the user to the Liquid Web portal to activate a license.
 	 *
-	 * The portal returns the user to this page once they are done, so they pick
-	 * the wizard back up where they left it.
-	 *
-	 * When the stored license already covers this product, the URL is scoped to
-	 * the product and tier so the portal pre-selects the right subscription.
-	 * Otherwise the user lands on their subscription list and picks it
-	 * themselves, which is the best we can do without knowing what they hold.
-	 *
 	 * Returns an empty string when there is nothing for the user to do: either
 	 * the bundled Harbor library predates the activation URL API, or the site
 	 * already holds a valid activated license for this product. The wizard
@@ -575,11 +611,37 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return string The activation URL, or an empty string when unavailable.
 	 */
 	public function get_license_activation_url(): string {
-		if ( ! class_exists( Activation_Url::class ) ) {
+		if ( $this->has_activated_license() ) {
 			return '';
 		}
 
-		if ( $this->has_activated_license() ) {
+		return $this->build_license_activation_url();
+	}
+
+	/**
+	 * Build the URL that sends the user to the Liquid Web portal to activate a
+	 * license, whatever this site's activation state.
+	 *
+	 * The portal returns the user to this page once they are done, so they pick
+	 * up where they left off.
+	 *
+	 * When the stored license already covers this product, the URL is scoped to
+	 * the product and tier so the portal pre-selects the right subscription.
+	 * Otherwise the user lands on their subscription list and picks it
+	 * themselves, which is the best we can do without knowing what they hold.
+	 *
+	 * Callers that only want a route for a user with something left to do should
+	 * use get_license_activation_url() instead. This one answers the narrower
+	 * question of whether a URL can be built at all, which the setup guide needs
+	 * so it can show a step as done rather than hide it.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The activation URL, or an empty string when the bundled
+	 *                Harbor library cannot build one.
+	 */
+	protected function build_license_activation_url(): string {
+		if ( ! class_exists( Activation_Url::class ) ) {
 			return '';
 		}
 
@@ -596,6 +658,30 @@ class Landing_Page extends Abstract_Admin_Page {
 			$entitlement->get_tier(),
 			$return_url
 		);
+	}
+
+	/**
+	 * Get the URL of the portal's subscriptions screen, where a user manages a
+	 * license that is already activated on this site.
+	 *
+	 * There is nothing left to activate at that point, so the setup guide sends
+	 * the user straight to the screen they manage the license from rather than
+	 * back through the activation flow. This is the same destination Harbor's
+	 * own licensing UI uses for its "Manage license" link.
+	 *
+	 * The base URL carries no trailing slash, so the path supplies its own.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The subscriptions URL, or an empty string when the bundled
+	 *                Harbor library cannot supply one.
+	 */
+	protected function get_license_management_url(): string {
+		if ( ! class_exists( Config::class ) ) {
+			return '';
+		}
+
+		return Config::get_portal_base_url() . '/subscriptions/';
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -233,45 +233,6 @@ class Landing_Page extends Abstract_Admin_Page {
 				</div>
 				<div class="tec-admin-page__content-section-subheader"><?php echo esc_html( $count_complete ) . '/' . esc_html( count( $condition ) ) . ' ' . esc_html__( 'steps completed', 'the-events-calendar' ); ?></div>
 				<ul class="tec-admin-page__content-step-list">
-					<?php if ( $license_url ) : ?>
-					<li
-						id="tec-events-onboarding-wizard-license-item"
-						<?php
-						tec_classes(
-							[
-								'step-list__item'                            => true,
-								'tec-admin-page__onboarding-step--completed' => $license_activated,
-							]
-						);
-						?>
-					>
-						<div class="step-list__item-left">
-							<span class="step-list__item-icon" role="presentation"></span>
-							<?php esc_html_e( 'License activated', 'the-events-calendar' ); ?>
-						</div>
-						<?php if ( $license_link_url ) : ?>
-						<div class="step-list__item-right">
-							<?php
-							/*
-							 * Before activation the link leaves wp-admin for the portal, so it
-							 * carries the external affordance; the management link stays in
-							 * wp-admin and so does not. Neither opens a new tab: the activation
-							 * URL carries a return address, and the in-WP manager has the browser
-							 * back button.
-							 */
-							?>
-							<span class="<?php echo esc_attr( $license_activated ? '' : 'tec-admin-page__link--external' ); ?>">
-								<a
-									href="<?php echo esc_url( $license_link_url ); ?>"
-									class="tec-admin-page__link"
-								>
-									<?php echo esc_html( $license_link_text ); ?>
-								</a>
-							</span>
-						</div>
-						<?php endif; ?>
-					</li>
-					<?php endif; ?>
 					<li
 						id="tec-events-onboarding-wizard-views-item"
 						<?php
@@ -382,6 +343,45 @@ class Landing_Page extends Abstract_Admin_Page {
 							</a>
 						</div>
 					</li>
+					<?php if ( $license_url ) : ?>
+					<li
+						id="tec-events-onboarding-wizard-license-item"
+						<?php
+						tec_classes(
+							[
+								'step-list__item'                            => true,
+								'tec-admin-page__onboarding-step--completed' => $license_activated,
+							]
+						);
+						?>
+					>
+						<div class="step-list__item-left">
+							<span class="step-list__item-icon" role="presentation"></span>
+							<?php esc_html_e( 'License activated', 'the-events-calendar' ); ?>
+						</div>
+						<?php if ( $license_link_url ) : ?>
+						<div class="step-list__item-right">
+							<?php
+							/*
+							 * Before activation the link leaves wp-admin for the portal, so it
+							 * carries the external affordance; the management link stays in
+							 * wp-admin and so does not. Neither opens a new tab: the activation
+							 * URL carries a return address, and the in-WP manager has the browser
+							 * back button.
+							 */
+							?>
+							<span class="<?php echo esc_attr( $license_activated ? '' : 'tec-admin-page__link--external' ); ?>">
+								<a
+									href="<?php echo esc_url( $license_link_url ); ?>"
+									class="tec-admin-page__link"
+								>
+									<?php echo esc_html( $license_link_text ); ?>
+								</a>
+							</span>
+						</div>
+						<?php endif; ?>
+					</li>
+					<?php endif; ?>
 				</ul>
 				<div class="tec-admin-page__content-section-mid">
 					<h2 class="tec-admin-page__content-header">

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -14,11 +14,6 @@ use TEC\Common\StellarWP\Installer\Installer;
 use TEC\Common\Admin\Abstract_Admin_Page;
 use TEC\Common\Admin\Traits\Is_Events_Page;
 use TEC\Common\Asset;
-use TEC\Common\LiquidWeb\Harbor\Config;
-use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
-use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
-use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
-use TEC\Common\LiquidWeb\Harbor\Portal\Activation_Url;
 use Tribe__Events__Main as TEC;
 
 /**
@@ -48,15 +43,6 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @var string
 	 */
 	const DISMISS_PAGE_OPTION = 'tec_events_onboarding_page_dismissed';
-
-	/**
-	 * The product slug this plugin is licensed under in the Liquid Web catalog.
-	 *
-	 * @since TBD
-	 *
-	 * @var string
-	 */
-	const LICENSE_PRODUCT_SLUG = 'the-events-calendar';
 
 	/**
 	 * The slug for the admin menu.
@@ -217,9 +203,10 @@ class Landing_Page extends Abstract_Admin_Page {
 			isset( $completed_tabs[5] ) || ! empty( $venue_data ),
 		];
 
-		// An empty URL means the bundled Harbor library cannot build one, so there is no step to show.
-		$license_url       = $this->build_license_activation_url();
-		$license_activated = $this->has_activated_license();
+		// An empty URL means there is no activation route to offer, so no step to show either.
+		$license           = tribe( License_Data::class );
+		$license_url       = $license->build_activation_url( $this->get_return_url() );
+		$license_activated = $license->is_activated();
 
 		// Order here only feeds the tally below. The steps are laid out in the markup.
 		if ( $license_url ) {
@@ -228,7 +215,7 @@ class Landing_Page extends Abstract_Admin_Page {
 
 		// Once the license is activated there is nothing left to activate, so the
 		// step points at the portal for managing it instead.
-		$license_link_url  = $license_activated ? $this->get_license_management_url() : $license_url;
+		$license_link_url  = $license_activated ? $license->get_management_url() : $license_url;
 		$license_link_text = $license_activated
 			? __( 'Manage license', 'the-events-calendar' )
 			: __( 'Activate license', 'the-events-calendar' );
@@ -600,7 +587,7 @@ class Landing_Page extends Abstract_Admin_Page {
 			'countries'               => tribe( Data::class )->get_country_list(),
 			'currencies'              => tribe( Data::class )->get_currency_list(),
 			/* Licensing */
-			'activationUrl'           => $this->get_license_activation_url(),
+			'activationUrl'           => tribe( License_Data::class )->get_activation_url( $this->get_return_url() ),
 		];
 
 
@@ -618,169 +605,15 @@ class Landing_Page extends Abstract_Admin_Page {
 	}
 
 	/**
-	 * Get the URL that sends the user to the Liquid Web portal to activate a license.
-	 *
-	 * Returns an empty string when there is nothing for the user to do: either
-	 * the bundled Harbor library predates the activation URL API, or the site
-	 * already holds a valid activated license for this product. The wizard
-	 * treats an empty string as "hide the button".
+	 * Get this page's own address, for handing to anything that sends the user
+	 * off site and needs somewhere to send them back to.
 	 *
 	 * @since TBD
 	 *
-	 * @return string The activation URL, or an empty string when unavailable.
+	 * @return string The URL of the guided setup page.
 	 */
-	public function get_license_activation_url(): string {
-		// Cheapest check first: with no way to build a URL there is no reason to
-		// read licensing state to find out whether we would have wanted one.
-		if ( ! $this->can_build_activation_url() ) {
-			return '';
-		}
-
-		if ( $this->has_activated_license() ) {
-			return '';
-		}
-
-		return $this->build_license_activation_url();
-	}
-
-	/**
-	 * Whether the bundled Harbor library can build an activation URL at all.
-	 *
-	 * Older copies predate the activation URL API. Both entry points guard on
-	 * this, one to skip work it would only discard and one because it cannot
-	 * proceed without it, so it lives in a single place rather than as a
-	 * duplicated class_exists() call.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool True when the activation URL service is available.
-	 */
-	protected function can_build_activation_url(): bool {
-		return class_exists( Activation_Url::class );
-	}
-
-	/**
-	 * Build the URL that sends the user to the Liquid Web portal to activate a
-	 * license, whatever this site's activation state.
-	 *
-	 * The portal returns the user to this page once they are done, so they pick
-	 * up where they left off.
-	 *
-	 * When the stored license already covers this product, the URL is scoped to
-	 * the product and tier so the portal pre-selects the right subscription.
-	 * Otherwise the user lands on their subscription list and picks it
-	 * themselves, which is the best we can do without knowing what they hold.
-	 *
-	 * Callers that only want a route for a user with something left to do should
-	 * use get_license_activation_url() instead. This one answers the narrower
-	 * question of whether a URL can be built at all, which the setup guide needs
-	 * so it can show a step as done rather than hide it.
-	 *
-	 * @since TBD
-	 *
-	 * @return string The activation URL, or an empty string when the bundled
-	 *                Harbor library cannot build one.
-	 */
-	protected function build_license_activation_url(): string {
-		if ( ! $this->can_build_activation_url() ) {
-			return '';
-		}
-
-		$builder     = tribe( Activation_Url::class );
-		$return_url  = admin_url( 'edit.php?post_type=tribe_events&page=' . static::$slug );
-		$entitlement = $this->get_licensed_entry();
-
-		if ( ! $entitlement instanceof Product_Entry ) {
-			return $builder->get_base( $return_url );
-		}
-
-		return $builder->for_product(
-			$entitlement->get_product_slug(),
-			$entitlement->get_tier(),
-			$return_url
-		);
-	}
-
-	/**
-	 * Get the URL of the portal's subscriptions screen, where a user manages a
-	 * license that is already activated on this site.
-	 *
-	 * There is nothing left to activate at that point, so the setup guide sends
-	 * the user straight to the screen they manage the license from rather than
-	 * back through the activation flow. This is the same destination Harbor's
-	 * own licensing UI uses for its "Manage license" link.
-	 *
-	 * The base URL carries no trailing slash, so the path supplies its own.
-	 *
-	 * @since TBD
-	 *
-	 * @return string The subscriptions URL, or an empty string when the bundled
-	 *                Harbor library cannot supply one.
-	 */
-	protected function get_license_management_url(): string {
-		if ( ! class_exists( Config::class ) ) {
-			return '';
-		}
-
-		return Config::get_portal_base_url() . '/subscriptions/';
-	}
-
-	/**
-	 * Get the licensed entry for the calendar, whatever its activation state.
-	 *
-	 * Used to scope the activation URL. The tier is known as soon as the key
-	 * covers the product, well before it has been activated on this domain, so
-	 * this deliberately does not filter on activation.
-	 *
-	 * Returns the first entry when a key covers several tiers. Picking between
-	 * them is the portal's job, and it still receives the product either way.
-	 *
-	 * @since TBD
-	 *
-	 * @return Product_Entry|null The entry, or null when the key does not cover this product.
-	 */
-	protected function get_licensed_entry(): ?Product_Entry {
-		if ( ! class_exists( License_Repository::class ) ) {
-			return null;
-		}
-
-		$products = tribe( License_Repository::class )->get_products();
-
-		if ( ! $products instanceof Product_Collection ) {
-			return null;
-		}
-
-		$entries = $products->get_all_by_slug( self::LICENSE_PRODUCT_SLUG );
-
-		return $entries ? reset( $entries ) : null;
-	}
-
-	/**
-	 * Whether this site already holds a valid, activated license for the calendar.
-	 *
-	 * Mirrors the check Harbor's own license UI makes: an entry counts only when
-	 * it is activated against this domain and its entitlement is currently
-	 * valid. A key that exists but has not been activated here does not count,
-	 * because the user still has something to do in the portal.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool True when the calendar is licensed and activated on this site.
-	 */
-	protected function has_activated_license(): bool {
-		if ( ! class_exists( License_Repository::class ) ) {
-			return false;
-		}
-
-		$products = tribe( License_Repository::class )->get_products();
-
-		if ( ! $products instanceof Product_Collection ) {
-			return false;
-		}
-
-		$entry = $products->get_activated_entry( self::LICENSE_PRODUCT_SLUG );
-
-		return $entry instanceof Product_Entry && $entry->is_valid();
+	protected function get_return_url(): string {
+		return admin_url( 'edit.php?post_type=tribe_events&page=' . static::$slug );
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -203,9 +203,13 @@ class Landing_Page extends Abstract_Admin_Page {
 			isset( $completed_tabs[5] ) || ! empty( $venue_data ),
 		];
 
-		// An empty URL means there is no activation route to offer, so no step to show either.
+		// An empty URL means there is no activation route to offer, so no step to show
+		// either. The calendar is free, so the step only earns its place on a site
+		// running a premium plugin a license would unlock.
 		$license           = tribe( License_Data::class );
-		$license_url       = $license->build_activation_url( $this->get_return_url() );
+		$license_url       = $license->has_active_premium_plugin()
+			? $license->build_activation_url( $this->get_return_url() )
+			: '';
 		$license_activated = $license->is_activated();
 
 		// Order here only feeds the tally below. The steps are laid out in the markup.

--- a/src/Events/Admin/Onboarding/Landing_Page.php
+++ b/src/Events/Admin/Onboarding/Landing_Page.php
@@ -260,9 +260,28 @@ class Landing_Page extends Abstract_Admin_Page {
 						</div>
 						<?php if ( $license_link_url ) : ?>
 						<div class="step-list__item-right">
-							<a href="<?php echo esc_url( $license_link_url ); ?>" class="tec-admin-page__link">
-								<?php echo esc_html( $license_link_text ); ?>
-							</a>
+							<span class="tec-admin-page__link--external">
+								<a
+									href="<?php echo esc_url( $license_link_url ); ?>"
+									class="tec-admin-page__link"
+									<?php
+									/*
+									 * Only the management link opens in a new tab. The activation URL
+									 * carries a return address, and sending that round trip to a tab
+									 * the user has left behind would strand them on this page with a
+									 * stale step. Managing a license has no return trip, so keeping
+									 * this page open is the only way back.
+									 */
+									if ( $license_activated ) :
+										?>
+										target="_blank" rel="nofollow noopener"
+										<?php
+									endif;
+									?>
+								>
+									<?php echo esc_html( $license_link_text ); ?>
+								</a>
+							</span>
 						</div>
 						<?php endif; ?>
 					</li>
@@ -611,11 +630,33 @@ class Landing_Page extends Abstract_Admin_Page {
 	 * @return string The activation URL, or an empty string when unavailable.
 	 */
 	public function get_license_activation_url(): string {
+		// Cheapest check first: with no way to build a URL there is no reason to
+		// read licensing state to find out whether we would have wanted one.
+		if ( ! $this->can_build_activation_url() ) {
+			return '';
+		}
+
 		if ( $this->has_activated_license() ) {
 			return '';
 		}
 
 		return $this->build_license_activation_url();
+	}
+
+	/**
+	 * Whether the bundled Harbor library can build an activation URL at all.
+	 *
+	 * Older copies predate the activation URL API. Both entry points guard on
+	 * this, one to skip work it would only discard and one because it cannot
+	 * proceed without it, so it lives in a single place rather than as a
+	 * duplicated class_exists() call.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the activation URL service is available.
+	 */
+	protected function can_build_activation_url(): bool {
+		return class_exists( Activation_Url::class );
 	}
 
 	/**
@@ -641,7 +682,7 @@ class Landing_Page extends Abstract_Admin_Page {
 	 *                Harbor library cannot build one.
 	 */
 	protected function build_license_activation_url(): string {
-		if ( ! class_exists( Activation_Url::class ) ) {
+		if ( ! $this->can_build_activation_url() ) {
 			return '';
 		}
 

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -136,6 +136,10 @@ class License_Data {
 	 * of whether a URL can be built at all, which the setup guide needs so it
 	 * can show a step as done rather than hide it.
 	 *
+	 * Harbor returns null when it has no URL to give; that is folded into the
+	 * empty string this returns, because both mean the same thing here — there
+	 * is nothing to link to.
+	 *
 	 * @since TBD
 	 *
 	 * @param string $return_url Where the portal returns the user afterwards.
@@ -156,14 +160,14 @@ class License_Data {
 		$entitlement = $this->get_licensed_entry();
 
 		if ( ! $entitlement instanceof Product_Entry ) {
-			return lw_harbor_get_activation_base_url( $return_url );
+			return lw_harbor_get_activation_base_url( $return_url ) ?? '';
 		}
 
 		return lw_harbor_get_product_activation_url(
 			$entitlement->get_product_slug(),
 			$entitlement->get_tier(),
 			$return_url
-		);
+		) ?? '';
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -9,9 +9,6 @@
 
 namespace TEC\Events\Admin\Onboarding;
 
-use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
-use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
-use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
 use Tribe__Dependency;
 
 /**
@@ -59,8 +56,7 @@ class License_Data {
 	 * @return bool True when the activation URL functions are available.
 	 */
 	public function can_build_activation_url(): bool {
-		return function_exists( 'lw_harbor_get_activation_base_url' )
-			&& function_exists( 'lw_harbor_get_product_activation_url' );
+		return function_exists( 'lw_harbor_get_product_activation_url' );
 	}
 
 	/**
@@ -125,11 +121,11 @@ class License_Data {
 	 * The portal returns the user to the given address once they are done, so
 	 * they pick up where they left off.
 	 *
-	 * When the stored license already covers the calendar, the URL is scoped to
-	 * the product and tier so the portal pre-selects the right subscription.
-	 * Otherwise the user lands on their subscription list and picks it
-	 * themselves, which is the best that can be done without knowing what they
-	 * hold.
+	 * The URL is scoped to the tier when Harbor names one, so the portal
+	 * pre-selects the right subscription. When it cannot — the key does not cover
+	 * the calendar, or covers it at several tiers — the tier is null and the
+	 * portal shows its own picker, still limited to this domain. That is the right
+	 * screen for a genuine choice, and better than guessing on the user's behalf.
 	 *
 	 * Callers that only want a URL for a user with something left to do should
 	 * use get_activation_url() instead. This one answers the narrower question
@@ -150,24 +146,18 @@ class License_Data {
 	public function build_activation_url( string $return_url ): string {
 		// Guarded inline (not only via can_build_activation_url()) so static
 		// analysis can see the functions are called only when they exist.
-		if (
-			! function_exists( 'lw_harbor_get_activation_base_url' )
-			|| ! function_exists( 'lw_harbor_get_product_activation_url' )
-		) {
+		if ( ! function_exists( 'lw_harbor_get_product_activation_url' ) ) {
 			return '';
 		}
 
-		$entitlement = $this->get_licensed_entry();
+		// A null tier is passed through deliberately: the portal answers an
+		// unscoped sku with its own product and tier picker, still limited to
+		// this domain, which is the right screen when the tier is unknown.
+		$tier = function_exists( 'lw_harbor_get_product_tier' )
+			? lw_harbor_get_product_tier( self::PRODUCT_SLUG )
+			: null;
 
-		if ( ! $entitlement instanceof Product_Entry ) {
-			return lw_harbor_get_activation_base_url( $return_url ) ?? '';
-		}
-
-		return lw_harbor_get_product_activation_url(
-			$entitlement->get_product_slug(),
-			$entitlement->get_tier(),
-			$return_url
-		) ?? '';
+		return lw_harbor_get_product_activation_url( self::PRODUCT_SLUG, $tier, $return_url ) ?? '';
 	}
 
 	/**
@@ -204,61 +194,7 @@ class License_Data {
 	 * @return bool True when the calendar is licensed and activated on this site.
 	 */
 	public function is_activated(): bool {
-		$products = $this->get_products();
-
-		if ( ! $products instanceof Product_Collection ) {
-			return false;
-		}
-
-		$entry = $products->get_activated_entry( self::PRODUCT_SLUG );
-
-		return $entry instanceof Product_Entry && $entry->is_valid();
-	}
-
-	/**
-	 * Get the licensed entry for the calendar, whatever its activation state.
-	 *
-	 * Used to scope the activation URL. The tier is known as soon as the key
-	 * covers the product, well before it has been activated on this domain, so
-	 * this deliberately does not filter on activation.
-	 *
-	 * Returns the first entry when a key covers several tiers. Picking between
-	 * them is the portal's job, and it still receives the product either way.
-	 *
-	 * @since TBD
-	 *
-	 * @return Product_Entry|null The entry, or null when the key does not cover the calendar.
-	 */
-	protected function get_licensed_entry(): ?Product_Entry {
-		$products = $this->get_products();
-
-		if ( ! $products instanceof Product_Collection ) {
-			return null;
-		}
-
-		$entries = $products->get_all_by_slug( self::PRODUCT_SLUG );
-
-		return $entries ? reset( $entries ) : null;
-	}
-
-	/**
-	 * Get the licensed products Harbor holds for this site.
-	 *
-	 * Harbor returns a WP_Error when its last fetch failed, and null when it has
-	 * never fetched. Neither is something the onboarding UI can act on, so both
-	 * are flattened to null here and read by callers as "no license".
-	 *
-	 * @since TBD
-	 *
-	 * @return Product_Collection|null The products, or null when unavailable.
-	 */
-	protected function get_products(): ?Product_Collection {
-		if ( ! class_exists( License_Repository::class ) ) {
-			return null;
-		}
-
-		$products = tribe( License_Repository::class )->get_products();
-
-		return $products instanceof Product_Collection ? $products : null;
+		return function_exists( 'lw_harbor_is_product_license_active' )
+			&& lw_harbor_is_product_license_active( self::PRODUCT_SLUG );
 	}
 }

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -9,11 +9,9 @@
 
 namespace TEC\Events\Admin\Onboarding;
 
-use TEC\Common\LiquidWeb\Harbor\Config;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
-use TEC\Common\LiquidWeb\Harbor\Portal\Activation_Url;
 
 /**
  * Class License_Data
@@ -47,15 +45,21 @@ class License_Data {
 	 *
 	 * Older copies predate the activation URL API. Callers guard on this, some
 	 * to skip work they would only discard and some because they cannot proceed
-	 * without it, so it lives here rather than as a duplicated class_exists()
+	 * without it, so it lives here rather than as a duplicated function_exists()
 	 * call at each site.
+	 *
+	 * We reach Harbor through its stable global functions rather than resolving
+	 * its classes directly: the functions always resolve to the loaded,
+	 * highest-version Harbor copy, so we are never at the mercy of whichever
+	 * version our own bundled copy happens to be.
 	 *
 	 * @since TBD
 	 *
-	 * @return bool True when the activation URL service is available.
+	 * @return bool True when the activation URL functions are available.
 	 */
 	public function can_build_activation_url(): bool {
-		return class_exists( Activation_Url::class );
+		return function_exists( 'lw_harbor_get_activation_url' )
+			&& function_exists( 'lw_harbor_get_product_activation_url' );
 	}
 
 	/**
@@ -112,18 +116,22 @@ class License_Data {
 	 *                Harbor library cannot build one.
 	 */
 	public function build_activation_url( string $return_url ): string {
-		if ( ! $this->can_build_activation_url() ) {
+		// Guarded inline (not only via can_build_activation_url()) so static
+		// analysis can see the functions are called only when they exist.
+		if (
+			! function_exists( 'lw_harbor_get_activation_url' )
+			|| ! function_exists( 'lw_harbor_get_product_activation_url' )
+		) {
 			return '';
 		}
 
-		$builder     = tribe( Activation_Url::class );
 		$entitlement = $this->get_licensed_entry();
 
 		if ( ! $entitlement instanceof Product_Entry ) {
-			return $builder->get_base( $return_url );
+			return lw_harbor_get_activation_url( $return_url );
 		}
 
-		return $builder->for_product(
+		return lw_harbor_get_product_activation_url(
 			$entitlement->get_product_slug(),
 			$entitlement->get_tier(),
 			$return_url
@@ -131,27 +139,24 @@ class License_Data {
 	}
 
 	/**
-	 * Get the URL of the portal's subscriptions screen, where a user manages a
-	 * license that is already activated on this site.
+	 * Get the URL of the in-WP page where a user manages their Liquid Web
+	 * licenses.
 	 *
-	 * There is nothing left to activate at that point, so callers send the user
-	 * straight to the screen they manage the license from rather than back
-	 * through the activation flow. This is the same destination Harbor's own
-	 * licensing UI uses for its "Manage license" link.
-	 *
-	 * The base URL carries no trailing slash, so the path supplies its own.
+	 * This is the Software Manager settings page Harbor registers, not the
+	 * external portal: an activated user manages their products without leaving
+	 * the site. Returns an empty string when Harbor is not active, so callers can
+	 * treat that as "hide the button".
 	 *
 	 * @since TBD
 	 *
-	 * @return string The subscriptions URL, or an empty string when the bundled
-	 *                Harbor library cannot supply one.
+	 * @return string The management page URL, or an empty string when unavailable.
 	 */
 	public function get_management_url(): string {
-		if ( ! class_exists( Config::class ) ) {
+		if ( ! function_exists( 'lw_harbor_get_license_page_url' ) ) {
 			return '';
 		}
 
-		return Config::get_portal_base_url() . '/subscriptions/';
+		return lw_harbor_get_license_page_url();
 	}
 
 	/**

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -59,7 +59,7 @@ class License_Data {
 	 * @return bool True when the activation URL functions are available.
 	 */
 	public function can_build_activation_url(): bool {
-		return function_exists( 'lw_harbor_get_activation_url' )
+		return function_exists( 'lw_harbor_get_activation_base_url' )
 			&& function_exists( 'lw_harbor_get_product_activation_url' );
 	}
 
@@ -147,7 +147,7 @@ class License_Data {
 		// Guarded inline (not only via can_build_activation_url()) so static
 		// analysis can see the functions are called only when they exist.
 		if (
-			! function_exists( 'lw_harbor_get_activation_url' )
+			! function_exists( 'lw_harbor_get_activation_base_url' )
 			|| ! function_exists( 'lw_harbor_get_product_activation_url' )
 		) {
 			return '';
@@ -156,7 +156,7 @@ class License_Data {
 		$entitlement = $this->get_licensed_entry();
 
 		if ( ! $entitlement instanceof Product_Entry ) {
-			return lw_harbor_get_activation_url( $return_url );
+			return lw_harbor_get_activation_base_url( $return_url );
 		}
 
 		return lw_harbor_get_product_activation_url(

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -12,6 +12,7 @@ namespace TEC\Events\Admin\Onboarding;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
 use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
+use Tribe__Dependency;
 
 /**
  * Class License_Data
@@ -63,13 +64,34 @@ class License_Data {
 	}
 
 	/**
+	 * Whether this site runs an active premium plugin a license would unlock.
+	 *
+	 * The calendar is free, and a license only unlocks the premium plugins built
+	 * on top of it. Offering activation UI to a site running none of them would
+	 * imply a license is needed to publish events at all, so onboarding asks this
+	 * first and stays silent when the answer is no.
+	 *
+	 * Delegates to Common's shared answer rather than keeping a second list of
+	 * premium plugins here. That answer is only reliable once plugins have
+	 * registered themselves, which is long settled by the time an admin page
+	 * renders.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when a premium plugin is active on this site.
+	 */
+	public function has_active_premium_plugin(): bool {
+		return Tribe__Dependency::instance()->has_active_premium_plugin();
+	}
+
+	/**
 	 * Get the URL that sends a user to the portal to activate a license, for
 	 * callers that only want one while the user still has something to do.
 	 *
-	 * Returns an empty string when there is nothing to be done: either the
-	 * bundled Harbor library predates the activation URL API, or the site
-	 * already holds a valid activated license. The onboarding wizard treats an
-	 * empty string as "hide the button".
+	 * Returns an empty string when there is nothing to be done: the site runs no
+	 * premium plugin a license would unlock, the bundled Harbor library predates
+	 * the activation URL API, or the site already holds a valid activated
+	 * license. The onboarding wizard treats an empty string as "hide the button".
 	 *
 	 * @since TBD
 	 *
@@ -78,8 +100,14 @@ class License_Data {
 	 * @return string The activation URL, or an empty string when unavailable.
 	 */
 	public function get_activation_url( string $return_url ): string {
-		// Cheapest check first: with no way to build a URL there is no reason to
-		// read licensing state to find out whether we would have wanted one.
+		// Most fundamental question first: on a site with nothing a license would
+		// unlock there is no reason to ask anything else, or to offer any UI.
+		if ( ! $this->has_active_premium_plugin() ) {
+			return '';
+		}
+
+		// With no way to build a URL there is no reason to read licensing state to
+		// find out whether we would have wanted one.
 		if ( ! $this->can_build_activation_url() ) {
 			return '';
 		}

--- a/src/Events/Admin/Onboarding/License_Data.php
+++ b/src/Events/Admin/Onboarding/License_Data.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Class that answers the licensing questions the onboarding UI asks.
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\Admin\Onboarding
+ */
+
+namespace TEC\Events\Admin\Onboarding;
+
+use TEC\Common\LiquidWeb\Harbor\Config;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Product_Collection;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Repositories\License_Repository;
+use TEC\Common\LiquidWeb\Harbor\Licensing\Results\Product_Entry;
+use TEC\Common\LiquidWeb\Harbor\Portal\Activation_Url;
+
+/**
+ * Class License_Data
+ *
+ * Whether this site has activated the calendar, and where to send a user who
+ * still has something to do about it. Sits alongside Data, which answers the
+ * same shape of question about the calendar's own settings, so that the pages
+ * consuming both stay about rendering rather than about Harbor.
+ *
+ * Every method degrades to "nothing to offer" — false, null or an empty string —
+ * when the bundled Harbor library is older than the API it needs. Callers can
+ * treat that as "hide the UI" without repeating the version checks themselves.
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\Admin\Onboarding
+ */
+class License_Data {
+
+	/**
+	 * The product slug the calendar is licensed under in the Liquid Web catalog.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const PRODUCT_SLUG = 'the-events-calendar';
+
+	/**
+	 * Whether the bundled Harbor library can build an activation URL at all.
+	 *
+	 * Older copies predate the activation URL API. Callers guard on this, some
+	 * to skip work they would only discard and some because they cannot proceed
+	 * without it, so it lives here rather than as a duplicated class_exists()
+	 * call at each site.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the activation URL service is available.
+	 */
+	public function can_build_activation_url(): bool {
+		return class_exists( Activation_Url::class );
+	}
+
+	/**
+	 * Get the URL that sends a user to the portal to activate a license, for
+	 * callers that only want one while the user still has something to do.
+	 *
+	 * Returns an empty string when there is nothing to be done: either the
+	 * bundled Harbor library predates the activation URL API, or the site
+	 * already holds a valid activated license. The onboarding wizard treats an
+	 * empty string as "hide the button".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $return_url Where the portal returns the user afterwards.
+	 *
+	 * @return string The activation URL, or an empty string when unavailable.
+	 */
+	public function get_activation_url( string $return_url ): string {
+		// Cheapest check first: with no way to build a URL there is no reason to
+		// read licensing state to find out whether we would have wanted one.
+		if ( ! $this->can_build_activation_url() ) {
+			return '';
+		}
+
+		if ( $this->is_activated() ) {
+			return '';
+		}
+
+		return $this->build_activation_url( $return_url );
+	}
+
+	/**
+	 * Build the activation URL whatever this site's activation state.
+	 *
+	 * The portal returns the user to the given address once they are done, so
+	 * they pick up where they left off.
+	 *
+	 * When the stored license already covers the calendar, the URL is scoped to
+	 * the product and tier so the portal pre-selects the right subscription.
+	 * Otherwise the user lands on their subscription list and picks it
+	 * themselves, which is the best that can be done without knowing what they
+	 * hold.
+	 *
+	 * Callers that only want a URL for a user with something left to do should
+	 * use get_activation_url() instead. This one answers the narrower question
+	 * of whether a URL can be built at all, which the setup guide needs so it
+	 * can show a step as done rather than hide it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $return_url Where the portal returns the user afterwards.
+	 *
+	 * @return string The activation URL, or an empty string when the bundled
+	 *                Harbor library cannot build one.
+	 */
+	public function build_activation_url( string $return_url ): string {
+		if ( ! $this->can_build_activation_url() ) {
+			return '';
+		}
+
+		$builder     = tribe( Activation_Url::class );
+		$entitlement = $this->get_licensed_entry();
+
+		if ( ! $entitlement instanceof Product_Entry ) {
+			return $builder->get_base( $return_url );
+		}
+
+		return $builder->for_product(
+			$entitlement->get_product_slug(),
+			$entitlement->get_tier(),
+			$return_url
+		);
+	}
+
+	/**
+	 * Get the URL of the portal's subscriptions screen, where a user manages a
+	 * license that is already activated on this site.
+	 *
+	 * There is nothing left to activate at that point, so callers send the user
+	 * straight to the screen they manage the license from rather than back
+	 * through the activation flow. This is the same destination Harbor's own
+	 * licensing UI uses for its "Manage license" link.
+	 *
+	 * The base URL carries no trailing slash, so the path supplies its own.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The subscriptions URL, or an empty string when the bundled
+	 *                Harbor library cannot supply one.
+	 */
+	public function get_management_url(): string {
+		if ( ! class_exists( Config::class ) ) {
+			return '';
+		}
+
+		return Config::get_portal_base_url() . '/subscriptions/';
+	}
+
+	/**
+	 * Whether this site already holds a valid, activated license for the calendar.
+	 *
+	 * Mirrors the check Harbor's own license UI makes: an entry counts only when
+	 * it is activated against this domain and its entitlement is currently
+	 * valid. A key that exists but has not been activated here does not count,
+	 * because the user still has something to do in the portal.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True when the calendar is licensed and activated on this site.
+	 */
+	public function is_activated(): bool {
+		$products = $this->get_products();
+
+		if ( ! $products instanceof Product_Collection ) {
+			return false;
+		}
+
+		$entry = $products->get_activated_entry( self::PRODUCT_SLUG );
+
+		return $entry instanceof Product_Entry && $entry->is_valid();
+	}
+
+	/**
+	 * Get the licensed entry for the calendar, whatever its activation state.
+	 *
+	 * Used to scope the activation URL. The tier is known as soon as the key
+	 * covers the product, well before it has been activated on this domain, so
+	 * this deliberately does not filter on activation.
+	 *
+	 * Returns the first entry when a key covers several tiers. Picking between
+	 * them is the portal's job, and it still receives the product either way.
+	 *
+	 * @since TBD
+	 *
+	 * @return Product_Entry|null The entry, or null when the key does not cover the calendar.
+	 */
+	protected function get_licensed_entry(): ?Product_Entry {
+		$products = $this->get_products();
+
+		if ( ! $products instanceof Product_Collection ) {
+			return null;
+		}
+
+		$entries = $products->get_all_by_slug( self::PRODUCT_SLUG );
+
+		return $entries ? reset( $entries ) : null;
+	}
+
+	/**
+	 * Get the licensed products Harbor holds for this site.
+	 *
+	 * Harbor returns a WP_Error when its last fetch failed, and null when it has
+	 * never fetched. Neither is something the onboarding UI can act on, so both
+	 * are flattened to null here and read by callers as "no license".
+	 *
+	 * @since TBD
+	 *
+	 * @return Product_Collection|null The products, or null when unavailable.
+	 */
+	protected function get_products(): ?Product_Collection {
+		if ( ! class_exists( License_Repository::class ) ) {
+			return null;
+		}
+
+		$products = tribe( License_Repository::class )->get_products();
+
+		return $products instanceof Product_Collection ? $products : null;
+	}
+}

--- a/src/resources/packages/wizard/components/buttons/activate.tsx
+++ b/src/resources/packages/wizard/components/buttons/activate.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { SETTINGS_STORE_KEY } from '../../data';
+
+/**
+ * Sends the user to the Liquid Web portal to activate a license.
+ *
+ * The URL is built server side and carries a return address, so the portal
+ * brings the user back to the guided setup once they are done.
+ *
+ * Renders nothing when no URL was supplied, which is the case on installs
+ * whose bundled Harbor library predates the activation URL API.
+ */
+const ActivateButton = () => {
+	const activationUrl = useSelect( ( select ) => select( SETTINGS_STORE_KEY ).getSetting( 'activationUrl' ), [] );
+
+	if ( ! activationUrl ) {
+		return null;
+	}
+
+	return (
+		<Button
+			variant="secondary"
+			href={ activationUrl }
+			className="tec-events-onboarding__button tec-events-onboarding__button--activate"
+		>
+			{ __( 'Activate license', 'the-events-calendar' ) }
+		</Button>
+	);
+};
+
+export default ActivateButton;

--- a/src/resources/packages/wizard/components/tabs/welcome/tab.tsx
+++ b/src/resources/packages/wizard/components/tabs/welcome/tab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import SetupButton from '../../buttons/setup';
+import ActivateButton from '../../buttons/activate';
 import ExitButton from '../../buttons/exit';
 import OptInCheckbox from './inputs/opt-in';
 import Illustration from './img/wizard-welcome-img.png';
@@ -46,7 +47,10 @@ const WelcomeContent = ( { moveToNextTab, skipToNextTab } ) => {
 				</p>
 			</div>
 			<div className="tec-events-onboarding__tab-content">
-				<SetupButton tabSettings={ tabSettings } moveToNextTab={ moveToNextTab } />
+				<div className="tec-events-onboarding__button-group">
+					<SetupButton tabSettings={ tabSettings } moveToNextTab={ moveToNextTab } />
+					<ActivateButton />
+				</div>
 				<ExitButton />
 			</div>
 			<div className="tec-events-onboarding__tab-footer">

--- a/src/resources/packages/wizard/index.css
+++ b/src/resources/packages/wizard/index.css
@@ -424,6 +424,29 @@
 	margin: 0 auto;
 }
 
+/* Lays sibling buttons on one row, wrapping to their own lines when narrow. */
+.tec-events-onboarding__button-group {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--tec-spacer-4);
+	justify-content: center;
+	margin: 0 auto;
+}
+
+/*
+ * The auto side margins that centre a lone button absorb all the free space
+ * once it is a flex item, which spreads the buttons out and leaves the gap
+ * above with nothing to do. Zero them so justify-content and gap take over.
+ */
+.tec-events-onboarding__button-group > .tec-events-onboarding__button,
+.tec-events-onboarding__button-group > .tec-events-onboarding__button.is-primary,
+.tec-events-onboarding__button-group > .tec-events-onboarding__button.is-secondary,
+.tec-events-onboarding__button-group > .tec-events-onboarding__button.is-tertiary {
+	margin-left: 0;
+	margin-right: 0;
+}
+
 @media (min-width: 500px) {
 
 	.tec-events-onboarding__tab-content {

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -25,7 +25,7 @@ use RuntimeException;
 class Landing_Page_License_Step_Test extends WPTestCase {
 
 	/**
-	 * A stand-in for a URL built by Harbor's Activation_Url service.
+	 * A stand-in for a URL built by Harbor's activation URL API.
 	 *
 	 * @since TBD
 	 *

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -9,6 +9,7 @@
 namespace TEC\Events\Admin\Onboarding;
 
 use ReflectionMethod;
+use RuntimeException;
 use TEC\Common\LiquidWeb\Harbor\Config;
 use Tribe\Tests\Traits\With_Uopz;
 use Codeception\TestCase\WPTestCase;
@@ -88,6 +89,28 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
+	 * Pull the opening anchor tag pointing at a given URL out of rendered markup,
+	 * so attributes can be asserted on that link alone rather than on the whole
+	 * checklist, which carries plenty of other links.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $markup The rendered markup.
+	 * @param string $url    The URL the anchor points at, unescaped.
+	 *
+	 * @return string The opening tag.
+	 */
+	protected function open_tag_for( string $markup, string $url ): string {
+		$pattern = '/<a\s[^>]*' . preg_quote( esc_url( $url ), '/' ) . '[^>]*>/';
+
+		preg_match( $pattern, $markup, $matches );
+
+		$this->assertNotEmpty( $matches, "No anchor found pointing at {$url}." );
+
+		return $matches[0];
+	}
+
+	/**
 	 * @test
 	 * @since TBD
 	 */
@@ -148,6 +171,38 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
+	 * Managing a license has no return trip, so the page has to stay open behind
+	 * it. Activating does have one, and sending that round trip to a tab the user
+	 * has left behind would strand them on a stale step.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_open_only_the_management_link_in_a_new_tab() {
+		$activating = $this->open_tag_for( $this->render_checklist( self::ACTIVATION_URL, false ), self::ACTIVATION_URL );
+		$activated  = $this->open_tag_for( $this->render_checklist( self::ACTIVATION_URL, true ), self::PORTAL_URL );
+
+		$this->assertStringNotContainsString( 'target=', $activating );
+		$this->assertStringContainsString( 'target="_blank"', $activated );
+		$this->assertStringContainsString( 'rel="nofollow noopener"', $activated );
+	}
+
+	/**
+	 * Both destinations leave WordPress, so both carry the external-link
+	 * affordance every other off-site link on this page uses.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_mark_both_destinations_as_external() {
+		foreach ( [ false, true ] as $activated ) {
+			$output = $this->render_checklist( self::ACTIVATION_URL, $activated );
+
+			$this->assertStringContainsString( 'tec-admin-page__link--external', $output );
+		}
+	}
+
+	/**
 	 * @test
 	 * @since TBD
 	 */
@@ -155,6 +210,57 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 		$output = $this->render_checklist( self::ACTIVATION_URL, false );
 
 		$this->assertStringNotContainsString( 'Manage license', $output );
+	}
+
+	/**
+	 * The wizard button is gated by get_license_activation_url(), which was
+	 * restructured when the builder was split out of it. These three pin the
+	 * behaviour that split could have quietly changed — most of all the button
+	 * reappearing on a site that has already activated.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_give_the_wizard_a_url_while_there_is_something_to_activate() {
+		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', true );
+		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', self::ACTIVATION_URL );
+		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', false );
+
+		$this->assertSame( self::ACTIVATION_URL, $this->landing_page->get_license_activation_url() );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_hide_the_wizard_button_once_the_license_is_activated() {
+		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', true );
+		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', self::ACTIVATION_URL );
+		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', true );
+
+		$this->assertSame( '', $this->landing_page->get_license_activation_url() );
+	}
+
+	/**
+	 * The cheap gate short-circuits before any licensing state is read, so this
+	 * also pins the ordering: a stub that would explode if reached proves
+	 * has_activated_license() is never called.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_hide_the_wizard_button_when_harbor_cannot_build_a_url() {
+		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', false );
+		$this->set_class_fn_return(
+			Landing_Page::class,
+			'has_activated_license',
+			static function () {
+				throw new RuntimeException( 'Licensing state should not be read when no URL can be built.' );
+			},
+			true
+		);
+
+		$this->assertSame( '', $this->landing_page->get_license_activation_url() );
 	}
 
 	/**
@@ -207,6 +313,23 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 		$this->assertStringNotContainsString( 'tec-events-onboarding-wizard-license-item', $output );
 		$this->assertStringNotContainsString( 'License activated', $output );
 		$this->assertStringNotContainsString( 'Activate license', $output );
+	}
+
+	/**
+	 * An activated license on a site whose Harbor is too old to build a URL. The
+	 * step could arguably show as complete, but there is nowhere to send the user
+	 * and no way to refresh what is shown, so it stays out of the list entirely.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_omit_the_step_when_activated_but_harbor_cannot_build_a_url() {
+		$output = $this->render_checklist( '', true );
+
+		$this->assertStringNotContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringNotContainsString( 'License activated', $output );
+		$this->assertStringNotContainsString( 'Manage license', $output );
+		$this->assertRegExp( '#\d+/5 steps completed#', $output );
 	}
 
 	/**

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -318,20 +318,28 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
-	 * Activating is the first thing a user should do, so the step leads the list.
+	 * The checklist keeps leading with the calendar setup a new user came here to
+	 * do, so the license step closes the list rather than opening it.
+	 *
+	 * Pinned against the venue step, which is the last of the calendar steps: an
+	 * assertion against only the first step would still pass if the license item
+	 * landed somewhere in the middle.
 	 *
 	 * @test
 	 * @since TBD
 	 */
-	public function it_should_place_the_license_step_first_in_the_list() {
+	public function it_should_place_the_license_step_last_in_the_list() {
 		$output = $this->render_checklist( self::ACTIVATION_URL, false );
 
 		$license_position = strpos( $output, 'tec-events-onboarding-wizard-license-item' );
 		$views_position   = strpos( $output, 'tec-events-onboarding-wizard-views-item' );
+		$venue_position   = strpos( $output, 'tec-events-onboarding-wizard-venue-item' );
 
 		$this->assertNotFalse( $license_position, 'The license step should be rendered.' );
 		$this->assertNotFalse( $views_position, 'The calendar views step should be rendered.' );
-		$this->assertLessThan( $views_position, $license_position );
+		$this->assertNotFalse( $venue_position, 'The event venue step should be rendered.' );
+		$this->assertGreaterThan( $views_position, $license_position );
+		$this->assertGreaterThan( $venue_position, $license_position );
 	}
 
 	/**

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Tests for the license activation step in the Setup Guide checklist.
+ * Tests for the license activation step in the Setup Guide checklist, and for
+ * the licensing questions behind it.
  *
  * @package TEC\Events\Admin\Onboarding
  * @since   TBD
@@ -8,24 +9,20 @@
 
 namespace TEC\Events\Admin\Onboarding;
 
-use ReflectionMethod;
-use RuntimeException;
-use TEC\Common\LiquidWeb\Harbor\Config;
-use Tribe\Tests\Traits\With_Uopz;
 use Codeception\TestCase\WPTestCase;
+use RuntimeException;
 
 /**
  * Class Landing_Page_License_Step_Test
  *
- * The step is driven by two things the site cannot control from a test: whether
- * the bundled Harbor library can build an activation URL, and whether this
- * domain already holds a valid activated license. Both are stubbed here so each
- * combination can be rendered on demand.
+ * The step is driven by licensing state no test can arrange for real: whether
+ * the bundled Harbor library has the activation URL API, and whether this domain
+ * holds an activated license. Both live behind License_Data, so a stand-in bound
+ * into the container covers every combination.
  *
  * @since TBD
  */
 class Landing_Page_License_Step_Test extends WPTestCase {
-	use With_Uopz;
 
 	/**
 	 * A stand-in for a URL built by Harbor's Activation_Url service.
@@ -68,19 +65,87 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
+	 * Hand the container back a real License_Data, so a stand-in bound by one
+	 * test cannot answer for the next.
+	 *
+	 * @after
+	 *
+	 * @since TBD
+	 */
+	public function restore_license_data() {
+		tribe_singleton( License_Data::class, License_Data::class );
+	}
+
+	/**
+	 * Bind a License_Data that reports the licensing state a test needs.
+	 *
+	 * Only the three questions that read the outside world are answered here.
+	 * get_activation_url() is deliberately left alone so its real gating logic
+	 * runs against these answers rather than being stubbed out with them.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $activation_url The URL Harbor can build, or '' when it cannot.
+	 * @param bool   $activated      Whether the calendar is activated on this site.
+	 *
+	 * @return void
+	 */
+	protected function bind_license_data( string $activation_url, bool $activated ): void {
+		$stand_in = new class( $activation_url, $activated, self::PORTAL_URL ) extends License_Data {
+
+			/**
+			 * @var string
+			 */
+			private $activation_url;
+
+			/**
+			 * @var bool
+			 */
+			private $activated;
+
+			/**
+			 * @var string
+			 */
+			private $management_url;
+
+			public function __construct( string $activation_url, bool $activated, string $management_url ) {
+				$this->activation_url = $activation_url;
+				$this->activated      = $activated;
+				$this->management_url = $management_url;
+			}
+
+			public function can_build_activation_url(): bool {
+				return '' !== $this->activation_url;
+			}
+
+			public function build_activation_url( string $return_url ): string {
+				return $this->activation_url;
+			}
+
+			public function is_activated(): bool {
+				return $this->activated;
+			}
+
+			public function get_management_url(): string {
+				return $this->management_url;
+			}
+		};
+
+		tribe_singleton( License_Data::class, $stand_in );
+	}
+
+	/**
 	 * Render the checklist section and hand back its markup.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $activation_url The URL Harbor can build, or an empty string when it cannot.
-	 * @param bool   $activated      Whether the calendar is licensed and activated on this site.
+	 * @param string $activation_url The URL Harbor can build, or '' when it cannot.
+	 * @param bool   $activated      Whether the calendar is activated on this site.
 	 *
 	 * @return string The rendered markup.
 	 */
 	protected function render_checklist( string $activation_url, bool $activated ): string {
-		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', $activation_url );
-		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', $activated );
-		$this->set_class_fn_return( Landing_Page::class, 'get_license_management_url', self::PORTAL_URL );
+		$this->bind_license_data( $activation_url, $activated );
 
 		ob_start();
 		$this->landing_page->admin_content_checklist_section();
@@ -171,6 +236,16 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_not_offer_license_management_before_activation() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$this->assertStringNotContainsString( 'Manage license', $output );
+	}
+
+	/**
 	 * Managing a license has no return trip, so the page has to stay open behind
 	 * it. Activating does have one, and sending that round trip to a tab the user
 	 * has left behind would strand them on a stale step.
@@ -200,90 +275,6 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 
 			$this->assertStringContainsString( 'tec-admin-page__link--external', $output );
 		}
-	}
-
-	/**
-	 * @test
-	 * @since TBD
-	 */
-	public function it_should_not_offer_license_management_before_activation() {
-		$output = $this->render_checklist( self::ACTIVATION_URL, false );
-
-		$this->assertStringNotContainsString( 'Manage license', $output );
-	}
-
-	/**
-	 * The wizard button is gated by get_license_activation_url(), which was
-	 * restructured when the builder was split out of it. These three pin the
-	 * behaviour that split could have quietly changed — most of all the button
-	 * reappearing on a site that has already activated.
-	 *
-	 * @test
-	 * @since TBD
-	 */
-	public function it_should_give_the_wizard_a_url_while_there_is_something_to_activate() {
-		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', true );
-		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', self::ACTIVATION_URL );
-		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', false );
-
-		$this->assertSame( self::ACTIVATION_URL, $this->landing_page->get_license_activation_url() );
-	}
-
-	/**
-	 * @test
-	 * @since TBD
-	 */
-	public function it_should_hide_the_wizard_button_once_the_license_is_activated() {
-		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', true );
-		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', self::ACTIVATION_URL );
-		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', true );
-
-		$this->assertSame( '', $this->landing_page->get_license_activation_url() );
-	}
-
-	/**
-	 * The cheap gate short-circuits before any licensing state is read, so this
-	 * also pins the ordering: a stub that would explode if reached proves
-	 * has_activated_license() is never called.
-	 *
-	 * @test
-	 * @since TBD
-	 */
-	public function it_should_hide_the_wizard_button_when_harbor_cannot_build_a_url() {
-		$this->set_class_fn_return( Landing_Page::class, 'can_build_activation_url', false );
-		$this->set_class_fn_return(
-			Landing_Page::class,
-			'has_activated_license',
-			static function () {
-				throw new RuntimeException( 'Licensing state should not be read when no URL can be built.' );
-			},
-			true
-		);
-
-		$this->assertSame( '', $this->landing_page->get_license_activation_url() );
-	}
-
-	/**
-	 * The portal's base URL carries no trailing slash, so the path has to supply
-	 * its own. Guards against that assumption drifting and producing a double
-	 * slash, or the path being dropped altogether.
-	 *
-	 * @test
-	 * @since TBD
-	 */
-	public function it_should_point_license_management_at_the_subscriptions_screen() {
-		if ( ! class_exists( Config::class ) ) {
-			$this->markTestSkipped( 'The bundled Harbor library predates the portal Config class.' );
-		}
-
-		$method = new ReflectionMethod( Landing_Page::class, 'get_license_management_url' );
-		$method->setAccessible( true );
-
-		$url = $method->invoke( $this->landing_page );
-
-		$this->assertStringStartsWith( 'http', $url );
-		$this->assertStringEndsWith( '/subscriptions/', $url );
-		$this->assertStringNotContainsString( '//subscriptions/', $url );
 	}
 
 	/**
@@ -368,5 +359,86 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 		$this->assertNotEmpty( $before, 'The incomplete render should report a tally out of 6.' );
 		$this->assertNotEmpty( $after, 'The complete render should report a tally out of 6.' );
 		$this->assertSame( (int) $before[1] + 1, (int) $after[1] );
+	}
+
+	/**
+	 * The wizard button is gated by get_activation_url(). These pin the two ways
+	 * it can come back empty, and most of all that it does so on a site which has
+	 * already activated.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_give_the_wizard_a_url_while_there_is_something_to_activate() {
+		$this->bind_license_data( self::ACTIVATION_URL, false );
+
+		$this->assertSame(
+			self::ACTIVATION_URL,
+			tribe( License_Data::class )->get_activation_url( 'https://example.com/return' )
+		);
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_hide_the_wizard_button_once_the_license_is_activated() {
+		$this->bind_license_data( self::ACTIVATION_URL, true );
+
+		$this->assertSame( '', tribe( License_Data::class )->get_activation_url( 'https://example.com/return' ) );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_hide_the_wizard_button_when_harbor_cannot_build_a_url() {
+		$this->bind_license_data( '', false );
+
+		$this->assertSame( '', tribe( License_Data::class )->get_activation_url( 'https://example.com/return' ) );
+	}
+
+	/**
+	 * The cheap gate short-circuits before any licensing state is read. A
+	 * stand-in that explodes if asked proves the ordering, not just the result.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_not_read_licensing_state_when_no_url_can_be_built() {
+		$stand_in = new class extends License_Data {
+
+			public function can_build_activation_url(): bool {
+				return false;
+			}
+
+			public function is_activated(): bool {
+				throw new RuntimeException( 'Licensing state should not be read when no URL can be built.' );
+			}
+		};
+
+		tribe_singleton( License_Data::class, $stand_in );
+
+		$this->assertSame( '', tribe( License_Data::class )->get_activation_url( 'https://example.com/return' ) );
+	}
+
+	/**
+	 * The portal's base URL carries no trailing slash, so the path has to supply
+	 * its own. Guards against that assumption drifting and producing a double
+	 * slash, or the path being dropped altogether.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_point_license_management_at_the_subscriptions_screen() {
+		$url = ( new License_Data() )->get_management_url();
+
+		if ( '' === $url ) {
+			$this->markTestSkipped( 'The bundled Harbor library predates the portal Config class.' );
+		}
+
+		$this->assertStringStartsWith( 'http', $url );
+		$this->assertStringEndsWith( '/subscriptions/', $url );
+		$this->assertStringNotContainsString( '//subscriptions/', $url );
 	}
 }

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -87,11 +87,14 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	 *
 	 * @param string $activation_url The URL Harbor can build, or '' when it cannot.
 	 * @param bool   $activated      Whether the calendar is activated on this site.
+	 * @param bool   $premium        Whether a premium plugin is active on this site.
+	 *                               Defaults to true: the licensing states below are
+	 *                               only reachable on a site that has one.
 	 *
 	 * @return void
 	 */
-	protected function bind_license_data( string $activation_url, bool $activated ): void {
-		$stand_in = new class( $activation_url, $activated, self::MANAGEMENT_URL ) extends License_Data {
+	protected function bind_license_data( string $activation_url, bool $activated, bool $premium = true ): void {
+		$stand_in = new class( $activation_url, $activated, self::MANAGEMENT_URL, $premium ) extends License_Data {
 
 			/**
 			 * @var string
@@ -108,10 +111,20 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 			 */
 			private $management_url;
 
-			public function __construct( string $activation_url, bool $activated, string $management_url ) {
+			/**
+			 * @var bool
+			 */
+			private $premium;
+
+			public function __construct( string $activation_url, bool $activated, string $management_url, bool $premium ) {
 				$this->activation_url = $activation_url;
 				$this->activated      = $activated;
 				$this->management_url = $management_url;
+				$this->premium        = $premium;
+			}
+
+			public function has_active_premium_plugin(): bool {
+				return $this->premium;
 			}
 
 			public function can_build_activation_url(): bool {
@@ -141,11 +154,12 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	 *
 	 * @param string $activation_url The URL Harbor can build, or '' when it cannot.
 	 * @param bool   $activated      Whether the calendar is activated on this site.
+	 * @param bool   $premium        Whether a premium plugin is active on this site.
 	 *
 	 * @return string The rendered markup.
 	 */
-	protected function render_checklist( string $activation_url, bool $activated ): string {
-		$this->bind_license_data( $activation_url, $activated );
+	protected function render_checklist( string $activation_url, bool $activated, bool $premium = true ): string {
+		$this->bind_license_data( $activation_url, $activated, $premium );
 
 		ob_start();
 		$this->landing_page->admin_content_checklist_section();
@@ -434,12 +448,83 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	public function it_should_not_read_licensing_state_when_no_url_can_be_built() {
 		$stand_in = new class extends License_Data {
 
+			public function has_active_premium_plugin(): bool {
+				return true;
+			}
+
 			public function can_build_activation_url(): bool {
 				return false;
 			}
 
 			public function is_activated(): bool {
 				throw new RuntimeException( 'Licensing state should not be read when no URL can be built.' );
+			}
+		};
+
+		tribe_singleton( License_Data::class, $stand_in );
+
+		$this->assertSame( '', tribe( License_Data::class )->get_activation_url( 'https://example.com/return' ) );
+	}
+
+	/**
+	 * The calendar is free. A site running no premium plugin has nothing a license
+	 * would unlock, so the step stays out of the checklist entirely rather than
+	 * implying activation is part of setting up the calendar.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_omit_the_step_when_no_premium_plugin_is_active() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false, false );
+
+		$this->assertStringNotContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringNotContainsString( 'License activated', $output );
+		$this->assertStringNotContainsString( 'Activate license', $output );
+		$this->assertRegExp( '#\d+/5 steps completed#', $output );
+	}
+
+	/**
+	 * The same holds once the license is activated: without a premium plugin there
+	 * is nothing to manage from here either.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_omit_the_step_when_activated_but_no_premium_plugin_is_active() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, true, false );
+
+		$this->assertStringNotContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringNotContainsString( 'Manage license', $output );
+		$this->assertRegExp( '#\d+/5 steps completed#', $output );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_hide_the_wizard_button_when_no_premium_plugin_is_active() {
+		$this->bind_license_data( self::ACTIVATION_URL, false, false );
+
+		$this->assertSame( '', tribe( License_Data::class )->get_activation_url( 'https://example.com/return' ) );
+	}
+
+	/**
+	 * The premium gate is the first question asked, so a site with nothing to
+	 * unlock never reaches the Harbor version check behind it. A stand-in that
+	 * explodes if asked proves the ordering, not just the result.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_not_ask_about_harbor_when_no_premium_plugin_is_active() {
+		$stand_in = new class extends License_Data {
+
+			public function has_active_premium_plugin(): bool {
+				return false;
+			}
+
+			public function can_build_activation_url(): bool {
+				throw new RuntimeException( 'Harbor should not be asked when no premium plugin is active.' );
 			}
 		};
 

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -34,13 +34,13 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	protected const ACTIVATION_URL = 'https://portal.example.com/subscriptions/?portal-referral=plugin';
 
 	/**
-	 * A stand-in for the portal's subscriptions screen.
+	 * A stand-in for the in-WP license manager page.
 	 *
 	 * @since TBD
 	 *
 	 * @var string
 	 */
-	protected const PORTAL_URL = 'https://portal.example.com/subscriptions/';
+	protected const MANAGEMENT_URL = 'https://site.example.com/wp-admin/options-general.php?page=lw-software-manager';
 
 	/**
 	 * The Landing_Page instance.
@@ -91,7 +91,7 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	 * @return void
 	 */
 	protected function bind_license_data( string $activation_url, bool $activated ): void {
-		$stand_in = new class( $activation_url, $activated, self::PORTAL_URL ) extends License_Data {
+		$stand_in = new class( $activation_url, $activated, self::MANAGEMENT_URL ) extends License_Data {
 
 			/**
 			 * @var string
@@ -176,6 +176,27 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
+	 * Pull the class attribute of the span wrapping the anchor for a given URL, so
+	 * a test can assert whether that link carries the external affordance.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $markup The rendered markup.
+	 * @param string $url    The URL the wrapped anchor points at, unescaped.
+	 *
+	 * @return string The wrapping span's class attribute value.
+	 */
+	protected function wrapping_span_for( string $markup, string $url ): string {
+		$pattern = '/<span class="([^"]*)">\s*<a\s[^>]*' . preg_quote( esc_url( $url ), '/' ) . '/';
+
+		preg_match( $pattern, $markup, $matches );
+
+		$this->assertNotEmpty( $matches, "No wrapped anchor found pointing at {$url}." );
+
+		return $matches[1];
+	}
+
+	/**
 	 * @test
 	 * @since TBD
 	 */
@@ -221,7 +242,7 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 
 	/**
 	 * There is nothing left to activate once the license is live, so the step
-	 * points at the portal rather than back through the activation flow.
+	 * points at the in-WP license manager rather than back through activation.
 	 *
 	 * @test
 	 * @since TBD
@@ -230,7 +251,7 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 		$output = $this->render_checklist( self::ACTIVATION_URL, true );
 
 		$this->assertStringContainsString( 'Manage license', $output );
-		$this->assertStringContainsString( esc_url( self::PORTAL_URL ), $output );
+		$this->assertStringContainsString( esc_url( self::MANAGEMENT_URL ), $output );
 		$this->assertStringNotContainsString( 'Activate license', $output );
 		$this->assertStringNotContainsString( esc_url( self::ACTIVATION_URL ), $output );
 	}
@@ -246,35 +267,40 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
-	 * Managing a license has no return trip, so the page has to stay open behind
-	 * it. Activating does have one, and sending that round trip to a tab the user
-	 * has left behind would strand them on a stale step.
+	 * Neither link opens a new tab. The activation URL carries a return address,
+	 * so a round trip to a tab the user has left behind would strand them on a
+	 * stale step; the management link stays in wp-admin, where the back button is
+	 * the way back.
 	 *
 	 * @test
 	 * @since TBD
 	 */
-	public function it_should_open_only_the_management_link_in_a_new_tab() {
+	public function it_should_not_open_either_link_in_a_new_tab() {
 		$activating = $this->open_tag_for( $this->render_checklist( self::ACTIVATION_URL, false ), self::ACTIVATION_URL );
-		$activated  = $this->open_tag_for( $this->render_checklist( self::ACTIVATION_URL, true ), self::PORTAL_URL );
+		$activated  = $this->open_tag_for( $this->render_checklist( self::ACTIVATION_URL, true ), self::MANAGEMENT_URL );
 
 		$this->assertStringNotContainsString( 'target=', $activating );
-		$this->assertStringContainsString( 'target="_blank"', $activated );
-		$this->assertStringContainsString( 'rel="nofollow noopener"', $activated );
+		$this->assertStringNotContainsString( 'target=', $activated );
 	}
 
 	/**
-	 * Both destinations leave WordPress, so both carry the external-link
-	 * affordance every other off-site link on this page uses.
+	 * The activation URL leaves WordPress for the portal, so it carries the
+	 * external-link affordance; the management link stays in wp-admin, so it does
+	 * not.
 	 *
 	 * @test
 	 * @since TBD
 	 */
-	public function it_should_mark_both_destinations_as_external() {
-		foreach ( [ false, true ] as $activated ) {
-			$output = $this->render_checklist( self::ACTIVATION_URL, $activated );
+	public function it_should_mark_only_the_activation_link_as_external() {
+		$this->assertStringContainsString(
+			'tec-admin-page__link--external',
+			$this->wrapping_span_for( $this->render_checklist( self::ACTIVATION_URL, false ), self::ACTIVATION_URL )
+		);
 
-			$this->assertStringContainsString( 'tec-admin-page__link--external', $output );
-		}
+		$this->assertStringNotContainsString(
+			'tec-admin-page__link--external',
+			$this->wrapping_span_for( $this->render_checklist( self::ACTIVATION_URL, true ), self::MANAGEMENT_URL )
+		);
 	}
 
 	/**
@@ -423,22 +449,19 @@ class Landing_Page_License_Step_Test extends WPTestCase {
 	}
 
 	/**
-	 * The portal's base URL carries no trailing slash, so the path has to supply
-	 * its own. Guards against that assumption drifting and producing a double
-	 * slash, or the path being dropped altogether.
+	 * Management sends the user to the in-WP Software Manager page Harbor
+	 * registers, not the external portal.
 	 *
 	 * @test
 	 * @since TBD
 	 */
-	public function it_should_point_license_management_at_the_subscriptions_screen() {
+	public function it_should_point_license_management_at_the_in_wp_manager() {
 		$url = ( new License_Data() )->get_management_url();
 
 		if ( '' === $url ) {
-			$this->markTestSkipped( 'The bundled Harbor library predates the portal Config class.' );
+			$this->markTestSkipped( 'The bundled Harbor library predates the activation URL API.' );
 		}
 
-		$this->assertStringStartsWith( 'http', $url );
-		$this->assertStringEndsWith( '/subscriptions/', $url );
-		$this->assertStringNotContainsString( '//subscriptions/', $url );
+		$this->assertStringContainsString( 'page=lw-software-manager', $url );
 	}
 }

--- a/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
+++ b/tests/integration/TEC/Events/Admin/Onboarding/Landing_Page_License_Step_Test.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Tests for the license activation step in the Setup Guide checklist.
+ *
+ * @package TEC\Events\Admin\Onboarding
+ * @since   TBD
+ */
+
+namespace TEC\Events\Admin\Onboarding;
+
+use ReflectionMethod;
+use TEC\Common\LiquidWeb\Harbor\Config;
+use Tribe\Tests\Traits\With_Uopz;
+use Codeception\TestCase\WPTestCase;
+
+/**
+ * Class Landing_Page_License_Step_Test
+ *
+ * The step is driven by two things the site cannot control from a test: whether
+ * the bundled Harbor library can build an activation URL, and whether this
+ * domain already holds a valid activated license. Both are stubbed here so each
+ * combination can be rendered on demand.
+ *
+ * @since TBD
+ */
+class Landing_Page_License_Step_Test extends WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * A stand-in for a URL built by Harbor's Activation_Url service.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const ACTIVATION_URL = 'https://portal.example.com/subscriptions/?portal-referral=plugin';
+
+	/**
+	 * A stand-in for the portal's subscriptions screen.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const PORTAL_URL = 'https://portal.example.com/subscriptions/';
+
+	/**
+	 * The Landing_Page instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Landing_Page
+	 */
+	protected $landing_page;
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @before
+	 *
+	 * @since TBD
+	 */
+	public function before() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->landing_page = tribe( Landing_Page::class );
+	}
+
+	/**
+	 * Render the checklist section and hand back its markup.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $activation_url The URL Harbor can build, or an empty string when it cannot.
+	 * @param bool   $activated      Whether the calendar is licensed and activated on this site.
+	 *
+	 * @return string The rendered markup.
+	 */
+	protected function render_checklist( string $activation_url, bool $activated ): string {
+		$this->set_class_fn_return( Landing_Page::class, 'build_license_activation_url', $activation_url );
+		$this->set_class_fn_return( Landing_Page::class, 'has_activated_license', $activated );
+		$this->set_class_fn_return( Landing_Page::class, 'get_license_management_url', self::PORTAL_URL );
+
+		ob_start();
+		$this->landing_page->admin_content_checklist_section();
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_offer_the_activation_link_when_the_license_is_not_activated() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$this->assertStringContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringContainsString( 'License activated', $output );
+		$this->assertStringContainsString( 'Activate license', $output );
+		$this->assertStringContainsString( esc_url( self::ACTIVATION_URL ), $output );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_not_mark_the_step_complete_when_the_license_is_not_activated() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$this->assertNotRegExp(
+			'/id="tec-events-onboarding-wizard-license-item"[^>]*onboarding-step--completed/',
+			$output
+		);
+	}
+
+	/**
+	 * The step stays on show once the license is activated, marked complete, so
+	 * the user sees a finished checklist rather than one that quietly shrinks.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_mark_the_step_complete_once_activated() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, true );
+
+		$this->assertStringContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringContainsString( 'License activated', $output );
+		$this->assertRegExp(
+			'/id="tec-events-onboarding-wizard-license-item"[^>]*onboarding-step--completed/',
+			$output
+		);
+	}
+
+	/**
+	 * There is nothing left to activate once the license is live, so the step
+	 * points at the portal rather than back through the activation flow.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_swap_the_link_for_license_management_once_activated() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, true );
+
+		$this->assertStringContainsString( 'Manage license', $output );
+		$this->assertStringContainsString( esc_url( self::PORTAL_URL ), $output );
+		$this->assertStringNotContainsString( 'Activate license', $output );
+		$this->assertStringNotContainsString( esc_url( self::ACTIVATION_URL ), $output );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_not_offer_license_management_before_activation() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$this->assertStringNotContainsString( 'Manage license', $output );
+	}
+
+	/**
+	 * The portal's base URL carries no trailing slash, so the path has to supply
+	 * its own. Guards against that assumption drifting and producing a double
+	 * slash, or the path being dropped altogether.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_point_license_management_at_the_subscriptions_screen() {
+		if ( ! class_exists( Config::class ) ) {
+			$this->markTestSkipped( 'The bundled Harbor library predates the portal Config class.' );
+		}
+
+		$method = new ReflectionMethod( Landing_Page::class, 'get_license_management_url' );
+		$method->setAccessible( true );
+
+		$url = $method->invoke( $this->landing_page );
+
+		$this->assertStringStartsWith( 'http', $url );
+		$this->assertStringEndsWith( '/subscriptions/', $url );
+		$this->assertStringNotContainsString( '//subscriptions/', $url );
+	}
+
+	/**
+	 * Activating is the first thing a user should do, so the step leads the list.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_place_the_license_step_first_in_the_list() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$license_position = strpos( $output, 'tec-events-onboarding-wizard-license-item' );
+		$views_position   = strpos( $output, 'tec-events-onboarding-wizard-views-item' );
+
+		$this->assertNotFalse( $license_position, 'The license step should be rendered.' );
+		$this->assertNotFalse( $views_position, 'The calendar views step should be rendered.' );
+		$this->assertLessThan( $views_position, $license_position );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_omit_the_step_when_harbor_cannot_build_a_url() {
+		$output = $this->render_checklist( '', false );
+
+		$this->assertStringNotContainsString( 'tec-events-onboarding-wizard-license-item', $output );
+		$this->assertStringNotContainsString( 'License activated', $output );
+		$this->assertStringNotContainsString( 'Activate license', $output );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_count_the_step_in_the_total_when_it_is_shown() {
+		$output = $this->render_checklist( self::ACTIVATION_URL, false );
+
+		$this->assertRegExp( '#\d+/6 steps completed#', $output );
+	}
+
+	/**
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_leave_the_total_alone_when_the_step_is_hidden() {
+		$output = $this->render_checklist( '', false );
+
+		$this->assertRegExp( '#\d+/5 steps completed#', $output );
+	}
+
+	/**
+	 * An activated license is a completed step, so it has to move the tally too.
+	 *
+	 * @test
+	 * @since TBD
+	 */
+	public function it_should_count_an_activated_license_as_a_completed_step() {
+		$incomplete = $this->render_checklist( self::ACTIVATION_URL, false );
+		$complete   = $this->render_checklist( self::ACTIVATION_URL, true );
+
+		preg_match( '#(\d+)/6 steps completed#', $incomplete, $before );
+		preg_match( '#(\d+)/6 steps completed#', $complete, $after );
+
+		$this->assertNotEmpty( $before, 'The incomplete render should report a tally out of 6.' );
+		$this->assertNotEmpty( $after, 'The complete render should report a tally out of 6.' );
+		$this->assertSame( (int) $before[1] + 1, (int) $after[1] );
+	}
+}


### PR DESCRIPTION
Relates to [SMTNC-1834](https://linear.app/nexcess/issue/SMTNC-1834/add-activation-ui-to-tec-pro-onboarding) · Parent: [SMTNC-1833](https://linear.app/nexcess/issue/SMTNC-1833/add-activation-ui-to-first-step-of-all-product-onboarding)

## Summary

Onboarding had no route to activating a license — a user who had bought TEC but not activated it here had to find the portal themselves, then find their way back.

This adds that route in both places onboarding appears:

- **Guided setup wizard** — an **Activate license** button beside "Set up my calendar".
- **Setup Guide page** — a **License activated** step at the head of the first-time setup checklist.

Both carry a return address, so the portal brings the user back where they left off.

**Neither appears unless the site runs an active premium plugin.** The calendar is free, and a license only unlocks the premium plugins built on top of it — so a site running none of them is never shown licensing UI implying otherwise.

## Artifact

(new audio)
https://www.loom.com/share/f86c82af864541fb9600ddcb8ce7bf03

<img width="1099" height="896" alt="Screenshot 2026-07-23 162127" src="https://github.com/user-attachments/assets/5e06e231-111c-4094-b9a1-48ce127703b8" />

<img width="1879" height="1094" alt="Screenshot 2026-07-23 161405" src="https://github.com/user-attachments/assets/288f475d-ac39-430f-8965-80717b62afd9" />

<img width="1732" height="1004" alt="Screenshot 2026-07-23 161527" src="https://github.com/user-attachments/assets/495b240b-62c6-49d5-b78d-ad120042c3da" />

## ⚠️ Inert until the Harbor bump

TEC bundles Harbor 1.4.0, whose global functions do not yet include the activation-URL API (`lw_harbor_get_activation_url()` / `lw_harbor_get_product_activation_url()`) — those arrive in [stellarwp/harbor#181](https://github.com/stellarwp/harbor/pull/181). Following review there, the onboarding calls those stable global functions rather than resolving Harbor's `Activation_Url` class from the container: the functions always resolve to the loaded, highest-version Harbor copy, so a consumer is never tied to whichever version it happens to bundle.

Both entry points gate on `can_build_activation_url()` — now a `function_exists()` check on those global functions — and return `''` when they are missing. The React component renders `null`; the checklist step is skipped *and* left out of its "steps completed" tally, so the count stays correct. On today's `main` neither appears — no fatal, no broken link.

Safe to merge whenever; starts working on its own once Harbor lands. It does mean **neither is visible on a clean checkout** — see Testing.

## What changed

| File | Change |
| --- | --- |
| `Admin/Onboarding/License_Data.php` | **New** — every licensing question the onboarding UI asks, including whether a premium plugin is active at all |
| `Admin/Onboarding/Landing_Page.php` | The new checklist step, gated on an active premium plugin; delegates all licensing to the above |
| `Admin/Onboarding/Controller.php` | Registers the new service |
| `wizard/components/buttons/activate.tsx` | New — secondary `Button`, renders `null` on an empty URL |
| `wizard/components/tabs/welcome/tab.tsx` | Wraps both buttons in a flex group |
| `wizard/index.css` | The button group |
| `…/Landing_Page_License_Step_Test.php` | New — 22 cases |

### Why there's a new service

The licensing logic first landed as six methods on `Landing_Page`, which left a class whose job is *rendering an admin page* knowing about Harbor's license repository, product collections, entitlement validity and portal URL formats. Those change for entirely different reasons than the page layout does.

The pattern to follow was already in the same namespace: **`Data`** is a container-resolved class holding exactly this kind of "fetch the state the onboarding UI needs" logic, and `Landing_Page` already delegates its organizer, venue, view and wizard-settings lookups to it. Licensing was the only such lookup that ended up on the page instead.

`License_Data` now sits beside `Data`, and **`Landing_Page` carries no Harbor references at all**. The service takes the return address as a parameter rather than reading `Landing_Page::$slug`, so it knows nothing about the page consuming it and the dependency runs one way.

It is registered in `Controller.php` as a `singleton()`, alongside `Data` and `Landing_Page`.

## Review notes

**1. The checklist step behaves differently from the wizard button — on purpose.** The button disappears once the license is live; the step stays and marks itself complete. A checklist that shrinks as you finish it is worse than one that fills in.

That is why `License_Data` exposes two URL methods rather than one. A single one had conflated two questions:

| Method | Question | Empty when… |
| --- | --- | --- |
| `build_activation_url()` | Can a URL be built at all? | Harbor is too old |
| `get_activation_url()` | Has the user still got something to do? | …that, **or** already activated |

The wizard wants the second, so its button disappears. The checklist wants the first, so it can render the step as **done** rather than hide it.

The step's link follows the state:

| State | Link | Destination | New tab |
| --- | --- | --- | --- |
| Not activated | Activate license | scoped activation URL, returns here | **No** |
| Activated | Manage license | in-WP Software Manager (`options-general.php?page=lw-software-manager`) | **No** |
| Harbor too old | — | step not rendered, not counted | — |

**Neither link opens a new tab, and only the activation link is external.** Before activation the link leaves WordPress for the portal, so it navigates in place — the activation URL carries a return address, and a round trip to a tab the user has wandered away from would strand them looking at a stale step — and carries the `tec-admin-page__link--external` affordance. Once activated the management link stays in wp-admin, so it navigates in place too (the browser back button is the way back) and drops the external affordance.

Management points at the in-WP **Software Manager** page Harbor registers (`options-general.php?page=lw-software-manager`, via `lw_harbor_get_license_page_url()`) — where an activated user manages their products without leaving the site, matching the LearnDash onboarding. There's a test pinning it.

**2. Step order and `$condition` are deliberately independent.** The step leads the list, but `$condition` only feeds the tally — `count()` and `array_filter()` don't care about order — so the existing `$condition[0..4]` references are untouched and the new entry is simply appended. **Please keep these independent** rather than reordering the array to match the markup; that would reintroduce the positional coupling. Tally goes `5` → `6` when the step shows.

**3. `is_activated()` vs `get_licensed_entry()` are not redundant.** The first filters on activation, the second doesn't. That second one is what lets the URL be scoped: the tier is known as soon as the key covers the product, well before activation, so `sku=the-events-calendar%3Aelite` can be set on exactly the installs this targets and the portal pre-selects the right subscription. No covering key, no tier to name — the user lands on their subscription list instead.

<details>
<summary>CSS note — why the margin override matters</summary>

`.tec-events-onboarding__tab-content` is a grid, so the buttons stacked. They're now a flex row with a 20px gap (`--tec-spacer-4`), which needed:

```css
.tec-events-onboarding__button-group > .tec-events-onboarding__button,
… > .tec-events-onboarding__button.is-primary,   /* + is-secondary, is-tertiary */
{
	margin-left: 0;
	margin-right: 0;
}
```

The existing rule centres a lone button with `margin: 0 auto`. Auto margins absorb all free space once the element is a flex item, spreading the buttons apart and leaving `gap` nothing to distribute. Zeroing them hands centring back to `justify-content`. Please keep this if the group is refactored. `flex-wrap: wrap` restores stacking on narrow viewports.

The checklist step needed no new CSS — it reuses `step-list__item` and `tec-admin-page__onboarding-step--completed`.
</details>

**4. The premium plugin gate.** The calendar is free on wp.org, and a license only unlocks the premium plugins built on top of it — so offering activation UI to a site running none of them would imply a license is part of setting the calendar up. `License_Data::has_active_premium_plugin()` gates both surfaces: the wizard button via `get_activation_url()`, the checklist step via an empty `$license_url`.

It delegates to Common's own `Tribe__Dependency::has_active_premium_plugin()` rather than keeping a second list of premium plugins here. Deliberately **not** the `lw_harbor/premium_plugin_exists` filter: that one is cross-brand by design, so an unrelated brand's premium plugin would have switched the calendar's onboarding on.

## Testing

Verified against a real install with Harbor's API manually injected, using live license data on a site holding an `elite` key that covers the calendar without being activated here:

```text
the-events-calendar    activated_entry=no    -> shown        entry=yes   sku=the-events-calendar%3Aelite
learndash              activated_entry=yes   -> HIDDEN
kadence                activated_entry=no    -> shown
not-a-real-product                                           entry=no    sku=(none)
```

Layout and labels confirmed in the browser.

The 22 new tests run in CI (`test (integration)`).

They cover the checklist step in every state, plus `get_activation_url()`'s gating directly. A stand-in `License_Data` is bound into the container, overriding only the four methods that read the outside world — so the real gating logic runs against those answers rather than being stubbed out with them. Two cases bind a stand-in that **throws** if the next question is asked, which pins the guard *ordering* rather than just its result: the premium gate short-circuits before Harbor is asked anything, and the Harbor check short-circuits before licensing state is read.

**Checks:** `php -l` clean; **phpcs clean on the added lines** — warnings are back to the pre-change baseline of 13, all on pre-existing sibling arrays; eslint clean on `activate.tsx`; stylelint unchanged at 38 pre-existing errors in `index.css`, none in the new block.

<details>
<summary>How to see this before the Harbor bump</summary>

Update `common`'s bundled Harbor to the stellarwp/harbor#181 branch (or cherry-pick the activation-URL API into `common/vendor/vendor-prefixed/stellarwp/harbor/`) so the `lw_harbor_get_activation_url()` / `lw_harbor_get_product_activation_url()` global functions register. Because the onboarding now calls those functions — defined in `global-functions.php`, loaded via Composer's `files` autoload — rather than resolving `Activation_Url` directly, the `setClassMapAuthoritative(true)` constraint that keeps new *classes* from autoloading does not apply to them.
</details>

## Before merge

- `@since TBD` on the new PHP members needs a real version.
- Depends on stellarwp/harbor#181 and a Harbor bump in `common`.

*Unrelated:* in Firefox the wizard button opens the portal in a new window. Nothing in this branch, TEC, common, Harbor, or WP core's `Button` sets a `target`, and Chrome is fine. Not caused by this PR — noted so it isn't filed twice.

https://claude.ai/code/session_011uxoDruAaZXzRy3hk8mr4W