### PR TITLE
[SMTNC-1979] posts_per_page in List view creates an infinite crawler trap

### DIFF
--- a/changelog/fix-smtnc-1979-posts_per_page-list-view-crawler-trap
+++ b/changelog/fix-smtnc-1979-posts_per_page-list-view-crawler-trap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the List view exposed an internal pagination look-ahead value in generated navigation and canonical URLs, and capped the number of events fetched per page to prevent unbounded queries.

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -23,6 +23,7 @@ use Tribe\Events\Views\V2\Repository\Event_Period;
 use Tribe\Events\Views\V2\Template\Featured_Title;
 use Tribe\Events\Views\V2\Template\Title;
 use Tribe\Events\Views\V2\Utils\View as View_Utils;
+use Tribe\Events\Views\V2\View;
 use Tribe__Context as Context;
 use Tribe__Customizer__Section as Customizer_Section;
 use Tribe__Events__Main as TEC;
@@ -471,6 +472,15 @@ class Hooks extends Service_Provider {
 		}
 		$per_page = (int) tribe_get_option( 'posts_per_page', tribe_get_option( 'postsPerPage', get_option( 'posts_per_page', 12 ) ) );
 		if ( $per_page > 0 ) {
+			/**
+			 * Filters the maximum number of events a View will fetch per page.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $max_events_per_page The maximum number of events per page.
+			 */
+			$max      = (int) apply_filters( 'tec_events_views_v2_max_events_per_page', View::MAX_EVENTS_PER_PAGE );
+			$per_page = min( $per_page, max( 1, $max ) );
 			$query->set( 'posts_per_page', $per_page );
 		}
 	}

--- a/src/Tribe/Views/V2/Hooks.php
+++ b/src/Tribe/Views/V2/Hooks.php
@@ -224,7 +224,11 @@ class Hooks extends Service_Provider {
 		}
 
 		// Trim to what is shown (we add one sometimes for pagination links).
-		$cnt = $view->get_context()->get( 'events_per_page' );
+		if ( $view instanceof View && method_exists( $view, 'get_events_per_page' ) ) {
+			$cnt = $view->get_events_per_page();
+		} else {
+			$cnt = $view->get_context()->get( 'events_per_page' );
+		}
 		if ( $cnt ) {
 			$events = array_slice( $events, 0, (int) $cnt );
 		}

--- a/src/Tribe/Views/V2/Query/Event_Query_Controller.php
+++ b/src/Tribe/Views/V2/Query/Event_Query_Controller.php
@@ -8,6 +8,7 @@
 
 namespace Tribe\Events\Views\V2\Query;
 
+use Tribe\Events\Views\V2\View;
 use Tribe__Events__Main as TEC;
 
 /**
@@ -144,6 +145,16 @@ class Event_Query_Controller {
 				 */
 				$per_page = max( 1, (int) tribe_get_option( 'posts_per_page', tribe_get_option( 'postsPerPage', get_option( 'posts_per_page', 12 ) ) ) );
 			}
