### PR TITLE
fix(Collections) keep the rebuild callback across serialization round trips

### DIFF
--- a/changelog/smtnc-2354-investigate-orm-fatal-error-with-object-caching.yaml
+++ b/changelog/smtnc-2354-investigate-orm-fatal-error-with-object-caching.yaml
@@ -1,0 +1,8 @@
+significance: patch
+type: fix
+entry: Fixed a fatal error when reading an event's venues or organizers on sites
+  running a persistent object cache, caused by a cached lazy collection losing the
+  callback it needs to rebuild itself. Also added the
+  `tec_events_lazy_post_collection_allowed_unserialize_callbacks` filter so
+  third-party code can register its own rebuild callbacks.
+timestamp: 2026-09-02T00:00:00.000Z

--- a/src/Tribe/Collections/Lazy_Post_Collection.php
+++ b/src/Tribe/Collections/Lazy_Post_Collection.php
@@ -23,11 +23,13 @@ class Lazy_Post_Collection extends Lazy_Collection {
 	/**
 	 * Callbacks allowed to rebuild the collection during unserialization.
 	 *
+	 * Use the `tec_events_lazy_post_collection_allowed_unserialize_callbacks` filter to add to this list.
+	 *
 	 * @since 6.17.3.1
 	 *
 	 * @var string[]
 	 */
-	protected const ALLOWED_UNSERIALIZE_CALLBACKS = [
+	private const ALLOWED_UNSERIALIZE_CALLBACKS = [
 		'get_post',
 		'tribe_get_organizer_object',
 		'tribe_get_venue_object',
@@ -87,6 +89,7 @@ class Lazy_Post_Collection extends Lazy_Collection {
 	 *
 	 * @since 5.0.0
 	 * @since 6.17.3.1 Only rebuild through an allowed callback.
+	 * @since TBD Restore the unserialize callback, so the collection can be serialized again.
 	 *
 	 * @param string $serialized The serialized values, usually an array of post IDs.
 	 *
@@ -101,9 +104,30 @@ class Lazy_Post_Collection extends Lazy_Collection {
 			return null;
 		}
 
-		if ( ! in_array( $unserialized['callback'], self::ALLOWED_UNSERIALIZE_CALLBACKS, true ) ) {
+		/**
+		 * Filters the callbacks allowed to rebuild a Lazy_Post_Collection during unserialization.
+		 *
+		 * The callback name is read back from serialized data and is not to be trusted: only add callbacks
+		 * that are safe to call with an arbitrary post ID.
+		 *
+		 * @since TBD
+		 *
+		 * @param string[] $allowed_callbacks The names of the callbacks allowed to rebuild the collection.
+		 */
+		$allowed_callbacks = (array) apply_filters(
+			'tec_events_lazy_post_collection_allowed_unserialize_callbacks',
+			self::ALLOWED_UNSERIALIZE_CALLBACKS
+		);
+
+		if ( ! in_array( $unserialized['callback'], $allowed_callbacks, true ) ) {
 			return null;
 		}
+
+		/*
+		 * Restore the callback: without it a collection that is serialized again, e.g. when it's read from
+		 * the object cache and written back to it, would store a `null` callback and fail to rebuild.
+		 */
+		$this->unserialize_callback = $unserialized['callback'];
 
 		return array_map( $unserialized['callback'], $unserialized['ids'] );
 	}

--- a/tests/wpunit/Tribe/Events/Collections/Lazy_Post_CollectionTest.php
+++ b/tests/wpunit/Tribe/Events/Collections/Lazy_Post_CollectionTest.php
@@ -32,6 +32,52 @@ class Lazy_Post_CollectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * A collection read back from the object cache can be written to it again: the second round trip has to
+	 * carry the same callback as the first one, or the collection comes back with nothing to rebuild from.
+	 *
+	 * @test
+	 */
+	public function it_should_survive_a_second_round_trip() {
+		$post     = static::factory()->post->create_and_get();
+		$restored = unserialize( serialize( $this->make_collection( 'get_post', [ $post ] ) ) );
+
+		$serialized = serialize( $restored );
+		$this->assertStringContainsString( 's:8:"get_post"', $serialized );
+
+		$restored_again = unserialize( $serialized );
+		$items          = $restored_again->all;
+
+		$this->assertCount( 1, $items );
+		$this->assertInstanceOf( \WP_Post::class, $items[0] );
+		$this->assertSame( $post->ID, $items[0]->ID );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_allow_filtering_the_allowed_callbacks() {
+		$serialized = serialize( $this->make_collection( 'get_post', [ static::factory()->post->create_and_get() ] ) );
+		// Swap the allowed callback for one that is not on the list.
+		$tampered = str_replace( 's:8:"get_post"', 's:14:"__return_false"', $serialized );
+
+		$items = new \ReflectionProperty( Lazy_Post_Collection::class, 'items' );
+		$items->setAccessible( true );
+
+		$this->assertNull( $items->getValue( unserialize( $tampered ) ) );
+
+		add_filter(
+			'tec_events_lazy_post_collection_allowed_unserialize_callbacks',
+			static function ( array $callbacks ): array {
+				$callbacks[] = '__return_false';
+
+				return $callbacks;
+			}
+		);
+
+		$this->assertSame( [ false ], $items->getValue( unserialize( $tampered ) ) );
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_reject_a_disallowed_callback() {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2354](https://linear.app/nexcess/issue/SMTNC-2354/investigate-orm-fatal-error-with-object-caching)

### 🗒️ Description

Bug fix. Pairs with the-events-calendar/tribe-common#2990 — both are needed, common first.

Reported at https://wordpress.org/support/topic/fatal-error-using-orm-with-object-caching: on a site with a persistent object cache, `tribe_events()->by( 'id', $id )->first()->venues` throws

```
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, no array or string given
  .../common/src/Tribe/Utils/Lazy_Collection.php(86)
```

**What goes wrong**

`custom_unserialize()` rebuilt the collection items from the stored post IDs but never restored `$unserialize_callback`. A restored collection therefore had `unserialize_callback === null`, which made serialization non-idempotent: the second round trip stored `{s:8:"callback";N;...}`.

Before 6.17.3.1 that `null` reached `array_map( null, $ids )`, which returns the IDs unchanged. Wrong data, but no fatal. #SVUL-80 added `ALLOWED_UNSERIALIZE_CALLBACKS`, and `in_array( null, [...], true )` is `false`, so `custom_unserialize()` now returns `null`, leaving the collection with `items === null` and `callback === null`. Any read from there is fatal.

The second round trip comes from `Base::get_object_cache_callback()` in common, which re-serialized properties it had just read back from a warm cache. That side is fixed in tribe-common#2990.

**Changes**

- `custom_unserialize()` restores `$this->unserialize_callback`, so round trips are idempotent. Same pattern as `Post_Thumbnail::__unserialize()`, which restores its `post_id`.
- `ALLOWED_UNSERIALIZE_CALLBACKS` is now `private` and goes through a new `tec_events_lazy_post_collection_allowed_unserialize_callbacks` filter, so third-party code can register its own rebuild callbacks without the constant being extendable. `in_array` stays strict, so a filter returning junk can only ever reject.

**Note for reviewers**

`Lazy_Post_Collection` is used only in this plugin (`Models/Post_Types/Event.php`, `Views/V2/Template/Event.php`). I checked ET, ETP, Pro, Filter Bar, Community and Eventbrite: none of them use it. `Lazy_String`, `Post_Thumbnail` and ET's `Tribe\Tickets\Events\Views\V2\Models\Tickets` all restore their identity fields on unserialize, so this was the only non-idempotent lazy object in first-party code.

### 🎥 Artifacts

n/a, back end only.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
