### PR TITLE
[SMTNC-1954] TEC: Fatal TypeError on crawled events URLs with malformed pagination params

### DIFF
--- a/changelog/smtnc-1954-tec-fatal-typeerror-on-crawled-events-urls-with-malformed.yaml
+++ b/changelog/smtnc-1954-tec-fatal-typeerror-on-crawled-events-urls-with-malformed.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where Events archive pages could return a fatal error
+  when the request included non-numeric or array pagination parameters.
+timestamp: 2026-08-11T04:46:48.072Z

--- a/src/Tribe/Views/V2/Url.php
+++ b/src/Tribe/Views/V2/Url.php
@@ -127,12 +127,18 @@ class Url {
 	/**
 	 * Returns the current page number for the URL.
 	 *
+	 * The `paged` and `page` query arguments come from the request and might be non-numeric, negative
+	 * or arrays; callers do arithmetic on the page number, so it's normalized here.
+	 *
 	 * @since 4.9.3
+	 * @since TBD Normalized the return value to a positive integer.
 	 *
 	 * @return int The current page number if specified in the URL or the default value.
 	 */
 	public function get_current_page() {
-		return Arr::get_first_set( $this->get_query_args(), [ 'paged', 'page' ], 1 );
+		$page = Arr::get_first_set( $this->get_query_args(), [ 'paged', 'page' ], 1 );
+
+		return is_numeric( $page ) && $page > 0 ? absint( $page ) : 1;
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/UrlTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/UrlTest.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Events\Views\V2;
 
+use Generator;
 use Tribe__Context as Context;
 
 class UrlTest extends \Codeception\TestCase\WPTestCase {
@@ -370,5 +371,53 @@ class UrlTest extends \Codeception\TestCase\WPTestCase {
 		} finally {
 			remove_filter( 'tec_events_views_v2_url_allowed_query_args', $filter );
 		}
+	}
+
+	/**
+	 * @return Generator<string, array{0: string, 1: int}>
+	 */
+	public function current_page_data_set(): Generator {
+		yield 'no_pagination_args' => [ '', 1 ];
+		yield 'paged' => [ '?paged=3', 3 ];
+		yield 'page' => [ '?page=4', 4 ];
+		yield 'paged_takes_precedence_over_page' => [ '?paged=3&page=7', 3 ];
+		yield 'paged_in_the_path' => [ 'page/2/', 2 ];
+		yield 'non_numeric_paged' => [ '?paged=abc', 1 ];
+		yield 'non_numeric_paged_w_numeric_page' => [ '?paged=abc&page=5', 1 ];
+		yield 'array_paged_w_numeric_page' => [ '?paged[]=2&page=5', 1 ];
+		yield 'zero_paged' => [ '?paged=0', 1 ];
+		yield 'negative_paged' => [ '?paged=-3', 1 ];
+	}
+
+	/**
+	 * It should always return a page number of 1 or greater as an integer
+	 *
+	 * @test
+	 * @dataProvider current_page_data_set
+	 *
+	 * @param string $query    The query string, or path fragment, to append to the archive URL.
+	 * @param int    $expected The page number the URL should resolve to.
+	 */
+	public function should_always_return_a_page_number_of_one_or_greater_as_an_integer( string $query, int $expected ) {
+		$url = new Url( home_url( '/events/list/' ) . $query );
+
+		$this->assertSame( $expected, $url->get_current_page() );
+	}
+
+	/**
+	 * `View::next_url()` and `View::prev_url()` do arithmetic on this value, which is a fatal
+	 * "Unsupported operand types" for anything that is not a number.
+	 *
+	 * @test
+	 * @dataProvider current_page_data_set
+	 *
+	 * @param string $query The query string, or path fragment, to append to the archive URL.
+	 */
+	public function should_return_a_page_number_that_can_be_used_in_arithmetic( string $query ) {
+		$url  = new Url( home_url( '/events/list/' ) . $query );
+		$page = $url->get_current_page();
+
+		$this->assertGreaterThanOrEqual( 1, $page + 1 );
+		$this->assertGreaterThanOrEqual( 0, $page - 1 );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1954](https://linear.app/nexcess/issue/SMTNC-1954/tec-fatal-typeerror-on-crawled-events-urls-with-malformed-pagination)

### 🎥 Artifacts

https://www.loom.com/share/0e8eb88eb9fd4b98adec66798391cf81

### 🗒️ Description

Normalizes the value `Url::get_current_page()` returns to a positive integer, so malformed `paged` and `page` request parameters can no longer fatal the Events archive.

### ⚠️ Blockers

None.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
