### PR TITLE
Fix all-day events not updating custom table dates when shortened.

### DIFF
--- a/changelog/fix-all-day-duration-not-updating-custom-tables
+++ b/changelog/fix-all-day-duration-not-updating-custom-tables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+All-day events now persist a recalculated duration when their date range changes, so shortening an all-day event updates custom table occurrence dates and continues to appear in List view.

--- a/src/Tribe/API.php
+++ b/src/Tribe/API.php
@@ -211,10 +211,6 @@ if ( ! class_exists( 'Tribe__Events__API' ) ) {
 				unset( $data['FeaturedImage'] );
 			}
 
-			if ( isset( $data['EventAllDay'] ) && 'yes' === $data['EventAllDay'] ) {
-				$data['EventDuration'] = null;
-			}
-
 			/**
 			 * Allow hooking in prior to updating meta fields.
 			 *

--- a/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/EventsTest.php
+++ b/tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/EventsTest.php
@@ -10,6 +10,8 @@ use TEC\Events\Custom_Tables\V1\Models\Occurrence;
 use Tribe\Events\Test\Factories\Event as Event_Factory;
 use Tribe\Tests\Traits\With_Log_Recording;
 use Tribe\Tests\Traits\With_Uopz;
+use Tribe__Events__API as API;
+use Tribe__Events__Main as TEC;
 use WP_Post;
 
 class EventsTest extends WPTestCase {
@@ -128,6 +130,44 @@ class EventsTest extends WPTestCase {
 		$this->assertCount( 0, $this->get_log_records() );
 		$this->assertInstanceOf( Event::class, Event::find( $event_id, 'post_id' ) );
 		$this->assertEquals( 1, Occurrence::where( 'post_id', '=', $event_id )->count() );
+	}
+
+	/**
+	 * Shortening an all-day event should rewrite occurrence dates instead of leaving a stale row.
+	 *
+	 * @test
+	 */
+	public function should_update_occurrence_dates_when_all_day_event_is_shortened() {
+		$id = static::factory()->post->create();
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->posts} SET post_type = %s WHERE ID = %d", TEC::POSTTYPE, $id ) );
+
+		API::saveEventMeta( $id, [
+			'EventAllDay'    => 'yes',
+			'EventStartDate' => '2023-08-08',
+			'EventEndDate'   => '2023-08-11',
+			'EventTimezone'  => 'America/Chicago',
+		] );
+
+		$events = new Events();
+		$this->assertTrue( $events->update( $id ) );
+
+		API::saveEventMeta( $id, [
+			'EventAllDay'    => 'yes',
+			'EventStartDate' => '2023-08-08',
+			'EventEndDate'   => '2023-08-10',
+			'EventTimezone'  => 'America/Chicago',
+		] );
+
+		$updated = $events->update( $id );
+
+		$this->assertTrue( $updated );
+		$this->assertCount( 0, $this->get_log_records() );
+
+		$occurrence = Occurrence::where( 'post_id', '=', $id )->first();
+		$this->assertInstanceOf( Occurrence::class, $occurrence );
+		$this->assertEquals( '2023-08-08 00:00:00', $occurrence->start_date );
+		$this->assertEquals( '2023-08-10 23:59:59', $occurrence->end_date );
 	}
 
 	/**

--- a/tests/wpunit/TEC/Events/APITest.php
+++ b/tests/wpunit/TEC/Events/APITest.php
@@ -65,6 +65,44 @@ class APITest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( 3 * HOUR_IN_SECONDS, (int) get_post_meta( $id, '_EventDuration', true ) );
 	}
 
+	/**
+	 * All-day saves should persist a duration matching the new date span.
+	 *
+	 * Previously, all-day events nullified EventDuration before meta was written,
+	 * so shortening the range left a stale longer duration in post meta.
+	 *
+	 * @test
+	 */
+	public function should_update_duration_when_all_day_event_is_shortened() {
+		$id = static::factory()->post->create();
+		global $wpdb;
+		$event_type = TEC::POSTTYPE;
+		$wpdb->query( "update $wpdb->posts set post_type='{$event_type}' where ID = $id" );
+
+		API::saveEventMeta( $id, [
+			'EventAllDay'    => 'yes',
+			'EventStartDate' => '2023-08-08',
+			'EventEndDate'   => '2023-08-11',
+			'EventTimezone'  => 'America/Chicago',
+		] );
+
+		$four_day_duration = (int) get_post_meta( $id, '_EventDuration', true );
+		$this->assertGreaterThan( 0, $four_day_duration );
+
+		API::saveEventMeta( $id, [
+			'EventAllDay'    => 'yes',
+			'EventStartDate' => '2023-08-08',
+			'EventEndDate'   => '2023-08-10',
+			'EventTimezone'  => 'America/Chicago',
+		] );
+
+		$three_day_duration = (int) get_post_meta( $id, '_EventDuration', true );
+		$this->assertGreaterThan( 0, $three_day_duration );
+		$this->assertLessThan( $four_day_duration, $three_day_duration );
+		$this->assertEquals( '2023-08-08 00:00:00', get_post_meta( $id, '_EventStartDate', true ) );
+		$this->assertEquals( '2023-08-10 23:59:59', get_post_meta( $id, '_EventEndDate', true ) );
+	}
+
 	public function get_event_terms_will_work_when_cat_tax_unregistered(): void {
 		unregister_taxonomy( TEC::TAXONOMY );
 		$post_id = tribe_events()->set_args( [


### PR DESCRIPTION
## Summary

- All-day event saves discarded the calculated `_EventDuration` by setting `EventDuration` to `null` before meta was written. Shortening an all-day range left a stale, longer duration in post meta.
- Custom tables then rejected the row because duration must be `<= end - start`. `Events::update()` returned `false`, so occurrence dates were not rewritten.
- List view queries occurrence UTC dates (`ends_after = now`). The single event page reads post meta. After a failed upsert, those two stores disagree: the editor and permalink show the new dates, while List view still treats the event as past.
- This patch stops nulling duration so the value from `prepare_event_date_meta()` is persisted. That matches what `fix_all_day_events()` already expects when it derives all-day end dates from `_EventDuration`.

---

## User-facing bug

A published, public all-day event can vanish from `/events/` (List view) after its dates are edited, even when:

- Status is Published and visibility is Public
- “Hide from Event Listings” is unchecked
- The single event permalink still loads and shows the new dates
- The issue reproduces with a default theme and only The Events Calendar active

Typical sequence:

1. Create an all-day event spanning several days (for example Aug 8–11).
2. Later edit it to a shorter all-day range (for example Jan 21–23 of a later year).
3. Click Update. The editor reports success.
4. The single event page shows the new dates.
5. List view does not include the event among upcoming events. “Next Events” is inactive, so the plugin believes it has already listed every upcoming event.

This was reproduced on **The Events Calendar 6.17.2** (WordPress 7.0.4, PHP 8.3, timezone `America/Chicago`, `tribe_events_timezone_mode = site`).

Concrete case: event ID `47322`. The editor and permalink showed January 21–23, 2027. `tec_occurrences` still stored:

| column | value |
| --- | --- |
| `start_date` | `2023-08-08 00:00:00` |
| `end_date` | `2023-08-11 23:59:59` |
| `end_date_utc` | `2023-08-12 04:59:59` |

List view keeps events with `end_date_utc > now`. In August 2026 that 2023 end date is already past, so the event is omitted. It can still appear under Previous Events, dated 2023.

REST confirms the split:

- `GET /wp-json/tribe/events/v1/events/47322` (by ID, hydrates from post meta) returns 2027 dates and `hide_from_listings: false`.
- Default upcoming archive search (now through ~2 years out) does not return the event.
- Archive search constrained to 2022–2024 start dates does return it.

---

## Why List view and the single event page disagree

Since 6.0, calendar and list queries do not primarily use `_EventStartDate` / `_EventEndDate`. They join `tec_occurrences` (and `tec_events`) and filter on those columns. With `tribe_events_timezone_mode = site`, the repository uses UTC keys:

```php
$this->normal_timezone = new DateTimeZone( 'UTC' );
$this->start_meta_key  = '_EventStartDateUTC';
$this->end_meta_key    = '_EventEndDateUTC';
```

List view then asks for events that have not ended yet:

```php
$args['ends_after'] = $date; // typically "now"
```

The single event template still reads post meta (and `tribe_get_event()` decorations from that meta). Updating dates in the editor writes post meta successfully. If the custom-tables upsert fails afterward, the permalink is “correct” and the listing is “wrong.” That is not a cache, theme, or “Hide from Event Listings” problem.

Custom Tables Health Check reporting “Good!” only means there are some posts and some rows in both tables. It does not compare occurrence dates to post meta.

---

## Root cause

### 1. All-day saves throw away the new duration

`Tribe__Events__API::prepare_event_date_meta()` already handles all-day events correctly:

- Sets start to `tribe_beginning_of_day()` (`00:00:00` with default cutoff)
- Sets end to `tribe_end_of_day()` (`23:59:59`)
- Sets `EventDuration` to `end_timestamp - start_timestamp` (span minus one second: 345599 for four all-day days, 259199 for three)

Both the classic editor (`Tribe__Events__Meta__Save`) and REST `updateEvent()` then call `saveEventMeta()`. Before this patch, that method did:

```php
if ( isset( $data['EventAllDay'] ) && 'yes' === $data['EventAllDay'] ) {
    $data['EventDuration'] = null;
}
```

Meta is written only when `isset( $data[ $htmlElement ] )` is true. `isset( null )` is `false`, so `_EventDuration` is never rewritten for an all-day save.

`_EventStartDate`, `_EventEndDate`, and the UTC twins **are** updated. Duration is left at whatever it was when the event was last saved as a longer range (or when it was first created).

That assignment dates to commit `931acda5` (August 2016, “Change authority”), six years before custom tables in 6.0. There is no stated rationale in the commit. It is leftover behavior that custom tables later made harmful.

### 2. Custom tables refuse to write the new dates

`TEC\Events\Custom_Tables\V1\Updates\Events::update()` builds a row from post meta via `Event::data_from_post()` and upserts it. Duration is taken from `_EventDuration` unless it is empty:

```php
$duration = get_post_meta( $post_id, '_EventDuration', true );

if ( empty( $duration ) && ! empty( $start_date_utc ) && ! empty( $end_date_utc ) ) {
    $duration = /* end_utc - start_utc */;
}
```

A stale positive duration is not empty, so it is not recalculated from the new dates.

The duration validator then requires `(end - start) >= duration`. After shortening a four-day all-day event to three days:

- New date span ≈ 259199 seconds
- Stored `_EventDuration` ≈ 345599 seconds
- `259199 >= 345599` fails

`Builder::upsert()` returns `false` and logs via `tribe_log` (Events → Help → Event Log), for example:

> The Event duration (345599) is greater than the one calculated using dates.

That does **not** go to PHP `debug.log` unless TEC’s `debugEvents` option is on. `Events::update()` treats upsert `false` as non-fatal:

```php
if ( $upsert === false ) {
    // At this stage the data might just be missing: it's fine.
    return false;
}
```

The editor still shows “Updated.” Occurrence rows keep the old dates.

### 3. Why clicking Update again does not help (until this fix)

`Meta_Watcher` only marks an event when a tracked key actually changes (`_EventStartDate`, `_EventEndDate`, `_EventDuration`, timezone, all-day, UTC twins). If the 2027 dates are already in post meta, saving again without changing a tracked value does not rebuild occurrences.

After this fix, a subsequent Update **does** change `_EventDuration` (345599 → 259199), so the watcher fires and the occurrence row can be rewritten. Existing mismatched events therefore heal on one save after deploying the patch. They are not repaired by updating the plugin alone.

---

## Why the fix writes duration instead of deleting it

An alternative would be to `delete_post_meta( …, '_EventDuration' )` for all-day events and rely on `empty( $duration )` in `data_from_post()`. That is worse.

`Tribe__Events__Main::fix_all_day_events()` (runs when the end-of-day cutoff setting changes) inner-joins `_EventDuration` for all-day events and sets:

```sql
end_date = DATE_ADD(start_date, INTERVAL duration SECOND)
```

The plugin already expects all-day events to carry a duration. The value `prepare_event_date_meta()` computes (span minus one second) is exactly what that `DATE_ADD` needs to land on `23:59:59`. Deleting the meta would keep all-day events out of that repair query permanently.

Timed events already persist duration this way. All-day events should too.

---

## The change

Remove the three-line block in `src/Tribe/API.php` that set `EventDuration` to `null` for all-day events. `prepare_event_date_meta()` has already computed the correct duration; the existing meta loop then writes `_EventDuration` like every other field.

No change to `Events::update()` silent-failure behavior (existing tests assert no log when upsert is stubbed to `false`). No defensive clamp in `Event::data_from_post()`; the save path is the actual bug.

---

## Tests

- `tests/wpunit/TEC/Events/APITest.php::should_update_duration_when_all_day_event_is_shortened`  
  Save a four-day all-day event, then save it as three all-day days. Assert `_EventDuration` shrinks and start/end meta match the new span.

- `tests/ct1_integration/TEC/Events/Custom_Tables/V1/Updates/EventsTest.php::should_update_occurrence_dates_when_all_day_event_is_shortened`  
  Same flow, then `Events::update()`. Assert the occurrence row has the new dates and `tribe_log` has no validator error.

Changelog: `changelog/fix-all-day-duration-not-updating-custom-tables` (`Significance: patch`, `Type: fix`).

---

## Test plan

- [ ] Create a published all-day event spanning four days, then edit it to three all-day days and Update.
- [ ] Confirm `_EventDuration` matches the new span (not the original four-day value).
- [ ] Confirm `tec_events` / `tec_occurrences` start/end (and UTC) dates match the shortened range.
- [ ] Confirm the event appears in List view in chronological order.
- [ ] Confirm timed (non-all-day) events still save duration as before.
- [ ] Confirm Events → Help → Event Log does not record a duration-validator error on that save.
- [ ] On a site that already has a mismatched event (post meta new, occurrences old): deploy the patch, open the event, click Update once, confirm occurrences catch up.
- [ ] `should_update_duration_when_all_day_event_is_shortened`
- [ ] `should_update_occurrence_dates_when_all_day_event_is_shortened`

---

## Existing data

This patch does not migrate old rows. Sites that already shortened all-day events need either:

1. One editor save after deploying the fix (duration meta changes, watcher fires, occurrences rebuild), or
2. A direct update of `_EventDuration`, `tec_events`, and `tec_occurrences` for that `post_id`.

Example duration for an all-day event Jan 21 00:00:00 through Jan 23 23:59:59 in `America/Chicago` (CST, UTC−6): `259199`, with `start_date_utc = 2027-01-21 06:00:00` and `end_date_utc = 2027-01-24 05:59:59`.
