### PR TITLE
Restore changelogger "version" label in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
       "content"
     ],
     "types": {
-      "version": "6.17.3",
+      "version": "Version",
       "performance": "Performance",
       "accessibility": "Accessibility"
     },


### PR DESCRIPTION
### 🎫 Ticket

[NO_TASK]

### 🗒️ Description

Restores changelogger's `types.version` label in `package.json`, which the release version bump overwrote with the plugin version number.

```diff
       "types": {
-      "version": "6.17.3",
+      "version": "Version",
         "performance": "Performance",
```
> [!IMPORTANT]
> **Draft on purpose.** actions#36 must merge and its sync PR must land in this repo *first*. Merge this before that and the next release bump overwrites the label again.

### 🎥 Artifacts <!-- if applicable-->

N/A — one-line config change, no user-facing UI.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) — **intentionally skipped** (`[skip-changelog]`)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts? 
- [x] Check the base branch for your PR. 
- [ ] Add your PR to the project board for the release.

[skip-changelog]
