### PR TITLE
[SMTNC-1889] Events archive `<title>` still shows the oldest events in the calendar (TECTRIA-868 fix incomplete)

### DIFF
--- a/changelog/smtnc-1889-events-archive-title-still-shows-the-oldest-events-in-the.yaml
+++ b/changelog/smtnc-1889-events-archive-title-still-shows-the-oldest-events-in-the.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the events archive page title showed the date
+  range of the oldest events in the calendar rather than the events listed on
+  the page.
+timestamp: 2026-08-07T20:43:26.176Z

--- a/src/Tribe/Views/V2/Template/Title.php
+++ b/src/Tribe/Views/V2/Template/Title.php
@@ -243,6 +243,7 @@ class Title {
 	 *
 	 * @since 4.9.10
 	 * @since 6.0.14 Changed function scope, and moved internal var to param.
+	 * @since TBD Only stand in for the first event date when a date was actually selected.
 	 *
 	 * @param Context $context    The context to use to build the title.
 	 * @param mixed   $event_date The event date object, string or timestamp.
@@ -251,8 +252,9 @@ class Title {
 	 * @return array The built post range title.
 	 */
 	public static function build_post_range_title( Context $context, $event_date, array $posts ) {
-		$event_date = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
-		$is_past    = 'past' === $context->get( 'event_display_mode' );
+		$has_selected_date = ! empty( $event_date );
+		$event_date        = Dates::build_date_object( $event_date )->format( Dates::DBDATEFORMAT );
+		$is_past           = 'past' === $context->get( 'event_display_mode' );
 
 		if ( $is_past ) {
 			$first = end( $posts );
@@ -269,10 +271,11 @@ class Title {
 
 		/*
 		 * If we are on page 1 then we may wish to use the *selected* start date in place of the
-		 * first returned event date.
+		 * first returned event date. An absent date normalizes to today above, which is not a
+		 * selection, and standing it in would name a date the page does not show.
 		 */
 		$page = $context->get( 'paged', 1 );
-		if ( 1 == $page && $event_date < $first_returned_date ) {
+		if ( $has_selected_date && 1 == $page && $event_date < $first_returned_date ) {
 			$first_event_date    = tribe_format_date( $event_date, false );
 			$first_returned_date = $event_date;
 		}
@@ -381,23 +384,12 @@ class Title {
 			$posts = null !== $wp_query->posts ? $wp_query->posts : $wp_query->get_posts();
 
 			if ( is_post_type_archive( 'tribe_events' ) ) {
-				/**
-				 * We create the View, we call get_html() to setup the repository with
-				 * all query args and then we get all the events. This is needed to fix title
-				 * filters that were fired before the View was setup.
-				 *
-				 * We pop the last one when needed. See:
-				 * setup_template_vars() in src/Tribe/Views/V2/View.php
+				/*
+				 * On classic themes the title is built during `wp_head`, before the View has run and
+				 * handed its events over through `set_posts()`, so query them here. The List View
+				 * arguments are context driven, which covers the past and Photo views too.
 				 */
-				$view  = View::make( 'list' );
-				$repo  = $view->get_repository();
-				$posts = $repo->all();
-
-				$is_paginated    = isset( $repo->query_args['posts_per_page'] ) && - 1 !== $repo->query_args['posts_per_page'];
-				$has_next_events = count( $posts ) > (int) $view->get_context()->get( 'events_per_page', 12 );
-				if ( $is_paginated && $has_next_events ) {
-					array_pop( $posts );
-				}
+				$posts = View::make( 'list' )->fetch_events();
 			}
 		}
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1612,6 +1612,42 @@ class View implements View_Interface {
 	}
 
 	/**
+	 * Applies the View repository arguments and returns the events the View would display, without
+	 * rendering it.
+	 *
+	 * Callers that need the events before the View runs cannot use `get_html()` for it: rendering
+	 * also fires the HTML cache and SEO hooks, and out of order those produce the wrong directives.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<\WP_Post> The events the View would display for its current context and page.
+	 */
+	public function fetch_events(): array {
+		if ( empty( $this->repository_args ) ) {
+			$this->repository_args = $this->get_repository_args();
+			$this->repository->by_args( $this->repository_args );
+		}
+
+		$events = array_filter(
+			$this->repository->all(),
+			static function ( $event ) {
+				return $event instanceof \WP_Post;
+			}
+		);
+
+		remove_filter( 'tribe_repository_query_arg_offset_override', [ $this, 'filter_repository_query_arg_offset_override' ], 10 );
+
+		$is_paginated = isset( $this->repository_args['posts_per_page'] ) && - 1 !== $this->repository_args['posts_per_page'];
+
+		/* The repository asks for one event more than the page holds; see setup_repository_args(). */
+		if ( $is_paginated && $this->has_next_event( $events ) ) {
+			array_pop( $events );
+		}
+
+		return $events;
+	}
+
+	/**
 	 * Sets up the View template variables.
 	 *
 	 * @since 4.9.4

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1620,7 +1620,7 @@ class View implements View_Interface {
 	 *
 	 * @since TBD
 	 *
-	 * @return array<\WP_Post> The events the View would display for its current context and page.
+	 * @return array<int, WP_Post> The events the View would display for its current context and page.
 	 */
 	public function fetch_events(): array {
 		if ( empty( $this->repository_args ) ) {
@@ -1631,7 +1631,7 @@ class View implements View_Interface {
 		$events = array_filter(
 			$this->repository->all(),
 			static function ( $event ) {
-				return $event instanceof \WP_Post;
+				return $event instanceof WP_Post;
 			}
 		);
 

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
@@ -3,13 +3,30 @@
 namespace Tribe\Events\Views\V2\Template;
 
 use Spatie\Snapshots\MatchesSnapshots;
+use Tribe\Events\Views\V2\Utils\View as Utils_View;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
 use Tribe__Events__Main as TEC;
+use WP_Post;
 use WP_Query;
 
 class TitleTest extends \Codeception\TestCase\WPTestCase {
 	use MatchesSnapshots;
 	use With_Post_Remapping;
+
+	/**
+	 * @var array<string, mixed> The global query objects as they stood before the current test.
+	 */
+	private $global_query_backup = [];
+
+	/**
+	 * @var string The request URI as it stood before the current test.
+	 */
+	private $request_uri_backup = '';
+
+	/**
+	 * @var mixed The `posts_per_page` option as it stood before the current test, restored verbatim.
+	 */
+	private $posts_per_page_backup;
 
 	public function setUp() {
 		parent::setUp();
@@ -17,6 +34,34 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 			return 'http://products.tribe';
 		};
 		add_filter( 'option_home', $return_mock_url );
+
+		$this->global_query_backup   = [
+			'wp'           => $GLOBALS['wp'] ?? null,
+			'wp_query'     => $GLOBALS['wp_query'] ?? null,
+			'wp_the_query' => $GLOBALS['wp_the_query'] ?? null,
+			'page'         => $GLOBALS['page'] ?? null,
+			'paged'        => $GLOBALS['paged'] ?? null,
+		];
+		$this->request_uri_backup    = $_SERVER['REQUEST_URI'] ?? '';
+		$this->posts_per_page_backup = get_option( 'posts_per_page' );
+	}
+
+	public function tearDown() {
+		/*
+		 * A simulated request outlives the test that made it: a leftover `paged` pages every later
+		 * title, a leftover request URI pages every later View URL, and a leftover page size
+		 * offsets every later View query.
+		 */
+		foreach ( $this->global_query_backup as $global => $value ) {
+			$GLOBALS[ $global ] = $value;
+		}
+
+		$_SERVER['REQUEST_URI'] = $this->request_uri_backup;
+
+		update_option( 'posts_per_page', $this->posts_per_page_backup );
+		tribe_context()->refresh();
+
+		parent::tearDown();
 	}
 
 
@@ -383,6 +428,76 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 */
+	public function should_query_only_upcoming_events_for_the_archive_when_posts_are_not_injected() {
+		/* A full page of past events is what pushes every upcoming one out of the unconstrained query. */
+		[ , $upcoming ] = $this->given_events_on_the_archive( 5, 5, 2 );
+
+		$this->when_visiting_the_archive();
+		$this->assertTrue( is_post_type_archive( TEC::POSTTYPE ) );
+
+		$title = new Title();
+
+		$this->assertEqualSets(
+			wp_list_pluck( $upcoming, 'ID' ),
+			wp_list_pluck( $title->get_posts(), 'ID' )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_build_the_archive_title_from_upcoming_events_when_posts_are_not_injected() {
+		[ $past, $upcoming ] = $this->given_events_on_the_archive( 5, 5, 2 );
+
+		$this->when_visiting_the_archive();
+
+		$title = ( new Title() )->build_title();
+
+		$first = tribe_get_start_date( reset( $upcoming ), false );
+		$last  = tribe_get_start_date( end( $upcoming ), false );
+
+		$this->assertStringContainsString( "$first - $last", $title );
+
+		foreach ( $past as $past_event ) {
+			$this->assertStringNotContainsString( tribe_get_start_date( $past_event, false ), $title );
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_query_the_most_recent_past_events_for_the_past_archive() {
+		[ $past ] = $this->given_events_on_the_archive( 5, 5, 2 );
+
+		$this->when_visiting_the_archive( [ Utils_View::get_past_event_display_key() => 'past' ] );
+
+		$posts = ( new Title() )->get_posts();
+
+		$this->assertEqualSets( wp_list_pluck( $past, 'ID' ), wp_list_pluck( $posts, 'ID' ) );
+		$this->assertSame( end( $past )->ID, reset( $posts )->ID );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_query_the_requested_page_of_upcoming_events_for_the_archive() {
+		$per_page = 2;
+
+		[ , $upcoming ] = $this->given_events_on_the_archive( $per_page, 0, 5 );
+
+		$this->when_visiting_the_archive( [ 'paged' => 2 ] );
+
+		$expected = array_slice( $upcoming, $per_page, $per_page );
+
+		$this->assertSame(
+			wp_list_pluck( $expected, 'ID' ),
+			array_values( wp_list_pluck( ( new Title() )->get_posts(), 'ID' ) )
+		);
+	}
+
+	/**
+	 * @test
+	 */
 	public function should_have_correct_title_on_venue_single() {
 		global $wp_query;
 		$old_q   = clone $wp_query;
@@ -426,5 +541,57 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 
 		// put old query back to avoid state bleed.
 		$wp_query = $old_q;
+	}
+
+	/**
+	 * Simulates a front-end request for the events archive.
+	 *
+	 * The Context is a singleton that caches what it reads, so it is refreshed afterwards to make it
+	 * report the request just simulated rather than the one before it.
+	 *
+	 * @param array<string, string|int> $query_args Query arguments to add to the archive URL.
+	 */
+	private function when_visiting_the_archive( array $query_args = [] ): void {
+		$this->go_to( add_query_arg( [ 'post_type' => TEC::POSTTYPE ] + $query_args, '/' ) );
+
+		tribe_context()->refresh();
+	}
+
+	/**
+	 * Populates the events archive and sets how many events one page of it holds.
+	 *
+	 * `events_per_page` reads back from the `posts_per_page` option, so the one value sizes both the
+	 * page and the unconstrained query the archive title used to run.
+	 *
+	 * @param int $per_page       How many events a page of the archive holds.
+	 * @param int $past_count     How many past events to create.
+	 * @param int $upcoming_count How many upcoming events to create.
+	 *
+	 * @return array{0: WP_Post[], 1: WP_Post[]} The past events and the upcoming ones, both oldest first.
+	 */
+	private function given_events_on_the_archive( int $per_page, int $past_count, int $upcoming_count ): array {
+		update_option( 'posts_per_page', $per_page );
+
+		$past = [];
+		for ( $i = $past_count; $i > 0; $i-- ) {
+			$past[] = tribe_events()->set_args( [
+				'start_date' => "-$i years",
+				'duration'   => HOUR_IN_SECONDS,
+				'title'      => "Past Event $i",
+				'status'     => 'publish',
+			] )->create();
+		}
+
+		$upcoming = [];
+		for ( $i = 1; $i <= $upcoming_count; $i++ ) {
+			$upcoming[] = tribe_events()->set_args( [
+				'start_date' => "+$i months",
+				'duration'   => HOUR_IN_SECONDS,
+				'title'      => "Upcoming Event $i",
+				'status'     => 'publish',
+			] )->create();
+		}
+
+		return [ $past, $upcoming ];
 	}
 }

--- a/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/Template/TitleTest.php
@@ -429,8 +429,10 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_query_only_upcoming_events_for_the_archive_when_posts_are_not_injected() {
-		/* A full page of past events is what pushes every upcoming one out of the unconstrained query. */
-		[ , $upcoming ] = $this->given_events_on_the_archive( 5, 5, 2 );
+		/* Filling the page with past events is what pushes every upcoming one out of the unconstrained query. */
+		$per_page = 5;
+
+		[ , $upcoming ] = $this->given_events_on_the_archive( $per_page, $per_page, 2 );
 
 		$this->when_visiting_the_archive();
 		$this->assertTrue( is_post_type_archive( TEC::POSTTYPE ) );
@@ -447,7 +449,10 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_build_the_archive_title_from_upcoming_events_when_posts_are_not_injected() {
-		[ $past, $upcoming ] = $this->given_events_on_the_archive( 5, 5, 2 );
+		/* With a full page of past events the range ends in the past too, so nothing clamps the start date. */
+		$per_page = 5;
+
+		[ $past, $upcoming ] = $this->given_events_on_the_archive( $per_page, $per_page, 2 );
 
 		$this->when_visiting_the_archive();
 
@@ -467,7 +472,10 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_query_the_most_recent_past_events_for_the_past_archive() {
-		[ $past ] = $this->given_events_on_the_archive( 5, 5, 2 );
+		/* Past view reads the same page size; a full page proves it orders by most recent, not oldest. */
+		$per_page = 5;
+
+		[ $past ] = $this->given_events_on_the_archive( $per_page, $per_page, 2 );
 
 		$this->when_visiting_the_archive( [ Utils_View::get_past_event_display_key() => 'past' ] );
 
@@ -481,6 +489,7 @@ class TitleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_query_the_requested_page_of_upcoming_events_for_the_archive() {
+		/* A page smaller than the upcoming events gives page 2 something to hold; no past events needed. */
 		$per_page = 2;
 
 		[ , $upcoming ] = $this->given_events_on_the_archive( $per_page, 0, 5 );


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1889](https://linear.app/nexcess/issue/SMTNC-1889/events-archive-title-still-shows-the-oldest-events-in-the-calendar)

### 🎥 Artifacts

https://www.loom.com/share/d83a8ff52fe94369ac203f79dc294bf0

### 🗒️ Description

Builds the events archive page title from the events the page actually lists, instead of from the oldest events in the calendar.

### ⚠️ Blockers

None.
Testing Instructions — paste 

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.