### PR TITLE
Prevent fatal when a snippet returns a non-array from tec_views_v2_subscribe_links

### DIFF
--- a/changelog/smtnc-1042-snippet-for-hiding-all-subscribe-links-causes-a-fatal.yaml
+++ b/changelog/smtnc-1042-snippet-for-hiding-all-subscribe-links-causes-a-fatal.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where hiding the subscribe links with a snippet that returns
+  a non-array value from the `tec_views_v2_subscribe_links` filter could cause a fatal
+  error on single event pages.
+timestamp: 2026-08-31T00:00:00.000Z

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -119,6 +119,11 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 			return $subscribe_links;
 		}
 
+		// An earlier filter may have replaced the list with a non-array; don't append to it.
+		if ( ! is_array( $subscribe_links ) ) {
+			return $subscribe_links;
+		}
+
 		$subscribe_links[ self::get_slug() ] = $this;
 
 		return $subscribe_links;

--- a/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
+++ b/src/Tribe/Views/V2/iCalendar/Links/Link_Abstract.php
@@ -112,6 +112,8 @@ abstract class Link_Abstract implements Link_Interface, JsonSerializable {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @since TBD Return the value untouched when an earlier callback replaced it with a non-array.
 	 */
 	public function filter_tec_views_v2_subscribe_links( $subscribe_links ) {
 		// Bail early if we're not supposed to show this link.

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -159,6 +159,7 @@ class iCalendar_Handler extends Service_Provider {
 	 *
 	 * @since 5.12.0
 	 * @since 6.17.0 Made $view explicitly nullable.
+	 * @since TBD Normalize the filtered value so a non-array return cannot reach consumers.
 	 *
 	 * @param View|null $view
 	 *
@@ -176,7 +177,10 @@ class iCalendar_Handler extends Service_Provider {
 		 * @param array<string|object> $subscribe_links The array of links.
 		 * @param View|null            $view            The View implementation.
 		 */
-		return apply_filters( 'tec_views_v2_subscribe_links', $subscribe_links, $view );
+		$subscribe_links = apply_filters( 'tec_views_v2_subscribe_links', $subscribe_links, $view );
+
+		// Snippets commonly hide the links with `__return_false`; consumers are documented an array.
+		return is_array( $subscribe_links ) ? $subscribe_links : [];
 	}
 
 	/**

--- a/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
+++ b/src/Tribe/Views/V2/iCalendar/iCalendar_Handler.php
@@ -179,7 +179,7 @@ class iCalendar_Handler extends Service_Provider {
 		 */
 		$subscribe_links = apply_filters( 'tec_views_v2_subscribe_links', $subscribe_links, $view );
 
-		// Snippets commonly hide the links with `__return_false`; consumers are documented an array.
+		// Consumers are documented an array; a snippet hiding the links can return anything.
 		return is_array( $subscribe_links ) ? $subscribe_links : [];
 	}
 

--- a/tests/views_integration/Tribe/Events/Views/V2/iCalendar/Subscribe_LinksTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/iCalendar/Subscribe_LinksTest.php
@@ -9,39 +9,91 @@ use Tribe\Events\Views\V2\iCalendar\Links\Google_Calendar;
  * Regression coverage for snippets that hide the subscribe links by returning a non-array
  * from `tec_views_v2_subscribe_links`.
  *
+ * A snippet registered from an mu-plugin or a theme runs before the link classes hook themselves at
+ * priority 10, so the links appended to whatever it returned: a truthy scalar fataled the page with
+ * `Cannot use a scalar value as an array`, and `false` was converted back into an array, putting the
+ * links the snippet meant to hide back on the page.
+ *
  * @see https://theeventscalendar.com/knowledgebase/remove-ical-and-google-calendar-links-from-single-event-views/
  */
 class Subscribe_LinksTest extends WPTestCase {
 
 	/**
-	 * @return iCalendar_Handler
+	 * The non-array values a snippet can return from the filter.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,array<mixed>> The data sets.
 	 */
-	protected function handler() {
-		return tribe( iCalendar_Handler::class );
-	}
-
-	public function test_get_subscribe_links_normalizes_non_array_filter_return() {
-		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 100 );
-
-		$this->assertSame( [], $this->handler()->get_subscribe_links() );
-	}
-
-	/**
-	 * The exact fatal reported: `count(): Argument #1 ($value) must be of type Countable|array, bool given`.
-	 */
-	public function test_single_event_links_does_not_fatal_when_filter_returns_false() {
-		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 100 );
-
-		$this->assertSame( '', $this->handler()->single_event_links( 'original links' ) );
+	public function non_array_returns() {
+		return [
+			'false'        => [ false ],
+			'true'         => [ true ],
+			'empty string' => [ '' ],
+			'null'         => [ null ],
+		];
 	}
 
 	/**
-	 * A snippet running before the links hook themselves must not make them append to a non-array.
+	 * A link must not append itself to a list an earlier callback replaced with a non-array.
+	 *
+	 * @since TBD
+	 *
+	 * @dataProvider non_array_returns
+	 *
+	 * @param mixed $value The value the snippet returned.
 	 */
-	public function test_link_does_not_append_to_non_array_list() {
-		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 5 );
+	public function test_link_returns_non_array_list_untouched( $value ) {
+		$this->assertSame( $value, tribe( Google_Calendar::class )->filter_tec_views_v2_subscribe_links( $value ) );
+	}
 
-		$this->assertFalse( tribe( Google_Calendar::class )->filter_tec_views_v2_subscribe_links( false ) );
-		$this->assertSame( [], $this->handler()->get_subscribe_links() );
+	/**
+	 * Consumers are documented an array, whatever the last callback returned.
+	 *
+	 * @since TBD
+	 *
+	 * @dataProvider non_array_returns
+	 *
+	 * @param mixed $value The value the snippet returned.
+	 */
+	public function test_get_subscribe_links_returns_an_array( $value ) {
+		$this->hide_links_with( $value, 100 );
+
+		$this->assertSame( [], tribe( iCalendar_Handler::class )->get_subscribe_links() );
+	}
+
+	/**
+	 * The reported fatal: a snippet running before the links broke the single event page.
+	 *
+	 * @since TBD
+	 *
+	 * @dataProvider non_array_returns
+	 *
+	 * @param mixed $value The value the snippet returned.
+	 */
+	public function test_single_event_links_does_not_fatal_when_a_snippet_runs_first( $value ) {
+		$this->hide_links_with( $value, 5 );
+
+		$this->assertSame( '', tribe( iCalendar_Handler::class )->single_event_links( 'original links' ) );
+	}
+
+	/**
+	 * Hooks a snippet that replaces the link list with a non-array value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value    The value the snippet returns.
+	 * @param int   $priority The priority the snippet hooks at.
+	 *
+	 * @return void
+	 */
+	protected function hide_links_with( $value, $priority ) {
+		add_filter(
+			'tec_views_v2_subscribe_links',
+			static function () use ( $value ) {
+				return $value;
+			},
+			$priority
+		);
 	}
 }

--- a/tests/views_integration/Tribe/Events/Views/V2/iCalendar/Subscribe_LinksTest.php
+++ b/tests/views_integration/Tribe/Events/Views/V2/iCalendar/Subscribe_LinksTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tribe\Events\Views\V2\iCalendar;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Events\Views\V2\iCalendar\Links\Google_Calendar;
+
+/**
+ * Regression coverage for snippets that hide the subscribe links by returning a non-array
+ * from `tec_views_v2_subscribe_links`.
+ *
+ * @see https://theeventscalendar.com/knowledgebase/remove-ical-and-google-calendar-links-from-single-event-views/
+ */
+class Subscribe_LinksTest extends WPTestCase {
+
+	/**
+	 * @return iCalendar_Handler
+	 */
+	protected function handler() {
+		return tribe( iCalendar_Handler::class );
+	}
+
+	public function test_get_subscribe_links_normalizes_non_array_filter_return() {
+		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 100 );
+
+		$this->assertSame( [], $this->handler()->get_subscribe_links() );
+	}
+
+	/**
+	 * The exact fatal reported: `count(): Argument #1 ($value) must be of type Countable|array, bool given`.
+	 */
+	public function test_single_event_links_does_not_fatal_when_filter_returns_false() {
+		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 100 );
+
+		$this->assertSame( '', $this->handler()->single_event_links( 'original links' ) );
+	}
+
+	/**
+	 * A snippet running before the links hook themselves must not make them append to a non-array.
+	 */
+	public function test_link_does_not_append_to_non_array_list() {
+		add_filter( 'tec_views_v2_subscribe_links', '__return_false', 5 );
+
+		$this->assertFalse( tribe( Google_Calendar::class )->filter_tec_views_v2_subscribe_links( false ) );
+		$this->assertSame( [], $this->handler()->get_subscribe_links() );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1042](https://linear.app/nexcess/issue/SMTNC-1042/snippet-for-hiding-all-subscribe-links-causes-a-fatal-error)

### 🗒️ Description

The snippet in [our KB article](https://theeventscalendar.com/knowledgebase/remove-ical-and-google-calendar-links-from-single-event-views/) hides the subscribe links with `add_filter( 'tec_views_v2_subscribe_links', '__return_false', 100 )`, which replaces the list of links with `false`. Calendar views only ever check that value with `empty()`, so it appears to work. Single events hand it to `count()`, and PHP 8 fatals:

```
Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given
in .../src/Tribe/Views/V2/iCalendar/Single_Events.php:85
```

`Single_Events::single_event_links()` already got a guard in 6.10.1, but that only covered the one caller the report named. This moves the check to where all of them route through:

- `iCalendar_Handler::get_subscribe_links()` now returns the array its docblock has always promised, so no consumer — templates, the single event links, the block — can receive a scalar.
- `Link_Abstract::filter_tec_views_v2_subscribe_links()` bails on a non-array instead of writing an offset into it. A snippet hooked below priority 10 reaches the link classes before they append, which is the same bug one step earlier in the chain.

The snippet in the KB article now does what it says on all views, so no workaround (`__return_empty_array`) is needed.

### Artifacts
https://www.loom.com/share/7320407c316d4e32b22fa3a403687690

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.