### PR TITLE
[SMTNC-1961] Day View direct URL shows only 1 event when recurring events exist (tec_occurrences JOIN with wrong postmeta WHERE)

### DIFF
--- a/changelog/smtnc-1961-day-view-direct-url-shows-only-1-event-when-recurring-events.yaml
+++ b/changelog/smtnc-1961-day-view-direct-url-shows-only-1-event-when-recurring-events.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the Day View direct URL omitted recurring event
+  occurrences because an earlier query on the same repository froze the custom
+  tables date redirection.
+timestamp: 2026-08-15T00:33:21.611Z

--- a/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
+++ b/src/Events/Custom_Tables/V1/WP_Query/Repository/Custom_Tables_Query_Filters.php
@@ -64,13 +64,15 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 	private $query_vars_mask;
 
 	/**
-	 * A flag property to indicate whether the Custom Table redirections have been already applied or not.
+	 * The query vars the Custom Table redirections were last applied to, `null` if they did not apply yet.
 	 *
 	 * @since 6.0.0
+	 * @since TBD Replaced the boolean flag: a Repository builds a new query per fetch while keeping one
+	 *            instance of this class, so the redirections have to apply again when the clauses change.
 	 *
-	 * @var bool
+	 * @var array<string,mixed>|null
 	 */
-	private $redirected = false;
+	private $redirected_query_vars;
 	/**
 	 * Reference to the class used to replace values from the request.
 	 *
@@ -118,9 +120,10 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 	 * to the Custom Tables where required.
 	 *
 	 * @since 6.0.0
+	 * @since TBD Applies again when the query vars changed since the last redirection.
 	 */
 	private function redirect() {
-		if ( $this->redirected ) {
+		if ( $this->query_vars === $this->redirected_query_vars ) {
 			return;
 		}
 
@@ -156,7 +159,7 @@ class Custom_Tables_Query_Filters extends Query_Filters {
 		$this->query_vars[ $after_order_by_index ] = $redirected_query_vars[ $after_order_by_index ];
 		$this->query_vars['fields']                = $redirected_query_vars['fields'];
 
-		$this->redirected = true;
+		$this->redirected_query_vars = $this->query_vars;
 	}
 
 	/**

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Custom_Tables_QueryTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/WP_Query/Custom_Tables_QueryTest.php
@@ -286,6 +286,33 @@ class Custom_Tables_QueryTest extends \Codeception\TestCase\WPTestCase {
 		);
 	}
 
+	/**
+	 * It should redirect the date clauses of a query built after an earlier one on the same Repository
+	 *
+	 * A Repository builds a new WP_Query per fetch but keeps one set of Query Filters. An early consumer,
+	 * like the no-index check in TEC\Events\SEO\Controller that only runs on a full page load, must not
+	 * freeze the custom tables redirection for the queries built after it.
+	 *
+	 * @test
+	 */
+	public function should_redirect_date_clauses_of_a_query_built_after_an_earlier_one_on_same_repository(): void {
+		$post       = $this->given_an_event_with_multiple_occurrences();
+		$last       = Occurrence::where( 'post_id', '=', $post->ID )->order_by( 'start_date', 'DESC' )->first();
+		$day        = ( new DateTimeImmutable( $last->start_date ) )->format( 'Y-m-d' );
+		$repository = tribe_events();
+
+		// Consume the Repository once before the date filters are set on it.
+		$repository->count();
+
+		$repository->by( 'date_overlaps', $day . ' 00:00:00', $day . ' 23:59:59' );
+
+		$this->assertEquals(
+			[ $post->ID ],
+			$repository->get_ids(),
+			'The Occurrence date, not the Event post meta date, should filter the query.'
+		);
+	}
+
 	public function orderby_data_provider(): \Generator {
 		yield 'no orderby specified' => [ [] ];
 		yield 'event_date' => [ [ 'orderby' => 'event_date' ] ];


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1961](https://linear.app/nexcess/issue/SMTNC-1961/day-view-direct-url-shows-only-1-event-when-recurring-events-exist-tec)

### 🎥 Artifacts
https://www.loom.com/share/7dc170c387024114af5025bab4ff9bb4

### 🗒️ Description

Recurring event occurrences were missing from the Day View on a direct URL load because the custom tables date redirection was computed once per Query Filters instance and reused by every later query built from the same repository.

### ⚠️ Blockers

None.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
