### PR TITLE
Lazy_Post_Collection loses its hydration callback across cache round trips, silently degrading venues/organizers to bare post IDs

### DIFF
--- a/src/Tribe/Collections/Lazy_Post_Collection.php
+++ b/src/Tribe/Collections/Lazy_Post_Collection.php
@@ -86,6 +86,34 @@ class Lazy_Post_Collection extends Lazy_Collection {
 			return null;
 		}
 
-		return array_map( $unserialized['callback'], $unserialized['ids'] );
+		/*
+		 * Restore the callback on the instance.
+		 *
+		 * `__unserialize()` does not run the constructor, so `$unserialize_callback`
+		 * is `null` on a restored collection. Without this, the next
+		 * `before_serialize()` stores `'callback' => null` and the round trip after
+		 * that has nothing to rebuild the posts with.
+		 */
+		if ( ! empty( $unserialized['callback'] ) ) {
+			$this->unserialize_callback = $unserialized['callback'];
+		}
+
+		$callback = ! empty( $unserialized['callback'] )
+			? $unserialized['callback']
+			: $this->unserialize_callback;
+
+		/*
+		 * Guard the callback before mapping with it.
+		 *
+		 * `array_map( null, $ids )` is the zip form: given a single array it
+		 * returns that array unchanged. A missing callback would therefore leave
+		 * the collection holding bare post IDs rather than posts, with no error
+		 * raised at any point.
+		 */
+		if ( ! is_callable( $callback ) ) {
+			return null;
+		}
+
+		return array_map( $callback, $unserialized['ids'] );
 	}
 }


### PR DESCRIPTION
### Summary

A `Lazy_Post_Collection` restored from a persistent object cache comes back with `$unserialize_callback === null`, because `Collection_Trait::__unserialize()` restores `$items` but not the callback, and `__unserialize()` does not run the constructor.

The next `before_serialize()` therefore stores `'callback' => null`, and the round trip after that reaches:

```php
return array_map( $unserialized['callback'], $unserialized['ids'] );
```

`array_map( null, $ids )` is the zip form — given a single array it returns that array **unchanged**. So the collection silently ends up holding bare post IDs instead of `WP_Post` objects. No error, no warning, no failed unserialize.

### It decays one generation per cache write

Reproduced against 6.17.2 on PHP 8.4.24, WordPress 7.0.4, Redis object cache with igbinary:

```
gen 0 | items[0]=WP_Post      | stored callback='tribe_get_venue_object'
gen 1 | items[0]=WP_Post      | stored callback='(none)'     <- callback lost here
gen 2 | items[0]=integer:317  | hydration silently fails
gen 3 | items[0]=integer:317  | permanent
```

Identical under native `serialize()` and `igbinary_serialize()`, so it is not serializer-specific.

Reproduction, with no plugin modification:

```php
$fetch = fn() => array_map( 'tribe_get_venue_object', [ $venue_id ] );
$c = new Tribe\Events\Collections\Lazy_Post_Collection( $fetch, 'tribe_get_venue_object' );

for ( $g = 0; $g <= 3; $g++ ) {
    if ( $g ) { $c = unserialize( serialize( $c ) ); }
    var_dump( $g, $c[0], $c->__serialize()['callback'] );
}
```

Control: `array_map( null, [ 317 ] ) === [ 317 ]` → `true`.

### User-visible effect

`src/views/v2/list/event/venue.php` (and the `day/` and `latest-past/` equivalents) do:

```php
$venue = $event->venues[0];
$append_after_address = array_filter( array_map( 'trim', [ $venue->state_province, ... ] ) );
```

With `$venue` an `int`, that produces a burst of `Attempt to read property "state_province" on int` / `"address"` / `"post_title"` / `"ID"` per event rendered, and the venue block renders **empty** — no name, no address. On one production site this was ~2,900 warnings in a day and a visibly blank venue on the events list.

`organizers` is the same class constructed with `tribe_get_organizer_object`, so it is affected identically.

### Why it looks intermittent

Flushing the object cache appears to fix it: everything resets to generation 0 and renders correctly. The fault returns once entries have been written twice — on the affected site, about ten hours later. That makes it easy to misdiagnose as stale cache data rather than a reproducible defect.

### The change

Restore the callback on the instance during `custom_unserialize()`, and refuse to map when no callable is available rather than letting `array_map( null, ... )` pass IDs through:

```php
if ( ! empty( $unserialized['callback'] ) ) {
    $this->unserialize_callback = $unserialized['callback'];
}

$callback = ! empty( $unserialized['callback'] )
    ? $unserialized['callback']
    : $this->unserialize_callback;

if ( ! is_callable( $callback ) ) {
    return null;
}

return array_map( $callback, $unserialized['ids'] );
```

The guard matters independently of the callback restoration: `array_map( null, $ids )` returning IDs unchanged is what turns a missing callback into silent data corruption instead of a detectable failure.

### Verification

Applied to the installed plugin on the affected production site, with no other workaround active:

```
before: gen 0 WP_Post | gen 1 WP_Post (callback lost) | gen 2 integer:317
after:  gen 0 WP_Post | gen 1 WP_Post | gen 2 WP_Post | gen 3 WP_Post
```

Venue title survives repeated round trips, the empty venue block is gone, and the warnings stop.

A fix in `Collection_Trait::__unserialize()` would also work and would cover any other collection that grows a similar callback, but that trait lives in `tribe-common` and is generic over collections that have no callback at all — so this keeps the change local to the class that owns the property.