### PR TITLE
 Improve error reporting

### DIFF
--- a/changelog/fix-smtnc-2262-ea-post-error-handling.yaml
+++ b/changelog/fix-smtnc-2262-ea-post-error-handling.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: tweak
+entry: Improve specificity of error handling when syncing event with Event Aggregator.
+timestamp: 2026-08-28T16:05:44.919Z

--- a/changelog/fix-smtnc-2262-ea-post-error-handling.yaml
+++ b/changelog/fix-smtnc-2262-ea-post-error-handling.yaml
@@ -1,4 +1,4 @@
 significance: patch
 type: tweak
-entry: Improve specificity of error handling when syncing event with Event Aggregator.
+entry: Improved specificity of error handling when syncing events with Event Aggregator.
 timestamp: 2026-08-28T16:05:44.919Z

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -288,10 +288,12 @@ class Tribe__Events__Aggregator__Service {
 	/**
 	 * Performs a POST request against the Event Aggregator service
 	 *
-	 * @param string $endpoint   Endpoint for the Event Aggregator service
-	 * @param array  $data       Parameters to send to the endpoint
+	 * @since TBD Moved the transport-error check ahead of the response-code read and added distinct handling for a blocked (403) response.
 	 *
-	 * @return stdClass|WP_Error
+	 * @param string $endpoint Endpoint for the Event Aggregator service.
+	 * @param array  $data     Parameters to send to the endpoint.
+	 *
+	 * @return stdClass|WP_Error The decoded response body, or a WP_Error describing the failure.
 	 */
 	public function post( $endpoint, $data = [] ) {
 		$url = $this->build_url( $endpoint );
@@ -314,9 +316,11 @@ class Tribe__Events__Aggregator__Service {
 
 		$response = $this->requests->post( esc_url_raw( $url ), $args );
 
-		// A transport-level failure (DNS, TLS, refused connection, timeout) never carries a
-		// response code, so this has to be checked before `$code` is read: a `WP_Error` would
-		// otherwise yield `0` and get reported as a generic server-side problem.
+		/*
+		 * A transport-level failure (DNS, TLS, refused connection, timeout) never carries a
+		 * response code, so this has to be checked before `$code` is read: a `WP_Error` would
+		 * otherwise yield `0` and get reported as a generic server-side problem.
+		 */
 		if ( is_wp_error( $response ) ) {
 			tribe( 'logger' )->log_debug(
 				'Request failed during the creation: ' . $response->get_error_message(),
@@ -329,6 +333,8 @@ class Tribe__Events__Aggregator__Service {
 		$code = (int) wp_remote_retrieve_response_code( $response );
 
 		if ( 403 === $code ) {
+			tribe( 'logger' )->log_debug( 'Request denied with a 403 - during the creation.', 'EA Service' );
+
 			return new WP_Error(
 				'core:aggregator:request-denied',
 				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.', 'the-events-calendar' )

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -314,18 +314,34 @@ class Tribe__Events__Aggregator__Service {
 
 		$response = $this->requests->post( esc_url_raw( $url ), $args );
 
-		// we know it is not a 404 or 403 at this point.
+		// A transport-level failure (DNS, TLS, refused connection, timeout) never carries a
+		// response code, so this has to be checked before `$code` is read: a `WP_Error` would
+		// otherwise yield `0` and get reported as a generic server-side problem.
+		if ( is_wp_error( $response ) ) {
+			tribe( 'logger' )->log_debug(
+				'Request failed during the creation: ' . $response->get_error_message(),
+				'EA Service'
+			);
+
+			return $response;
+		}
+
 		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 403 === $code ) {
+			return new WP_Error(
+				'core:aggregator:request-denied',
+				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.', 'the-events-calendar' )
+			);
+		}
+
+		// we know it is not a 403 at this point.
 		if ( $code >= 300 || $code < 200 ) {
 			tribe( 'logger' )->log_debug( "Invalid response code: {$code} - during the creation.", 'EA Service' );
 			return new WP_Error(
 				'core:aggregator:bad-response',
 				esc_html__( 'There may be an issue with the Event Aggregator server. Please try your import again later.', 'the-events-calendar' )
 			);
-		}
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
 		}
 
 		$json = json_decode( wp_remote_retrieve_body( $response ) );

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -246,7 +246,7 @@ class Tribe__Events__Aggregator__Service {
 		if ( 403 === $code ) {
 			return new WP_Error(
 				'core:aggregator:request-denied',
-				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.', 'the-events-calendar' )
+				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support.', 'the-events-calendar' )
 			);
 		}
 

--- a/src/Tribe/Aggregator/Service.php
+++ b/src/Tribe/Aggregator/Service.php
@@ -337,7 +337,7 @@ class Tribe__Events__Aggregator__Service {
 
 			return new WP_Error(
 				'core:aggregator:request-denied',
-				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.', 'the-events-calendar' )
+				esc_html__( 'Event Aggregator server has blocked your request. Please try your import again later or contact support.', 'the-events-calendar' )
 			);
 		}
 

--- a/src/Tribe/Aggregator/Tabs/New.php
+++ b/src/Tribe/Aggregator/Tabs/New.php
@@ -483,7 +483,7 @@ class Tribe__Events__Aggregator__Tabs__New extends Tribe__Events__Aggregator__Ta
 			$service      = tribe( 'events-aggregator.service' );
 			$result       = (object) array(
 				'message_code' => $result->get_error_code(),
-				'message'      => $service->get_service_message( $result->get_error_code(), $result->get_error_data() ?? [] ),
+				'message'      => $service->get_service_message( $result->get_error_code(), $result->get_error_data() ?? [], $result->get_error_message() ),
 			);
 			wp_send_json_error( $result );
 		}

--- a/tests/muintegration/Tribe/Events/Aggregator/ServiceTest.php
+++ b/tests/muintegration/Tribe/Events/Aggregator/ServiceTest.php
@@ -304,10 +304,6 @@ class ServiceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * A transport-level failure has no response code, so `post()` has to check for it before
-	 * reading one. Regression: the code check used to run first, turning every cURL failure
-	 * into `core:aggregator:bad-response` and discarding the real reason.
-	 *
 	 * @test
 	 * it should return the transport error when the post request fails at the transport level
 	 */
@@ -351,9 +347,6 @@ class ServiceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * The generic message is still correct for a genuine server-side fault; it just must not be
-	 * the catch-all for causes the client can tell apart.
-	 *
 	 * @test
 	 * it should report a bad response when the post request returns a server error
 	 */
@@ -378,9 +371,11 @@ class ServiceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * @since TBD
+	 *
 	 * @param int $code The HTTP status code the mocked response should carry.
 	 *
-	 * @return array
+	 * @return array{response: array{code: string}, headers: array{content-type: string}, body: string} A mocked `wp_remote_post()` response carrying the given status code.
 	 */
 	protected function make_mock_response_with_code( $code ) {
 		return [

--- a/tests/muintegration/Tribe/Events/Aggregator/ServiceTest.php
+++ b/tests/muintegration/Tribe/Events/Aggregator/ServiceTest.php
@@ -304,10 +304,92 @@ class ServiceTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * A transport-level failure has no response code, so `post()` has to check for it before
+	 * reading one. Regression: the code check used to run first, turning every cURL failure
+	 * into `core:aggregator:bad-response` and discarding the real reason.
+	 *
+	 * @test
+	 * it should return the transport error when the post request fails at the transport level
+	 */
+	public function it_should_return_the_transport_error_when_the_post_request_fails() {
+		update_option( 'pue_install_key_event_aggregator', 'foo-bar' );
+
+		$transport_error = new \WP_Error(
+			'http_request_failed',
+			'cURL error 28: Operation timed out after 15001 milliseconds'
+		);
+
+		$this->requests->post( Argument::type( 'string' ), Argument::type( 'array' ) )
+		               ->willReturn( $transport_error );
+
+		$sut      = $this->make_instance();
+		$response = $sut->post( 'import', [ 'origin' => 'eventbrite' ] );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'http_request_failed', $response->get_error_code() );
+		$this->assertEquals(
+			'cURL error 28: Operation timed out after 15001 milliseconds',
+			$response->get_error_message()
+		);
+	}
+
+	/**
+	 * @test
+	 * it should report a denied request distinctly when the post request is forbidden
+	 */
+	public function it_should_report_a_denied_request_when_the_post_request_is_forbidden() {
+		update_option( 'pue_install_key_event_aggregator', 'foo-bar' );
+
+		$this->requests->post( Argument::type( 'string' ), Argument::type( 'array' ) )
+		               ->willReturn( $this->make_mock_response_with_code( 403 ) );
+
+		$sut      = $this->make_instance();
+		$response = $sut->post( 'import', [ 'origin' => 'eventbrite' ] );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'core:aggregator:request-denied', $response->get_error_code() );
+	}
+
+	/**
+	 * The generic message is still correct for a genuine server-side fault; it just must not be
+	 * the catch-all for causes the client can tell apart.
+	 *
+	 * @test
+	 * it should report a bad response when the post request returns a server error
+	 */
+	public function it_should_report_a_bad_response_when_the_post_request_returns_a_server_error() {
+		update_option( 'pue_install_key_event_aggregator', 'foo-bar' );
+
+		$this->requests->post( Argument::type( 'string' ), Argument::type( 'array' ) )
+		               ->willReturn( $this->make_mock_response_with_code( 500 ) );
+
+		$sut      = $this->make_instance();
+		$response = $sut->post( 'import', [ 'origin' => 'eventbrite' ] );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 'core:aggregator:bad-response', $response->get_error_code() );
+	}
+
+	/**
 	 * @return Service
 	 */
 	private function make_instance() {
 		return new Service( $this->requests->reveal() );
+	}
+
+	/**
+	 * @param int $code The HTTP status code the mocked response should carry.
+	 *
+	 * @return array
+	 */
+	protected function make_mock_response_with_code( $code ) {
+		return [
+			'response' => [
+				'code' => (string) $code,
+			],
+			'headers'  => [ 'content-type' => 'json' ],
+			'body'     => '',
+		];
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2262](https://linear.app/nexcess/issue/SMTNC-2262/event-aggregator-fails-to-import-from-eventbrite-despite-successful)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This PR is to improve the specificity of the error handling for EA. Before, there were four different scenarios that would result in the error message “There was an error fetching the results from your import: There may be an issue with the Event Aggregator server. Please try your import again later.”

After this PR, specific error messages will show or if the error is a `403` it will show the message 'Event Aggregator server has blocked your request. Please try your import again later or contact support to know why.'

I don't think that these changes will necessarily straight up fix the linear ticket linked, but it at least will give us more information about why a user is being blocked from importing events from eventbrite. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
