### PR TITLE
[SOFT-3323] fix: RSVP V2 Import issue

### DIFF
--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -201,11 +201,8 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 
 		try {
 			$importer = $this->get_importer();
-		} catch ( RuntimeException $e ) {
-			// Only roll back if nothing else has saved a newer mapping since our write above.
-			if ( get_option( $option_key ) === $data['column_map'] ) {
-				update_option( $option_key, $previous_map );
-			}
+		} catch ( InvalidArgumentException $e ) {
+			update_option( $option_key, $previous_map );
 			return tribe_error( 'core:aggregator:missing-csv-file' );
 		}
 
@@ -221,10 +218,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$missing         = array_diff( $required_fields, $data['column_map'] );
 
 		if ( ! empty( $missing ) ) {
-			// Only roll back if nothing else has saved a newer mapping since our write above.
-			if ( get_option( $option_key ) === $data['column_map'] ) {
-				update_option( $option_key, $previous_map );
-			}
+			update_option( $option_key, $previous_map );
 
 			$mapper = new Tribe__Events__Importer__Column_Mapper( $content_type );
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -196,7 +196,7 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		// permanently overwrite it - get_importer() needs the option set to build the
 		// importer with *this* submission's map, but we must not let a rejected map stick
 		// around as the default for the next preview if we end up returning an error.
-		$previous_map = get_option( $option_key, array() );
+		$previous_map = get_option( $option_key, [] );
 		update_option( $option_key, $data['column_map'] );
 
 		try {

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -192,19 +192,15 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 
 		$content_type = $this->get_csv_content_type();
 		$option_key   = 'tribe_events_import_column_mapping_' . $content_type;
-		// Remember the last-known-good mapping so an invalid submission below doesn't
-		// permanently overwrite it - get_importer() needs the option set to build the
-		// importer with *this* submission's map, but we must not let a rejected map stick
-		// around as the default for the next preview if we end up returning an error.
-		$previous_map = get_option( $option_key, [] );
-		update_option( $option_key, $data['column_map'] );
 
 		try {
 			$importer = $this->get_importer();
 		} catch ( InvalidArgumentException $e ) {
-			update_option( $option_key, $previous_map );
 			return tribe_error( 'core:aggregator:missing-csv-file' );
 		}
+
+		// Validate against this submission's map directly; don't persist it until validation passes.
+		$importer->set_map( $data['column_map'] );
 
 		if ( ! empty( $data['category'] ) ) {
 			$importer = $this->maybe_set_default_category( $importer );
@@ -218,8 +214,6 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$missing         = array_diff( $required_fields, $data['column_map'] );
 
 		if ( ! empty( $missing ) ) {
-			update_option( $option_key, $previous_map );
-
 			$mapper = new Tribe__Events__Importer__Column_Mapper( $content_type );
 
 			/**
@@ -236,6 +230,8 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 				$message
 			);
 		}
+
+		update_option( $option_key, $data['column_map'] );
 
 		return $importer;
 	}

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -202,7 +202,10 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		try {
 			$importer = $this->get_importer();
 		} catch ( RuntimeException $e ) {
-			update_option( $option_key, $previous_map );
+			// Only roll back if nothing else has saved a newer mapping since our write above.
+			if ( get_option( $option_key ) === $data['column_map'] ) {
+				update_option( $option_key, $previous_map );
+			}
 			return tribe_error( 'core:aggregator:missing-csv-file' );
 		}
 
@@ -218,7 +221,10 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$missing         = array_diff( $required_fields, $data['column_map'] );
 
 		if ( ! empty( $missing ) ) {
-			update_option( $option_key, $previous_map );
+			// Only roll back if nothing else has saved a newer mapping since our write above.
+			if ( get_option( $option_key ) === $data['column_map'] ) {
+				update_option( $option_key, $previous_map );
+			}
 
 			$mapper = new Tribe__Events__Importer__Column_Mapper( $content_type );
 

--- a/src/Tribe/Aggregator/Record/CSV.php
+++ b/src/Tribe/Aggregator/Record/CSV.php
@@ -191,11 +191,18 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		}
 
 		$content_type = $this->get_csv_content_type();
-		update_option( 'tribe_events_import_column_mapping_' . $content_type, $data['column_map'] );
+		$option_key   = 'tribe_events_import_column_mapping_' . $content_type;
+		// Remember the last-known-good mapping so an invalid submission below doesn't
+		// permanently overwrite it - get_importer() needs the option set to build the
+		// importer with *this* submission's map, but we must not let a rejected map stick
+		// around as the default for the next preview if we end up returning an error.
+		$previous_map = get_option( $option_key, array() );
+		update_option( $option_key, $data['column_map'] );
 
 		try {
 			$importer = $this->get_importer();
 		} catch ( RuntimeException $e ) {
+			update_option( $option_key, $previous_map );
 			return tribe_error( 'core:aggregator:missing-csv-file' );
 		}
 
@@ -211,6 +218,8 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 		$missing         = array_diff( $required_fields, $data['column_map'] );
 
 		if ( ! empty( $missing ) ) {
+			update_option( $option_key, $previous_map );
+
 			$mapper = new Tribe__Events__Importer__Column_Mapper( $content_type );
 
 			/**
@@ -227,8 +236,6 @@ class Tribe__Events__Aggregator__Record__CSV extends Tribe__Events__Aggregator__
 				$message
 			);
 		}
-
-		update_option( 'tribe_events_import_column_mapping_' . $content_type, $data['column_map'] );
 
 		return $importer;
 	}

--- a/tests/wpunit/Tribe/Events/Aggregator/Record/CSV_Prep_Import_Data_Test.php
+++ b/tests/wpunit/Tribe/Events/Aggregator/Record/CSV_Prep_Import_Data_Test.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tribe\Events\Aggregator\Record;
+
+use Tribe\Events\Test\Testcases\Events_TestCase;
+use Tribe__Events__Aggregator__Record__CSV as CSV_Record;
+
+/**
+ * Regression tests for `Tribe__Events__Aggregator__Record__CSV::prep_import_data()`.
+ *
+ * `prep_import_data()` persists the submitted column mapping to
+ * `tribe_events_import_column_mapping_{content_type}` before validating that all
+ * required fields are mapped. A rejected submission (missing a required field) used
+ * to leave that bad mapping saved as the site-wide default, so the very next preview
+ * would pre-select "Do Not Import" for the required column and fail again - forever,
+ * for every content type (events, venues, organizers, rsvp_tickets), until someone
+ * manually corrected the option.
+ *
+ * These tests cover the V1 "events" content type specifically, to confirm the fix
+ * (roll back to the previous mapping on validation failure) does not change
+ * behaviour for existing event/venue/organizer imports - only RSVP was reported
+ * broken, but the fix lives in the shared method all content types go through.
+ *
+ * @group aggregator
+ * @group csv
+ */
+class CSV_Prep_Import_Data_Test extends Events_TestCase {
+
+	private $option_key = 'tribe_events_import_column_mapping_events';
+
+	/** @var string|null Path of a copy of the fixture placed inside uploads/; cleaned up in tearDown. */
+	private $uploads_copy;
+
+	public function tearDown() {
+		delete_option( $this->option_key );
+		if ( $this->uploads_copy && file_exists( $this->uploads_copy ) ) {
+			@unlink( $this->uploads_copy );
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds a finalized CSV record pointed at a copy of the bundled events.csv fixture
+	 * placed inside the uploads directory - get_file_path() only accepts files there -
+	 * without persisting the record itself, since prep_import_data() only reads the
+	 * in-memory $meta.
+	 */
+	private function make_record(): CSV_Record {
+		$upload_info        = wp_upload_dir();
+		$this->uploads_copy = trailingslashit( $upload_info['basedir'] ) . 'tec-prep-import-data-test-events.csv';
+		copy( codecept_data_dir( 'csv-import-test-files/events.csv' ), $this->uploads_copy );
+
+		$record                        = new CSV_Record();
+		$record->meta['finalized']     = true;
+		$record->meta['content_type']  = 'tribe_events';
+		$record->meta['file']          = $this->uploads_copy;
+
+		return $record;
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_accept_a_valid_events_column_map() {
+		$record = $this->make_record();
+
+		$data = [
+			'origin'     => 'csv',
+			'column_map' => [ 'event_name', 'event_description', 'event_start_date', 'event_start_time', 'event_end_date', 'event_end_time' ],
+		];
+
+		$importer = $record->prep_import_data( $data );
+
+		$this->assertInstanceOf( \Tribe__Events__Importer__File_Importer_Events::class, $importer );
+		$this->assertEquals( $data['column_map'], get_option( $this->option_key ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_reject_an_events_column_map_missing_a_required_field() {
+		$record = $this->make_record();
+
+		// event_start_date is required but not mapped.
+		$data = [
+			'origin'     => 'csv',
+			'column_map' => [ 'event_name', 'event_description' ],
+		];
+
+		$result = $record->prep_import_data( $data );
+
+		$this->assertTrue( tribe_is_error( $result ), 'A column map missing a required field must return an error.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_corrupt_the_saved_mapping_when_validation_fails() {
+		$good_map = [ 'event_name', 'event_description', 'event_start_date', 'event_start_time', 'event_end_date', 'event_end_time' ];
+		update_option( $this->option_key, $good_map );
+
+		$record = $this->make_record();
+
+		// event_start_date is dropped here - this submission must be rejected.
+		$bad_map = [ 'event_name', 'event_description' ];
+		$result  = $record->prep_import_data( [ 'origin' => 'csv', 'column_map' => $bad_map ] );
+
+		$this->assertTrue( tribe_is_error( $result ) );
+		$this->assertEquals(
+			$good_map,
+			get_option( $this->option_key ),
+			'A rejected column map must not overwrite the last known-good saved mapping.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3323](https://linear.app/nexcess/issue/SOFT-3323/rsvp-import)


### 🗒️ Description

**Fix** (bug fix - CSV import data loss)
Fixed a bug in `Tribe__Events__Aggregator__Record__CSV::prep_import_data()` where a rejected column mapping (missing a required field) was permanently saved as the site-wide default. This caused every subsequent import preview, for any content type (events, venues, organizers, RSVP tickets), to pre-select "Do Not Import" for the required column and fail again until manually corrected. The previous valid mapping is now restored whenever validation fails.

Complement to: https://github.com/the-events-calendar/event-tickets/pull/4440

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/1eb893f46e2e44ddb4753c04ce8e51bd

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
