### PR TITLE
Add token to checkout step in release workflow

### DIFF
--- a/.github/workflows/release-prepare-branch.yml
+++ b/.github/workflows/release-prepare-branch.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.GHA_BOT_TOKEN_MANAGER }}
 
       - name: Set Variables
         id: vars


### PR DESCRIPTION
🗒️ Description
This PR updates the release workflow to use GHA_BOT_TOKEN_MANAGER in the actions/checkout step.

Previously, subsequent git push commands were using the default GitHub Actions token (github-actions[bot]), which did not have the required permissions and resulted in a 403 error.

Using the existing bot token during checkout ensures that Git credentials are persisted with the appropriate permissions for branch creation and pushes.

Type of change: Bug fix (non-breaking change).