+
+			/**
+			 * Filters the maximum number of events a View will fetch per page.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $max_events_per_page The maximum number of events per page.
+			 */
+			$max      = (int) apply_filters( 'tec_events_views_v2_max_events_per_page', View::MAX_EVENTS_PER_PAGE );
+			$per_page = min( $per_page, max( 1, $max ) );
 
 			if ( 'past' === $display ) {
 				$orm_args = [

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1361,7 +1361,7 @@ class View implements View_Interface {
 	 *
 	 * @return int The bounded number of events per page.
 	 */
-	protected function get_events_per_page( Context $context = null ) {
+	protected function get_events_per_page( ?Context $context = null ) {
 		$context ??= $this->get_context();
 		$per_page = absint( $context->get( 'events_per_page', 12 ) );
 

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -48,6 +48,16 @@ class View implements View_Interface {
 	use Json_Ld_Data;
 
 	/**
+	 * The maximum number of events a View will fetch per page.
+	 *
+	 * The `posts_per_page` request variable can drive the number of events per page through the Context,
+	 * so the value is capped to keep unauthenticated requests from forcing unbounded queries.
+	 *
+	 * @since TBD
+	 */
+	const MAX_EVENTS_PER_PAGE = 200;
+
+	/**
 	 * An instance of the DI container.
 	 *
 	 * @var Container
@@ -1275,6 +1285,12 @@ class View implements View_Interface {
 		// By default let's use the locations set in the Context to map the arguments to query args.
 		$query_args = tribe_context()->map_to_read( $args, Context::REQUEST_VAR );
 
+		/*
+		 * `posts_per_page` is an internal repository argument carrying the pagination look-ahead value; it must
+		 * never be reflected into a generated View URL or an unbounded, self-generating crawl space results.
+		 */
+		unset( $query_args['posts_per_page'] );
+
 		global $wp;
 
 		return array_intersect_key( $query_args, array_combine( $wp->public_query_vars, $wp->public_query_vars ) );
@@ -1334,6 +1350,25 @@ class View implements View_Interface {
 	}
 
 	/**
+	 * Returns the number of events a View should show per page, bounded to a safe maximum.
+	 *
+	 * The value can be driven by the `posts_per_page` request variable through the Context, so it is
+	 * capped here to keep unauthenticated requests from forcing unbounded repository queries.
+	 *
+	 * @since TBD
+	 *
+	 * @param Context|null $context The context to read the value from, or `null` to use the View Context.
+	 *
+	 * @return int The bounded number of events per page.
+	 */
+	protected function get_events_per_page( Context $context = null ) {
+		$context ??= $this->get_context();
+		$per_page = absint( $context->get( 'events_per_page', 12 ) );
+
+		return min( $per_page, static::MAX_EVENTS_PER_PAGE );
+	}
+
+	/**
 	 * Sets up the View repository arguments from the View context or a provided Context object.
 	 *
 	 * @since 4.9.3
@@ -1358,7 +1393,7 @@ class View implements View_Interface {
 		 * @since 5.0.0
 		*/
 		$args = [
-			'posts_per_page'       => (int) $context_arr['events_per_page'] + 1,
+			'posts_per_page'       => $this->get_events_per_page( $context ) + 1,
 			'paged'                => max( Arr::get_first_set( array_filter( $context_arr ), [
 				'paged',
 				'page',
@@ -1427,7 +1462,7 @@ class View implements View_Interface {
 			1
 		);
 
-		return ( $current_page - 1 ) * (int) $context->get( 'events_per_page' );
+		return ( $current_page - 1 ) * $this->get_events_per_page();
 	}
 
 	/**
@@ -1592,7 +1627,7 @@ class View implements View_Interface {
 	 * @return mixed                   Weather the array of events has a next page.
 	 */
 	public function has_next_event( array $events, $overwrite_flag = true ) {
-		$has_next_events = count( $events ) > (int) $this->get_context()->get( 'events_per_page', 12 );
+		$has_next_events = count( $events ) > $this->get_events_per_page();
 		if ( (bool) $overwrite_flag ) {
 			$this->set_has_next_event( $has_next_events );
 		}

--- a/src/Tribe/Views/V2/View.php
+++ b/src/Tribe/Views/V2/View.php
@@ -1361,11 +1361,20 @@ class View implements View_Interface {
 	 *
 	 * @return int The bounded number of events per page.
 	 */
-	protected function get_events_per_page( ?Context $context = null ) {
+	public function get_events_per_page( ?Context $context = null ): int {
 		$context ??= $this->get_context();
 		$per_page = absint( $context->get( 'events_per_page', 12 ) );
 
-		return min( $per_page, static::MAX_EVENTS_PER_PAGE );
+		/**
+		 * Filters the maximum number of events a View will fetch per page.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $max_events_per_page The maximum number of events per page.
+		 */
+		$max = (int) apply_filters( 'tec_events_views_v2_max_events_per_page', static::MAX_EVENTS_PER_PAGE );
+
+		return min( $per_page, max( 1, $max ) );
 	}
 
 	/**

--- a/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
@@ -253,6 +253,43 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( '', $page_1_view->prev_url() );
 	}
 
+	/**
+	 * It should not expose the posts_per_page look-ahead value in the View URL.
+	 *
+	 * @test
+	 */
+	public function should_not_expose_posts_per_page_in_the_view_url() {
+		add_filter( 'tribe_events_views', static function () {
+			return [ 'test' => Test_View::class ];
+		} );
+
+		global $wp;
+		$wp->public_query_vars = array_unique( array_merge( $wp->public_query_vars, [ 'posts_per_page' ] ) );
+
+		$view = View::make( 'test' );
+		$view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
+
+		$this->assertArrayNotHasKey( 'posts_per_page', $view->get_url_object()->get_query_args() );
+	}
+
+	/**
+	 * It should cap the events per page repository argument.
+	 *
+	 * @test
+	 */
+	public function should_cap_the_events_per_page_repository_argument() {
+		add_filter( 'tribe_events_views', static function () {
+			return [ 'test' => Test_View::class ];
+		} );
+
+		$view = View::make( 'test' );
+		$view->set_context( tribe_context()->alter( [ 'events_per_page' => 3517 ] ) );
+
+		$repository_args = $view->_public_repository_args();
+
+		$this->assertEquals( View::MAX_EVENTS_PER_PAGE + 1, $repository_args['posts_per_page'] );
+	}
+
 	public static function wpSetUpBeforeClass() {
 		static::factory()->event = new Event();
 	}

--- a/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/ViewTest.php
@@ -12,9 +12,22 @@ require_once codecept_data_dir( 'Views/V2/classes/Test_View.php' );
 
 class ViewTest extends \Codeception\TestCase\WPTestCase {
 	use MatchesSnapshots;
+
+	/**
+	 * Backup of the global `$wp->public_query_vars`.
+	 *
+	 * @var array
+	 */
+	protected static $wp_public_query_vars;
+
 	public function setUp() {
 		parent::setUp();
 		static::factory()->event = new Event();
+	}
+
+	public function tearDown() {
+		remove_all_filters( 'tribe_events_views' );
+		parent::tearDown();
 	}
 
 	/**
@@ -259,17 +272,22 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_not_expose_posts_per_page_in_the_view_url() {
-		add_filter( 'tribe_events_views', static function () {
+		$filter = static function () {
 			return [ 'test' => Test_View::class ];
-		} );
+		};
+		add_filter( 'tribe_events_views', $filter );
 
 		global $wp;
+		$original_vars           = $wp->public_query_vars;
 		$wp->public_query_vars = array_unique( array_merge( $wp->public_query_vars, [ 'posts_per_page' ] ) );
 
 		$view = View::make( 'test' );
 		$view->setup_the_loop( [ 'posts_per_page' => 2, 'starts_after' => 'now' ] );
 
 		$this->assertArrayNotHasKey( 'posts_per_page', $view->get_url_object()->get_query_args() );
+
+		$wp->public_query_vars = $original_vars;
+		remove_filter( 'tribe_events_views', $filter );
 	}
 
 	/**
@@ -278,20 +296,32 @@ class ViewTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_cap_the_events_per_page_repository_argument() {
-		add_filter( 'tribe_events_views', static function () {
+		$filter = static function () {
 			return [ 'test' => Test_View::class ];
-		} );
+		};
+		add_filter( 'tribe_events_views', $filter );
 
 		$view = View::make( 'test' );
-		$view->set_context( tribe_context()->alter( [ 'events_per_page' => 3517 ] ) );
+		// Use a value well above the cap to ensure the capping logic is exercised even if the constant changes.
+		$view->set_context( tribe_context()->alter( [ 'events_per_page' => View::MAX_EVENTS_PER_PAGE * 2 ] ) );
 
 		$repository_args = $view->_public_repository_args();
 
 		$this->assertEquals( View::MAX_EVENTS_PER_PAGE + 1, $repository_args['posts_per_page'] );
+
+		remove_filter( 'tribe_events_views', $filter );
 	}
 
 	public static function wpSetUpBeforeClass() {
 		static::factory()->event = new Event();
+		global $wp;
+		static::$wp_public_query_vars = $wp->public_query_vars;
+	}
+
+	public static function tearDownAfterClass() {
+		global $wp;
+		$wp->public_query_vars = static::$wp_public_query_vars;
+		parent::tearDownAfterClass();
 	}
 
 	public function url_event_date_data_set() {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1979](https://linear.app/nexcess/issue/SMTNC-1979/posts-per_page-in-list-view-creates-an-infinite-crawler-trap)

### 🗒️ Description

Resolved an issue where the List view exposed an internal pagination look-ahead value in generated navigation and canonical URLs, creating an unbounded, self-generating crawl space. `posts_per_page` is now scrubbed from generated URLs, and the number of events fetched per page is capped at 200 so unauthenticated requests cannot drive unbounded repository queries.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing? (slic unavailable locally — not run)
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
