### PR TITLE
Update Harbor to v1.6.0

### DIFF
--- a/changelog/chore-bump-harbor-1-6-0.yaml
+++ b/changelog/chore-bump-harbor-1-6-0.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: tweak
+entry: Improved the unified licensing page experience.
+timestamp: 2026-07-29T21:17:47.102Z

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Updated Harbor to 1.6.0, split the products list into Installed and  Available Features, added an Activate link to the product header, and improved license handling on staging and preview sites.

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Harbor to 1.6.0, splitting the products list into Installed and Available Features, adding an Activate link to the product header, and improving license handling on staging and preview sites.

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Update Harbor to 1.6.0, splitting the products list into Installed and Available Features, adding an Activate link to the product header, and improving license handling on staging and preview sites.
+Updated Harbor to 1.6.0, split the products list into Installed and  Available Features, added an Activate link to the product header, and improved license handling on staging and preview sites.


### PR DESCRIPTION
Updates the bundled Harbor library to v1.6.0.

The Events Calendar gets Harbor through the `common` submodule rather than its own `composer.json`, so the only change here is moving the submodule pointer to the tribe-common commit that carries the bump.

Verified by running a fresh `composer install` inside `common/` — the Strauss-prefixed copy reports `1.6.0`.

[SMTNC-1876](https://linear.app/nexcess/issue/SMTNC-1876/update-harbor-to-v160-in-the-events-calendar)