### PR TITLE
[SMTNC-1515] Update TEC blocks to Block API version 3

### DIFF
--- a/changelog/tec-blocks-api-version-3.yaml
+++ b/changelog/tec-blocks-api-version-3.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: compatibility
+entry: Registered the plugin's editor blocks with Block API version 3 so they
+  render correctly inside the iframed block editor introduced in WordPress 6.9.
+timestamp: 2026-08-30T03:04:21.788Z

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -14,7 +14,9 @@ global.wp = {
 	apiRequest: () => $.Deferred(),
 	components: {},
 	data: {},
-	blockEditor: {},
+	blockEditor: {
+		useBlockProps: () => ( { className: 'wp-block' } ),
+	},
 	editor: {},
 	hooks: {
 		addAction: jest.fn(),

--- a/src/modules/blocks/__tests__/with-block-wrapper.test.js
+++ b/src/modules/blocks/__tests__/with-block-wrapper.test.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import withBlockWrapper, { BLOCK_API_VERSION } from '@moderntribe/events/blocks/with-block-wrapper';
+
+const Edit = ( { title } ) => <span>{ title }</span>;
+
+const blockDefinition = {
+	id: 'event-probe',
+	title: 'Event Probe',
+	category: 'tribe-events',
+	supports: { html: false },
+	edit: Edit,
+	save: () => null,
+};
+
+describe( 'Block wrapper', () => {
+	it( 'Should register at the Block API version the editor expects', () => {
+		expect( withBlockWrapper( blockDefinition ).apiVersion ).toBe( BLOCK_API_VERSION );
+	} );
+
+	it( 'Should leave the rest of the block definition untouched', () => {
+		const { edit, apiVersion, ...rest } = withBlockWrapper( blockDefinition );
+		const { edit: originalEdit, ...originalRest } = blockDefinition;
+
+		expect( rest ).toEqual( originalRest );
+	} );
+
+	it( 'Should render the block edit component inside the wrapper element', () => {
+		const wrapped = withBlockWrapper( blockDefinition );
+		const component = renderer.create( <wrapped.edit title={ blockDefinition.title } /> );
+
+		expect( component.root.findByType( Edit ).props.title ).toBe( blockDefinition.title );
+		expect( component.toJSON() ).toMatchObject( {
+			type: 'div',
+			props: { className: 'wp-block' },
+		} );
+	} );
+} );

--- a/src/modules/blocks/__tests__/with-block-wrapper.test.js
+++ b/src/modules/blocks/__tests__/with-block-wrapper.test.js
@@ -1,4 +1,10 @@
 /**
+ * Tests for the Block API version adapter.
+ *
+ * @since TBD
+ */
+
+/**
  * External dependencies
  */
 import renderer from 'react-test-renderer';
@@ -8,6 +14,9 @@ import React from 'react';
  * Internal dependencies
  */
 import withBlockWrapper, { BLOCK_API_VERSION } from '@moderntribe/events/blocks/with-block-wrapper';
+
+/* Mirrors the className the `useBlockProps` mock in jest.setup.js returns. */
+const WRAPPER_CLASS_NAME = 'wp-block';
 
 const Edit = ( { title } ) => <span>{ title }</span>;
 
@@ -21,15 +30,19 @@ const blockDefinition = {
 };
 
 describe( 'Block wrapper', () => {
-	it( 'Should register at the Block API version the editor expects', () => {
-		expect( withBlockWrapper( blockDefinition ).apiVersion ).toBe( BLOCK_API_VERSION );
+	it( 'Should register at Block API version 3', () => {
+		/* 3 is the version WordPress 6.9 requires of a block that runs in the iframed editor. */
+		expect( BLOCK_API_VERSION ).toBe( 3 );
+		expect( withBlockWrapper( blockDefinition ).apiVersion ).toBe( 3 );
 	} );
 
 	it( 'Should leave the rest of the block definition untouched', () => {
-		const { edit, apiVersion, ...rest } = withBlockWrapper( blockDefinition );
-		const { edit: originalEdit, ...originalRest } = blockDefinition;
+		const wrapped = withBlockWrapper( blockDefinition );
+		const untouched = Object.keys( blockDefinition ).filter( ( key ) => key !== 'edit' );
 
-		expect( rest ).toEqual( originalRest );
+		untouched.forEach( ( key ) => {
+			expect( wrapped[ key ] ).toEqual( blockDefinition[ key ] );
+		} );
 	} );
 
 	it( 'Should render the block edit component inside the wrapper element', () => {
@@ -39,7 +52,7 @@ describe( 'Block wrapper', () => {
 		expect( component.root.findByType( Edit ).props.title ).toBe( blockDefinition.title );
 		expect( component.toJSON() ).toMatchObject( {
 			type: 'div',
-			props: { className: 'wp-block' },
+			props: { className: WRAPPER_CLASS_NAME },
 		} );
 	} );
 } );

--- a/src/modules/blocks/archive-events/index.js
+++ b/src/modules/blocks/archive-events/index.js
@@ -30,9 +30,9 @@ export default {
 	icon: 'calendar-alt',
 	category: 'tribe-events',
 	keywords: [ __( 'Archive Events', 'the-events-calendar' ), __( 'The Events Calendar', 'the-events-calendar' ) ],
-	edit: ( props ) => {
+	edit: () => {
 		return (
-			<div className={ props.className }>
+			<div>
 				<h3>{ __( 'Archive Events', 'the-events-calendar' ) }</h3>
 				<p>
 					{

--- a/src/modules/blocks/archive-events/index.js
+++ b/src/modules/blocks/archive-events/index.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
  * External Dependencies
  */
 const { __ } = wp.i18n;
-const { useBlockProps } = wp.blockEditor;
 
 /**
  * Small component to simplify some pseudo event blocks.
@@ -32,11 +31,8 @@ export default {
 	category: 'tribe-events',
 	keywords: [ __( 'Archive Events', 'the-events-calendar' ), __( 'The Events Calendar', 'the-events-calendar' ) ],
 	edit: ( props ) => {
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const { className, ...blockProps } = useBlockProps();
-
 		return (
-			<div className={ `${ className } ${ props.className }` } { ...blockProps }>
+			<div className={ props.className }>
 				<h3>{ __( 'Archive Events', 'the-events-calendar' ) }</h3>
 				<p>
 					{

--- a/src/modules/blocks/event-venue/index.js
+++ b/src/modules/blocks/event-venue/index.js
@@ -15,6 +15,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import blockAttributes from './data/attributes';
 import EventVenue from './container';
 import { Venue } from '@moderntribe/events/icons';
+import withBlockWrapper from '@moderntribe/events/blocks/with-block-wrapper';
 
 export const blockDefinition = {
 	id: 'event-venue',
@@ -37,4 +38,4 @@ export const blockDefinition = {
 /**
  * Register Block
  */
-export default registerBlockType( `tribe/${ blockDefinition.id }`, blockDefinition );
+export default registerBlockType( `tribe/${ blockDefinition.id }`, withBlockWrapper( blockDefinition ) );

--- a/src/modules/blocks/index.js
+++ b/src/modules/blocks/index.js
@@ -19,6 +19,7 @@ import eventWebsite from '@moderntribe/events/blocks/event-website';
 import FeaturedImage from '@moderntribe/events/blocks/featured-image';
 import archiveEvents from '@moderntribe/events/blocks/archive-events';
 import singleEvent from '@moderntribe/events/blocks/single-event';
+import withBlockWrapper from '@moderntribe/events/blocks/with-block-wrapper';
 import { initStore } from '@moderntribe/events/data';
 import './style.pcss';
 
@@ -43,7 +44,7 @@ const blocks = [
 
 blocks.forEach( ( block ) => {
 	const blockName = block.id.includes( '/' ) ? block.id : `tribe/${ block.id }`;
-	registerBlockType( blockName, block );
+	registerBlockType( blockName, withBlockWrapper( block ) );
 } );
 
 // Initialize AFTER blocks are registered

--- a/src/modules/blocks/single-event/index.js
+++ b/src/modules/blocks/single-event/index.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
  * External Dependencies
  */
 const { __ } = wp.i18n;
-const { useBlockProps } = wp.blockEditor;
 
 /**
  * Small component to simplify some pseudo event blocks.
@@ -34,11 +33,8 @@ export default {
 	category: 'tribe-events',
 	keywords: [ __( 'Single Event', 'the-events-calendar' ), __( 'The Events Calendar', 'the-events-calendar' ) ],
 	edit: ( props ) => {
-		// eslint-disable-next-line react-hooks/rules-of-hooks
-		const { className, ...blockProps } = useBlockProps();
-
 		return (
-			<div className={ `${ className } ${ props.className }` } { ...blockProps }>
+			<div className={ props.className }>
 				<h3>{ __( 'Event Title', 'the-events-calendar' ) }</h3>
 				<p>
 					<strong>{ __( 'EVENT DATE/TIME', 'the-events-calendar' ) }</strong>

--- a/src/modules/blocks/single-event/index.js
+++ b/src/modules/blocks/single-event/index.js
@@ -32,9 +32,9 @@ export default {
 	icon: 'calendar-alt',
 	category: 'tribe-events',
 	keywords: [ __( 'Single Event', 'the-events-calendar' ), __( 'The Events Calendar', 'the-events-calendar' ) ],
-	edit: ( props ) => {
+	edit: () => {
 		return (
-			<div className={ props.className }>
+			<div>
 				<h3>{ __( 'Event Title', 'the-events-calendar' ) }</h3>
 				<p>
 					<strong>{ __( 'EVENT DATE/TIME', 'the-events-calendar' ) }</strong>

--- a/src/modules/blocks/with-block-wrapper.js
+++ b/src/modules/blocks/with-block-wrapper.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const { useBlockProps } = wp.blockEditor;
+
+/**
+ * The Block API version the blocks of this plugin register with.
+ *
+ * @since TBD
+ *
+ * @type {number}
+ */
+export const BLOCK_API_VERSION = 3;
+
+/**
+ * Adapts a block definition to the Block API version this plugin registers with.
+ *
+ * From Block API version 2 onwards the editor no longer renders the wrapper element around a
+ * block's `edit` output, so the block has to render it itself through `useBlockProps()`. Without
+ * it the block loses the attributes the editor relies on to select, drag and label it.
+ *
+ * @since TBD
+ *
+ * @param {Object}   block      The block definition to adapt.
+ * @param {Function} block.edit The component the editor renders for the block.
+ *
+ * @return {Object} The block definition, registering at the current Block API version.
+ */
+const withBlockWrapper = ( block ) => {
+	const Edit = block.edit;
+
+	const BlockEdit = ( props ) => {
+		const blockProps = useBlockProps();
+
+		return (
+			<div { ...blockProps }>
+				<Edit { ...props } />
+			</div>
+		);
+	};
+
+	return {
+		...block,
+		apiVersion: BLOCK_API_VERSION,
+		edit: BlockEdit,
+	};
+};
+
+export default withBlockWrapper;

--- a/src/modules/widgets/index.js
+++ b/src/modules/widgets/index.js
@@ -3,6 +3,7 @@
  */
 import EventsList from '@moderntribe/events/widgets/events-list';
 import QrCode from '@moderntribe/events/widgets/qr-code';
+import withBlockWrapper from '@moderntribe/events/blocks/with-block-wrapper';
 import './style.pcss';
 
 const { registerBlockType } = wp.blocks;
@@ -14,7 +15,7 @@ const blocks = [
 
 blocks.forEach( ( block ) => {
 	const blockName = `tribe/${ block.id }`;
-	registerBlockType( blockName, block );
+	registerBlockType( blockName, withBlockWrapper( block ) );
 } );
 
 export default blocks;


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1515](https://linear.app/nexcess/issue/SMTNC-1515/update-tec-blocks-to-block-api-version-3)

### 🎥 Artifacts

https://www.loom.com/share/2d68b550517e49bbab44a83f7800da63

### 🗒️ Description

Registers the plugin's editor blocks at Block API version 3 so they render their own wrapper element and keep working inside the iframed block editor that WordPress 6.9 deprecated older blocks for.

### ⚠️ Blockers

None.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
