### PR TITLE
[SMTNC-1857] FSE Single Event template saves create single-event-N duplicates and revert the active template to default

### DIFF
--- a/changelog/smtnc-1857-fse-single-event-template-saves-create-single-event-n.yaml
+++ b/changelog/smtnc-1857-fse-single-event-template-saves-create-single-event-n.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where saving the Single Event or Calendar Views
+  template in the Site Editor could move the customization onto a numbered
+  template and restore the default layout.
+timestamp: 2026-07-29T14:02:16.624Z

--- a/src/Events/Block_Templates/Archive_Events/Archive_Block_Template.php
+++ b/src/Events/Block_Templates/Archive_Events/Archive_Block_Template.php
@@ -7,6 +7,7 @@ use Tribe__Events__Main;
 use TEC\Common\Editor\Full_Site\Template_Utils;
 use WP_Block_Template;
 use TEC\Events\Block_Templates\Block_Template_Contract;
+use TEC\Events\Block_Templates\With_Canonical_Block_Template;
 
 /**
  * Class Archive_Block_Template
@@ -17,6 +18,8 @@ use TEC\Events\Block_Templates\Block_Template_Contract;
  * @package TEC\Events\Block_Templates\Archive_Events
  */
 class Archive_Block_Template implements Block_Template_Contract {
+	use With_Canonical_Block_Template;
+
 	/**
 	 * @since 6.3.3
 	 *
@@ -95,11 +98,12 @@ class Archive_Block_Template implements Block_Template_Contract {
 	 * Creates if non-existent theme post, then returns the WP_Block_Template object for archive events.
 	 *
 	 * @since 6.2.7
+	 * @since TBD Resolves a single canonical post when duplicates claim our slug.
 	 *
 	 * @return null|WP_Block_Template The hydrated archive events template object.
 	 */
 	public function get_block_template(): ?WP_Block_Template {
-		$wp_block_template = Template_Utils::find_block_template_by_post( $this->block->slug(), $this->block->get_namespace() );
+		$wp_block_template = $this->find_canonical_block_template( $this->block->slug(), $this->block->get_namespace() );
 
 		// If empty, this is our first time loading our Block Template. Let's create it.
 		if ( ! $wp_block_template ) {

--- a/src/Events/Block_Templates/Controller.php
+++ b/src/Events/Block_Templates/Controller.php
@@ -67,6 +67,7 @@ class Controller extends Controller_Contract {
 	 */
 	protected function add_filters() {
 		add_filter( 'get_block_templates', [ $this, 'filter_include_templates' ], 25, 3 );
+		add_filter( 'pre_get_block_template', [ $this, 'filter_pre_get_block_template' ], 10, 3 );
 		add_filter( 'get_block_template', [ $this, 'filter_include_template_by_id' ], 10, 3 );
 		add_filter( 'tribe_get_option_tribeEventsTemplate', [ $this, 'filter_events_template_setting_option' ] );
 		add_filter( 'tribe_get_single_option', [ $this, 'filter_tribe_get_single_option' ], 10, 3 );
@@ -90,6 +91,7 @@ class Controller extends Controller_Contract {
 	 */
 	public function remove_filters() {
 		remove_filter( 'get_block_templates', [ $this, 'filter_include_templates' ], 25 );
+		remove_filter( 'pre_get_block_template', [ $this, 'filter_pre_get_block_template' ], 10 );
 		remove_filter( 'get_block_template', [ $this, 'filter_include_template_by_id' ], 10 );
 		remove_filter( 'tribe_get_option_tribeEventsTemplate', [ $this, 'filter_events_template_setting_option' ] );
 		remove_filter( 'tribe_get_single_option', [ $this, 'filter_tribe_get_single_option' ], 10 );
@@ -200,6 +202,30 @@ class Controller extends Controller_Contract {
 		}
 
 		return $query_result;
+	}
+
+	/**
+	 * Answers for our Block Templates before WordPress queries for them.
+	 *
+	 * WordPress resolves a template ID straight from the database and returns on the first hit, so the
+	 * `get_block_template` filter never runs once a post exists. Answering here keeps our own lookup in
+	 * charge of picking which post owns the slug, which the Site Editor save path depends on when it
+	 * loads a template directly instead of through the template list.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|WP_Block_Template $block_template The filtered template.
+	 * @param string                 $id             The block template ID.
+	 * @param string                 $template_type  The template type.
+	 *
+	 * @return null|WP_Block_Template The template when the ID is one of ours, otherwise the input.
+	 */
+	public function filter_pre_get_block_template( $block_template, $id, $template_type ) {
+		if ( null !== $block_template ) {
+			return $block_template;
+		}
+
+		return $this->filter_include_template_by_id( $block_template, $id, $template_type );
 	}
 
 	/**

--- a/src/Events/Block_Templates/Single_Event/Single_Block_Template.php
+++ b/src/Events/Block_Templates/Single_Event/Single_Block_Template.php
@@ -7,6 +7,7 @@ use Tribe__Events__Main;
 use TEC\Common\Editor\Full_Site\Template_Utils;
 use WP_Block_Template;
 use TEC\Events\Block_Templates\Block_Template_Contract;
+use TEC\Events\Block_Templates\With_Canonical_Block_Template;
 
 /**
  * Class Single_Block_Template
@@ -17,6 +18,8 @@ use TEC\Events\Block_Templates\Block_Template_Contract;
  * @package TEC\Events\Block_Templates\Single_Event
  */
 class Single_Block_Template implements Block_Template_Contract {
+	use With_Canonical_Block_Template;
+
 	/**
 	 * @since 6.3.3
 	 *
@@ -99,11 +102,12 @@ class Single_Block_Template implements Block_Template_Contract {
 	 * Creates if non-existent theme post, then returns the WP_Block_Template object for single events.
 	 *
 	 * @since 6.2.7
+	 * @since TBD Resolves a single canonical post when duplicates claim our slug.
 	 *
 	 * @return null|WP_Block_Template The hydrated single events template object.
 	 */
 	public function get_block_template(): ?WP_Block_Template {
-		$wp_block_template = Template_Utils::find_block_template_by_post( $this->block->slug(), $this->block->get_namespace() );
+		$wp_block_template = $this->find_canonical_block_template( $this->block->slug(), $this->block->get_namespace() );
 
 		// If empty, this is our first time loading our Block Template. Let's create it.
 		if ( ! $wp_block_template ) {

--- a/src/Events/Block_Templates/With_Canonical_Block_Template.php
+++ b/src/Events/Block_Templates/With_Canonical_Block_Template.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Resolves the single post that owns a Block Template slug inside our theme namespace.
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\Block_Templates
+ */
+
+namespace TEC\Events\Block_Templates;
+
+use TEC\Common\Editor\Full_Site\Template_Utils;
+use WP_Block_Template;
+use WP_Post;
+use WP_Query;
+
+/**
+ * Trait With_Canonical_Block_Template
+ *
+ * @since TBD
+ *
+ * @package TEC\Events\Block_Templates
+ */
+trait With_Canonical_Block_Template {
+	/**
+	 * Finds the post that owns a template slug in our namespace, trashing the published siblings
+	 * competing for the same slug.
+	 *
+	 * WordPress resolves `wp_template` slug uniqueness against the active stylesheet rather than
+	 * against the `wp_theme` term a post is filed under, so posts inserted into our namespace never
+	 * receive a suffix and siblings accumulate. Once two of them exist, the next Site Editor save
+	 * renames the post it writes to, stranding the customization on a `{slug}-N` post while the
+	 * slug itself resolves to a different one.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The template slug to resolve.
+	 * @param string $theme The `wp_theme` term the template is filed under.
+	 *
+	 * @return WP_Block_Template|null The hydrated template, or null when no post owns the slug.
+	 */
+	protected function find_canonical_block_template( string $slug, string $theme ): ?WP_Block_Template {
+		$posts     = $this->get_block_template_posts( $slug, $theme );
+		$canonical = array_shift( $posts );
+
+		if ( ! $canonical instanceof WP_Post ) {
+			return null;
+		}
+
+		foreach ( $posts as $duplicate ) {
+			if ( 'publish' !== $duplicate->post_status ) {
+				continue;
+			}
+
+			wp_trash_post( $duplicate->ID );
+		}
+
+		return Template_Utils::hydrate_block_template_by_post( $canonical );
+	}
+
+	/**
+	 * Reads the posts claiming a template slug in our namespace, most authoritative first.
+	 *
+	 * A published post always outranks an unpublished one, and the most recently modified post wins
+	 * within each group so the freshest customization is the one that survives consolidation.
+	 * Trashed posts are left out entirely, so a stale one can never answer for a live template.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The template slug to resolve.
+	 * @param string $theme The `wp_theme` term the template is filed under.
+	 *
+	 * @return WP_Post[] The matching posts, canonical first.
+	 */
+	protected function get_block_template_posts( string $slug, string $theme ): array {
+		$query = new WP_Query(
+			[
+				'post_name__in'       => [ $slug ],
+				'post_type'           => 'wp_template',
+				'post_status'         => [ 'publish', 'draft', 'auto-draft' ],
+				/* A namespace holds one post per slug; the ceiling only bounds an already corrupted table. */
+				'posts_per_page'      => 100,
+				'no_found_rows'       => true,
+				'ignore_sticky_posts' => true,
+				'orderby'             => [
+					'modified' => 'DESC',
+					'ID'       => 'DESC',
+				],
+				'tax_query'           => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					[
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => $theme,
+					],
+				],
+			]
+		);
+
+		$published   = [];
+		$unpublished = [];
+
+		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof WP_Post ) {
+				continue;
+			}
+
+			if ( 'publish' === $post->post_status ) {
+				$published[] = $post;
+				continue;
+			}
+
+			$unpublished[] = $post;
+		}
+
+		return array_merge( $published, $unpublished );
+	}
+}

--- a/src/Events/Block_Templates/With_Canonical_Block_Template.php
+++ b/src/Events/Block_Templates/With_Canonical_Block_Template.php
@@ -86,7 +86,7 @@ trait With_Canonical_Block_Template {
 					'modified' => 'DESC',
 					'ID'       => 'DESC',
 				],
-				'tax_query'           => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				'tax_query'           => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- The `wp_theme` term is how a block template is namespaced; there is no other way to scope this lookup.
 					[
 						'taxonomy' => 'wp_theme',
 						'field'    => 'name',

--- a/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
+++ b/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
@@ -13,7 +13,7 @@ class Single_Block_TemplateTest extends WPTestCase {
 	 *
 	 * @var string
 	 */
-	private const NAMESPACE = 'tec';
+	private const THEME = 'tec';
 
 	/**
 	 * The slug the Single Event template claims.
@@ -21,78 +21,6 @@ class Single_Block_TemplateTest extends WPTestCase {
 	 * @var string
 	 */
 	private const SLUG = 'single-event';
-
-	/**
-	 * Inserts a published `wp_template` post claiming our slug inside our namespace.
-	 *
-	 * WordPress scopes `wp_template` slug uniqueness to the active stylesheet, so repeated calls
-	 * here reproduce the customer state: several published posts all named `single-event` and all
-	 * filed under the `tec` term.
-	 *
-	 * @param string $content The post content to store.
-	 * @param int    $age     How many minutes in the past the post was last modified.
-	 *
-	 * @return int The created post ID.
-	 */
-	private function given_a_template_post( string $content, int $age = 0 ): int {
-		global $wpdb;
-
-		$post_id = wp_insert_post(
-			[
-				'post_type'    => 'wp_template',
-				'post_status'  => 'publish',
-				'post_name'    => self::SLUG,
-				'post_title'   => 'Single Event',
-				'post_content' => $content,
-			]
-		);
-
-		wp_set_post_terms( $post_id, self::NAMESPACE, 'wp_theme' );
-
-		if ( $age > 0 ) {
-			$modified = gmdate( 'Y-m-d H:i:s', strtotime( get_post( $post_id )->post_modified_gmt ) - ( $age * MINUTE_IN_SECONDS ) );
-			$wpdb->update(
-				$wpdb->posts,
-				[
-					'post_modified'     => $modified,
-					'post_modified_gmt' => $modified,
-				],
-				[ 'ID' => $post_id ]
-			);
-			clean_post_cache( $post_id );
-		}
-
-		return $post_id;
-	}
-
-	/**
-	 * Returns the IDs of every non-trashed post currently claiming our slug in our namespace.
-	 *
-	 * @return int[] The matching post IDs.
-	 */
-	private function get_posts_claiming_slug(): array {
-		$query = new WP_Query(
-			[
-				'post_name__in'  => [ self::SLUG ],
-				'post_type'      => 'wp_template',
-				'post_status'    => [ 'publish', 'draft', 'auto-draft' ],
-				'fields'         => 'ids',
-				'posts_per_page' => 100,
-				'no_found_rows'  => true,
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-					[
-						'taxonomy' => 'wp_theme',
-						'field'    => 'name',
-						'terms'    => self::NAMESPACE,
-					],
-				],
-			]
-		);
-
-		return $query->posts;
-	}
 
 	public function test_it_keeps_the_most_recently_modified_post_and_trashes_the_duplicates(): void {
 		$stale_content = '<!-- wp:paragraph --><p>Stale layout</p><!-- /wp:paragraph -->';
@@ -123,8 +51,8 @@ class Single_Block_TemplateTest extends WPTestCase {
 	}
 
 	public function test_it_ignores_trashed_posts_when_a_published_post_exists(): void {
-		$content   = '<!-- wp:paragraph --><p>Published layout</p><!-- /wp:paragraph -->';
-		$post_id   = $this->given_a_template_post( $content );
+		$content    = '<!-- wp:paragraph --><p>Published layout</p><!-- /wp:paragraph -->';
+		$post_id    = $this->given_a_template_post( $content );
 		$trashed_id = $this->given_a_template_post( '<!-- wp:paragraph --><p>Trashed layout</p><!-- /wp:paragraph -->' );
 
 		wp_trash_post( $trashed_id );
@@ -145,8 +73,8 @@ class Single_Block_TemplateTest extends WPTestCase {
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$edited  = '<!-- wp:heading --><h2>Edited layout</h2><!-- /wp:heading -->';
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . self::NAMESPACE . '//' . self::SLUG );
-		$request->set_param( 'id', self::NAMESPACE . '//' . self::SLUG );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . self::THEME . '//' . self::SLUG );
+		$request->set_param( 'id', self::THEME . '//' . self::SLUG );
 		$request->set_param( 'content', $edited );
 
 		$response = rest_do_request( $request );
@@ -158,6 +86,79 @@ class Single_Block_TemplateTest extends WPTestCase {
 		$this->assertSame( self::SLUG, $saved->post_name );
 		$this->assertSame( $edited, $saved->post_content );
 		$this->assertSame( [ $canonical_id ], $this->get_posts_claiming_slug() );
-		$this->assertSame( $canonical_id, get_block_template( self::NAMESPACE . '//' . self::SLUG )->wp_id );
+		$this->assertSame( $canonical_id, get_block_template( self::THEME . '//' . self::SLUG )->wp_id );
+	}
+
+	/**
+	 * Inserts a published `wp_template` post claiming our slug inside our namespace.
+	 *
+	 * WordPress scopes `wp_template` slug uniqueness to the active stylesheet, so repeated calls
+	 * here reproduce the customer state: several published posts all named `single-event` and all
+	 * filed under the `tec` term.
+	 *
+	 * @param string $content The post content to store.
+	 * @param int    $age     How many minutes in the past the post was last modified.
+	 *
+	 * @return int The created post ID.
+	 */
+	private function given_a_template_post( string $content, int $age = 0 ): int {
+		global $wpdb;
+
+		$post_id = wp_insert_post(
+			[
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_name'    => self::SLUG,
+				'post_title'   => 'Single Event',
+				'post_content' => $content,
+			]
+		);
+
+		wp_set_post_terms( $post_id, self::THEME, 'wp_theme' );
+
+		if ( $age > 0 ) {
+			$modified = gmdate( 'Y-m-d H:i:s', strtotime( get_post( $post_id )->post_modified_gmt ) - ( $age * MINUTE_IN_SECONDS ) );
+			$wpdb->update(
+				$wpdb->posts,
+				[
+					'post_modified'     => $modified,
+					'post_modified_gmt' => $modified,
+				],
+				[ 'ID' => $post_id ]
+			);
+			clean_post_cache( $post_id );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Returns the IDs of every non-trashed post currently claiming our slug in our namespace.
+	 *
+	 * @return int[] The matching post IDs.
+	 */
+	private function get_posts_claiming_slug(): array {
+		$query = new WP_Query(
+			[
+				'post_name__in'  => [ self::SLUG ],
+				'post_type'      => 'wp_template',
+				'post_status'    => [ 'publish', 'draft', 'auto-draft' ],
+				'fields'         => 'ids',
+				/* Mirrors the ceiling the production lookup uses, so both read the same corrupted table. */
+				'posts_per_page' => 100,
+				'no_found_rows'  => true,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- The `wp_theme` term is how a block template is namespaced.
+					[
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => self::THEME,
+					],
+				],
+			]
+		);
+
+		return $query->posts;
 	}
 }

--- a/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
+++ b/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace TEC\Events\Block_Templates;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Events\Block_Templates\Single_Event\Single_Block_Template;
+use WP_Query;
+use WP_REST_Request;
+
+class Single_Block_TemplateTest extends WPTestCase {
+	/**
+	 * The `wp_theme` term our templates are filed under.
+	 *
+	 * @var string
+	 */
+	private const NAMESPACE = 'tec';
+
+	/**
+	 * The slug the Single Event template claims.
+	 *
+	 * @var string
+	 */
+	private const SLUG = 'single-event';
+
+	/**
+	 * Inserts a published `wp_template` post claiming our slug inside our namespace.
+	 *
+	 * WordPress scopes `wp_template` slug uniqueness to the active stylesheet, so repeated calls
+	 * here reproduce the customer state: several published posts all named `single-event` and all
+	 * filed under the `tec` term.
+	 *
+	 * @param string $content The post content to store.
+	 * @param int    $age     How many minutes in the past the post was last modified.
+	 *
+	 * @return int The created post ID.
+	 */
+	private function given_a_template_post( string $content, int $age = 0 ): int {
+		global $wpdb;
+
+		$post_id = wp_insert_post(
+			[
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'post_name'    => self::SLUG,
+				'post_title'   => 'Single Event',
+				'post_content' => $content,
+			]
+		);
+
+		wp_set_post_terms( $post_id, self::NAMESPACE, 'wp_theme' );
+
+		if ( $age > 0 ) {
+			$modified = gmdate( 'Y-m-d H:i:s', strtotime( get_post( $post_id )->post_modified_gmt ) - ( $age * MINUTE_IN_SECONDS ) );
+			$wpdb->update(
+				$wpdb->posts,
+				[
+					'post_modified'     => $modified,
+					'post_modified_gmt' => $modified,
+				],
+				[ 'ID' => $post_id ]
+			);
+			clean_post_cache( $post_id );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Returns the IDs of every non-trashed post currently claiming our slug in our namespace.
+	 *
+	 * @return int[] The matching post IDs.
+	 */
+	private function get_posts_claiming_slug(): array {
+		$query = new WP_Query(
+			[
+				'post_name__in'  => [ self::SLUG ],
+				'post_type'      => 'wp_template',
+				'post_status'    => [ 'publish', 'draft', 'auto-draft' ],
+				'fields'         => 'ids',
+				'posts_per_page' => 100,
+				'no_found_rows'  => true,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					[
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => self::NAMESPACE,
+					],
+				],
+			]
+		);
+
+		return $query->posts;
+	}
+
+	public function test_it_keeps_the_most_recently_modified_post_and_trashes_the_duplicates(): void {
+		$stale_content = '<!-- wp:paragraph --><p>Stale layout</p><!-- /wp:paragraph -->';
+		$fresh_content = '<!-- wp:paragraph --><p>Current layout</p><!-- /wp:paragraph -->';
+
+		/* The stale post is the newest row by ID, so only the modified date can pick the winner. */
+		$fresh_id = $this->given_a_template_post( $fresh_content );
+		$stale_id = $this->given_a_template_post( $stale_content, 30 );
+
+		$template = tribe( Single_Block_Template::class )->get_block_template();
+
+		$this->assertSame( $fresh_id, $template->wp_id );
+		$this->assertSame( $fresh_content, $template->content );
+		$this->assertSame( [ $fresh_id ], $this->get_posts_claiming_slug() );
+		$this->assertSame( 'trash', get_post_status( $stale_id ) );
+	}
+
+	public function test_it_leaves_a_single_template_post_untouched(): void {
+		$content = '<!-- wp:paragraph --><p>Only layout</p><!-- /wp:paragraph -->';
+		$post_id = $this->given_a_template_post( $content );
+
+		$template = tribe( Single_Block_Template::class )->get_block_template();
+
+		$this->assertSame( $post_id, $template->wp_id );
+		$this->assertSame( $content, $template->content );
+		$this->assertSame( [ $post_id ], $this->get_posts_claiming_slug() );
+		$this->assertSame( 'publish', get_post_status( $post_id ) );
+	}
+
+	public function test_it_ignores_trashed_posts_when_a_published_post_exists(): void {
+		$content   = '<!-- wp:paragraph --><p>Published layout</p><!-- /wp:paragraph -->';
+		$post_id   = $this->given_a_template_post( $content );
+		$trashed_id = $this->given_a_template_post( '<!-- wp:paragraph --><p>Trashed layout</p><!-- /wp:paragraph -->' );
+
+		wp_trash_post( $trashed_id );
+
+		$template = tribe( Single_Block_Template::class )->get_block_template();
+
+		$this->assertSame( $post_id, $template->wp_id );
+		$this->assertSame( $content, $template->content );
+	}
+
+	public function test_a_site_editor_save_updates_the_canonical_post_in_place(): void {
+		$this->given_a_template_post( '<!-- wp:paragraph --><p>Default markup</p><!-- /wp:paragraph -->', 30 );
+		$canonical_id = $this->given_a_template_post( '<!-- wp:paragraph --><p>Customer layout</p><!-- /wp:paragraph -->' );
+
+		/* The Site Editor lists the templates before it can save one. */
+		tribe( Single_Block_Template::class )->get_block_template();
+
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$edited  = '<!-- wp:heading --><h2>Edited layout</h2><!-- /wp:heading -->';
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . self::NAMESPACE . '//' . self::SLUG );
+		$request->set_param( 'id', self::NAMESPACE . '//' . self::SLUG );
+		$request->set_param( 'content', $edited );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$saved = get_post( $canonical_id );
+
+		$this->assertSame( self::SLUG, $saved->post_name );
+		$this->assertSame( $edited, $saved->post_content );
+		$this->assertSame( [ $canonical_id ], $this->get_posts_claiming_slug() );
+		$this->assertSame( $canonical_id, get_block_template( self::NAMESPACE . '//' . self::SLUG )->wp_id );
+	}
+}

--- a/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
+++ b/tests/wpunit/TEC/Events/Block_Templates/Single_Block_TemplateTest.php
@@ -67,9 +67,10 @@ class Single_Block_TemplateTest extends WPTestCase {
 		$this->given_a_template_post( '<!-- wp:paragraph --><p>Default markup</p><!-- /wp:paragraph -->', 30 );
 		$canonical_id = $this->given_a_template_post( '<!-- wp:paragraph --><p>Customer layout</p><!-- /wp:paragraph -->' );
 
-		/* The Site Editor lists the templates before it can save one. */
-		tribe( Single_Block_Template::class )->get_block_template();
-
+		/*
+		 * Nothing lists the templates first: opening a template by its URL resolves it straight by ID,
+		 * which is the path the save runs through and the one that used to skip consolidation.
+		 */
 		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$edited  = '<!-- wp:heading --><h2>Edited layout</h2><!-- /wp:heading -->';


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1857](https://linear.app/nexcess/issue/SMTNC-1857/fse-single-event-template-saves-create-single-event-n-duplicates-and)

### 🗒️ Description

Resolved an issue where saving the Single Event or Calendar Views template in the Site Editor could move the customization onto a numbered template and restore the default layout. WordPress scopes `wp_template` slug uniqueness to the active stylesheet rather than to the `wp_theme` term a template is filed under, so sibling posts could accumulate under the `tec` namespace and every later save renamed the post it was writing to. The template lookup now resolves a single canonical post, ignores trashed posts, and consolidates the published siblings competing for the slug.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
