### PR TITLE
[SMTNC-2411] Document the planning requirement and how to run the tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,10 @@ store as `tec-plans`.
 
 ### Working on a ticket
 
-1. **Create the change before writing code**, named after the ticket:
-   `openspec new change SOFT-1234 --store tec-plans --description "what this does"`
+1. **Create the change before writing code**, named after the ticket in lower
+   case. OpenSpec requires kebab-case and rejects anything else, so the ticket
+   `SOFT-1234` becomes the change `soft-1234`:
+   `openspec new change soft-1234 --store tec-plans --description "what this does"`
 2. Write the proposal, then commit and push it in the plans repo.
 3. Branch as usual: `feat/SOFT-1234/short-desc`.
 4. Implement. If the work shows the plan was wrong — it often does — update the

--- a/readme.md
+++ b/readme.md
@@ -71,13 +71,15 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/the-events-calendar/skills) covers the
+[`openspec` skill](https://github.com/stellarwp/skills) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 
+The below will work only once the `stellarwp/skills` becomes public.
+
 ```
-/plugin marketplace add the-events-calendar/skills
-/plugin install tec
+/plugin marketplace add stellarwp/skills
+/plugin install nexcess
 ```
 
 ## Running the tests
@@ -91,9 +93,9 @@ PHP tests are Codeception + wp-browser suites run inside Docker by [slic](https:
 ```bash
 # 1. Clone the plugin with its common submodule, and slic beside it.
 cd /path/to/plugins           # parent dir; slic will scan it for targets
-git clone --recurse-submodules git@github.com:the-events-calendar/the-events-calendar.git
+git clone --recursive git@github.com:the-events-calendar/the-events-calendar.git
 git clone git@github.com:stellarwp/slic.git slic
-# already cloned without --recurse-submodules?
+# already cloned without --recursive?
 # (cd the-events-calendar && git submodule update --init --recursive)
 
 # 2. Point slic at this directory and quiet the prompts (CI's exact flags).

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,14 @@ store as `tec-plans`.
 5. Open the PR. The template asks for the change ID, and CI checks the plan exists
    and is still active.
 
-Every `openspec` command takes `--store tec-plans`. There is no default and no
-repo-side link, so omitting it writes the change into whatever repository you
+Commands that read or write plans take `--store tec-plans`: `new change`,
+`status`, `instructions`, `list`, `show`, `validate`, `archive`, `context` and
+`doctor`. The `openspec store` commands manage registrations instead and take
+`--id`, which is why the setup block above uses that.
+
+A machine that has run the skills repo's `install.sh` has OpenSpec's
+`defaultStore` set to `tec-plans` and resolves without the flag. Pass it anyway:
+a machine without that setting writes the change into whatever repository you
 happen to be standing in.
 
 ### Where the rest is written down
@@ -79,7 +85,7 @@ archiving it once (after the last repository merges, not per repo). Install it w
 
 The below will work only once the `stellarwp/skills-se` becomes public.
 
-```
+```text
 /plugin marketplace add stellarwp/skills-se
 /plugin install nexcess-se
 ```
@@ -184,4 +190,4 @@ All three workflows are gated on a PHP-file-change check, so a docs-only PR runs
 - CI pins WordPress with `wp core update --force --version=6.8` (6.9 for the SEO suite). Locally the container's bundled version is usually fine; add the same `wp core update` if you need to reproduce a version-specific failure.
 - CI appends `--ext DotReporter` for compact logs; skip it locally for readable output.
 - CI's ssh-agent, composer cache and `docker network prune -f` steps are runner housekeeping with no local equivalent.
-- After `rest_tec_v1_integration`, CI also runs `npm ci` and `npm run spectral -- http://localhost:8888/wp-json/tec/v1/docs/` to lint the OpenAPI doc. To reproduce: `${SLIC_BIN} wp plugin activate the-events-calendar && ${SLIC_BIN} wp rewrite structure '/%postname%/' --hard`, then run those npm commands on the host.
+- After `rest_tec_v1_integration`, CI also runs `npm ci` and `npm run spectral -- http://localhost:8888/wp-json/tec/v1/docs/` to lint the OpenAPI doc. To reproduce: `${SLIC_BIN} wp plugin activate the-events-calendar && ${SLIC_BIN} wp rewrite structure '/%postname%/' --hard`, then run those npm commands on the host from inside `the-events-calendar/`, which is where the `package.json` lives.

--- a/readme.md
+++ b/readme.md
@@ -71,17 +71,20 @@ Commands that read or write plans take `--store tec-plans`: `new change`,
 `doctor`. The `openspec store` commands manage registrations instead and take
 `--id`, which is why the setup block above uses that.
 
-A machine that has run the skills repo's `install.sh` has OpenSpec's
-`defaultStore` set to `tec-plans` and resolves without the flag. Pass it anyway:
-a machine without that setting writes the change into whatever repository you
-happen to be standing in.
+Nothing sets a default store for you — the skills repo's `install.sh` is
+org-wide and does not know you work on TEC. Without the flag the command writes
+the change into whatever repository you happen to be standing in. A developer who
+only works on TEC may run `openspec config set defaultStore tec-plans` once as a
+personal convenience; the flag stays in every example because the next machine
+will not have it.
 
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/stellarwp/skills-se) covers the
-workflow itself — writing a proposal worth reviewing, keeping it current, and
-archiving it once (after the last repository merges, not per repo). Install it with:
+[`openspec-workflow` skill](https://github.com/stellarwp/skills-se) covers the
+workflow itself — writing a proposal worth reviewing and keeping it current — and
+its TEC extension, `tec-openspec`, covers the shared store, the ticket-ID naming,
+and archiving once (after the last repository merges, not per repo). Install it with:
 
 The below will work only once the `stellarwp/skills-se` becomes public.
 

--- a/readme.md
+++ b/readme.md
@@ -71,15 +71,15 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`tec-openspec` skill](https://github.com/stellarwp/skills) covers the
+[`tec-openspec` skill](https://github.com/stellarwp/skills-se) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 
-The below will work only once the `stellarwp/skills` becomes public.
+The below will work only once the `stellarwp/skills-se` becomes public.
 
 ```
-/plugin marketplace add stellarwp/skills
-/plugin install nexcess
+/plugin marketplace add stellarwp/skills-se
+/plugin install nexcess-se
 ```
 
 ## Running the tests

--- a/readme.md
+++ b/readme.md
@@ -79,3 +79,105 @@ archiving it once (after the last repository merges, not per repo). Install it w
 /plugin marketplace add the-events-calendar/skills
 /plugin install tec
 ```
+
+## Running the tests
+
+PHP tests are Codeception + wp-browser suites run inside Docker by [slic](https://github.com/stellarwp/slic), exactly as CI does.
+
+### Setup
+
+`common` is a git submodule of this plugin, but slic treats `the-events-calendar/common` as its own target: it gets its own `composer install`. Run every `slic` command from the **parent directory** that contains `the-events-calendar/`.
+
+```bash
+# 1. Clone the plugin with its common submodule, and slic beside it.
+cd /path/to/plugins           # parent dir; slic will scan it for targets
+git clone --recurse-submodules git@github.com:the-events-calendar/the-events-calendar.git
+git clone git@github.com:stellarwp/slic.git slic
+# already cloned without --recurse-submodules?
+# (cd the-events-calendar && git submodule update --init --recursive)
+
+# 2. Point slic at this directory and quiet the prompts (CI's exact flags).
+export SLIC_BIN="$PWD/slic/slic"
+${SLIC_BIN} here
+${SLIC_BIN} interactive off
+${SLIC_BIN} build-prompt off
+${SLIC_BIN} build-subdir off
+${SLIC_BIN} xdebug off
+${SLIC_BIN} info
+
+# 3. Install dependencies for common FIRST, then the plugin.
+${SLIC_BIN} use the-events-calendar/common
+${SLIC_BIN} composer install --no-dev
+${SLIC_BIN} use the-events-calendar
+${SLIC_BIN} composer install
+
+# 4. Start the containers.
+${SLIC_BIN} up wordpress
+${SLIC_BIN} up chrome                 # only needed by views_ui (WPWebDriver)
+${SLIC_BIN} wp theme install twentytwenty --activate
+```
+
+Two suites need an extra plugin in the WordPress container:
+
+```bash
+${SLIC_BIN} wp plugin install elementor        # elementor_integration
+${SLIC_BIN} wp plugin install wordpress-seo    # integrations_plugin_wordpress_seo
+```
+
+### Running a suite
+
+```bash
+${SLIC_BIN} use the-events-calendar
+${SLIC_BIN} run integration
+
+# a single file, or a single method
+${SLIC_BIN} run wpunit tests/wpunit/Tribe/Events/Event_Test.php
+${SLIC_BIN} run wpunit tests/wpunit/Tribe/Events/Event_Test.php:it_creates_an_event
+
+# filter by name across the suite
+${SLIC_BIN} run views_integration --filter=month
+```
+
+Do not run all suites in one `codecept run`; WordPress globals leak between them.
+
+### Suites
+
+| Suite | Covers | CI |
+|---|---|---|
+| `aggregatorv1` | Event Aggregator v1 REST endpoints | every PR |
+| `blocks_editor_integration` | Block editor / Gutenberg blocks | every PR |
+| `ct1_integration` | Custom Tables v1 schema and queries | every PR |
+| `ct1_migration` | CT1 migration from the legacy meta storage | every PR |
+| `ct1_multisite_integration` | CT1 under multisite | every PR |
+| `ct1_wp_json_api` | WP REST API with CT1 enabled | every PR |
+| `deprecated` | Deprecated functions and classes still resolve | every PR |
+| `elementor_integration` | Elementor widgets (needs `elementor`) | every PR (separate workflow) |
+| `embed_calendar_integration` | Calendar embed shortcode/block | every PR |
+| `event_status` | Event status (cancelled/postponed) | every PR |
+| `features` | Feature-flag layer | no |
+| `integration` | General plugin integration | every PR |
+| `integration_category_colors` | Category colors feature | every PR |
+| `integrations_plugin_wordpress_seo` | Yoast SEO compat (needs `wordpress-seo`, WP 6.9) | every PR (separate workflow) |
+| `muintegration` | Multisite integration | every PR |
+| `rest_tec_v1_integration` | `tec/v1` REST API | every PR (+ OpenAPI lint) |
+| `restv1` | Legacy `tribe/events/v1` REST API | every PR |
+| `rewrite_functional` | Permalinks and rewrite rules | every PR |
+| `views_integration` | Views v2 rendering | every PR |
+| `views_rest` | Views v2 REST responses | no — commented out of the matrix ("weird error with RBE changes") |
+| `views_settings` | Views v2 settings | every PR |
+| `views_ui` | Views v2 browser tests (needs Chrome container) | every PR |
+| `views_v2_customizer_integration` | Views v2 Customizer styles | every PR |
+| `views_widgets` | Views v2 widgets | every PR |
+| `views_wpunit` | Views v2 unit-level | every PR |
+| `wp_json_api` | Core WP REST API for TEC post types | every PR |
+| `wpml_integration` | WPML compat | no |
+| `wpunit` | Plugin unit tests | every PR |
+
+All three workflows are gated on a PHP-file-change check, so a docs-only PR runs none of them.
+
+### How this differs from CI
+
+- CI pins WordPress with `wp core update --force --version=6.8` (6.9 for the SEO suite). Locally the container's bundled version is usually fine; add the same `wp core update` if you need to reproduce a version-specific failure.
+- CI appends `--ext DotReporter` for compact logs; skip it locally for readable output.
+- CI's ssh-agent, composer cache and `docker network prune -f` steps are runner housekeeping with no local equivalent.
+- After `rest_tec_v1_integration`, CI also runs `npm ci` and `npm run spectral -- http://localhost:8888/wp-json/tec/v1/docs/` to lint the OpenAPI doc. To reproduce: `${SLIC_BIN} wp plugin activate the-events-calendar && ${SLIC_BIN} wp rewrite structure '/%postname%/' --hard`, then run those npm commands on the host.

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ store instead: [`the-events-calendar/plans`](https://github.com/the-events-calen
 npm install -g @fission-ai/openspec
 git clone git@github.com:the-events-calendar/plans.git ~/repos/tec-plans
 openspec store register ~/repos/tec-plans --id tec-plans
+openspec config set defaultStore tec-plans
 ```
 
 The clone path is yours to choose. The `--id` is not — every command refers to the
@@ -71,12 +72,14 @@ Commands that read or write plans take `--store tec-plans`: `new change`,
 `doctor`. The `openspec store` commands manage registrations instead and take
 `--id`, which is why the setup block above uses that.
 
-Nothing sets a default store for you — the skills repo's `install.sh` is
-org-wide and does not know you work on TEC. Without the flag the command writes
-the change into whatever repository you happen to be standing in. A developer who
-only works on TEC may run `openspec config set defaultStore tec-plans` once as a
-personal convenience; the flag stays in every example because the next machine
-will not have it.
+Setting the store as OpenSpec's global default is part of the setup, not an
+optional extra. The stock OpenSpec skills and the `/opsx:*` commands know
+nothing about our store and act on whatever root resolves from the current
+directory, and this repository has no `openspec/` root of its own — so without
+the default they fail, or land the change in a stray root. The org-wide skills
+repo's `install.sh` deliberately does not set it: it serves every StellarWP
+brand. Confirm with `openspec context`, which should print `Using OpenSpec root:
+tec-plans`. Pass the flag anyway; it is right whether or not the default is set.
 
 ### Where the rest is written down
 

--- a/readme.md
+++ b/readme.md
@@ -31,3 +31,51 @@ That's all! please have fun and code responsibly :)
 * **Website**: https://theeventscalendar.com/product/wordpress-events-calendar/
 * **Support**: https://theeventscalendar.com/support
 * **Documentation**: https://theeventscalendar.com/functions/
+
+## Specs and planning
+
+Work on this repository is planned before it is written, using
+[OpenSpec](https://github.com/Fission-AI/OpenSpec). **This is enforced** — every
+pull request is checked for a plan.
+
+Plans do not live here. A TEC feature routinely spans several repositories, so a
+spec kept in one of them is invisible from the others. They all live in one shared
+store instead: [`the-events-calendar/plans`](https://github.com/the-events-calendar/plans).
+
+### First time only
+
+```bash
+npm install -g @fission-ai/openspec
+git clone git@github.com:the-events-calendar/plans.git ~/repos/tec-plans
+openspec store register ~/repos/tec-plans --id tec-plans
+```
+
+The clone path is yours to choose. The `--id` is not — every command refers to the
+store as `tec-plans`.
+
+### Working on a ticket
+
+1. **Create the change before writing code**, named after the ticket:
+   `openspec new change SOFT-1234 --store tec-plans --description "what this does"`
+2. Write the proposal, then commit and push it in the plans repo.
+3. Branch as usual: `feat/SOFT-1234/short-desc`.
+4. Implement. If the work shows the plan was wrong — it often does — update the
+   change rather than letting the plan and the code drift apart.
+5. Open the PR. The template asks for the change ID, and CI checks the plan exists
+   and is still active.
+
+Every `openspec` command takes `--store tec-plans`. There is no default and no
+repo-side link, so omitting it writes the change into whatever repository you
+happen to be standing in.
+
+### Where the rest is written down
+
+This section covers what is specific to working here. The
+[`tec-openspec` skill](https://github.com/the-events-calendar/skills) covers the
+workflow itself — writing a proposal worth reviewing, keeping it current, and
+archiving it once (after the last repository merges, not per repo). Install it with:
+
+```
+/plugin marketplace add the-events-calendar/skills
+/plugin install tec
+```

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ happen to be standing in.
 ### Where the rest is written down
 
 This section covers what is specific to working here. The
-[`openspec` skill](https://github.com/stellarwp/skills) covers the
+[`tec-openspec` skill](https://github.com/stellarwp/skills) covers the
 workflow itself — writing a proposal worth reviewing, keeping it current, and
 archiving it once (after the last repository merges, not per repo). Install it with:
 


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2411](https://linear.app/nexcess/issue/SMTNC-2411)

Part of [SMTNC-2410](https://linear.app/nexcess/issue/SMTNC-2410), Enforce OpenSpec for TEC products.

### 📋 Plan

_None._ This is part of the change that introduces the plan requirement, so it predates the store having entries.

### 🗒️ Description

Documents that work on this repository is planned before it is written, and that plans live in the shared [`the-events-calendar/plans`](https://github.com/the-events-calendar/plans) store rather than here.

A TEC feature routinely spans several repositories — a change lands in `event-tickets`, its extension in `event-tickets-plus`, the shared piece in `tribe-common`. A spec kept in any one of them is invisible from the other two, which is why there is one store instead of one per repo.

The section covers what is specific to working here: first-time store setup, the per-ticket flow, and the fact that every `openspec` command needs `--store tec-plans` because there is no default and no repo-side link. It deliberately does **not** repeat the workflow itself — writing a good proposal, keeping it current, archiving it once after the last repo merges — because that lives in the `tec-openspec` skill and duplicating it guarantees drift.

**The section is byte-identical across all 16 active TEC repositories.** Please keep it that way; edits belong in all of them or none.

### 🎥 Artifacts

_Not applicable — documentation only._

### ✔️ Verification

Documentation only. No code paths, build config or workflows touched in this PR.
The repository's existing readme was **appended to**; nothing else in it was changed.

The CI check that enforces this arrives separately, via the sync group added in [the-events-calendar/actions#37](https://github.com/the-events-calendar/actions/pull/37). This PR is only the documentation.

### ✔️ Checklist
- [ ] There is an OpenSpec plan for this work in `tec-plans` — no, see above.
- [ ] Ran `npm run changelog` — not applicable, documentation only.
- [x] Base branch checked against the repository's actual default branch.
- [ ] Code is covered by tests — not applicable, no code changed.

### 🤖 AI usage

Claude Opus 5 wrote this documentation section and opened this PR, in a working session with me. The section is identical across all active TEC repositories by design. No human has reviewed the wording yet — that is what this review is for.

---

### 🧪 Second commit: how to run the tests

Adds a `## Running the tests` section giving the same steps CI follows — taken from this repository's own test workflows, not written from memory. Setup, dependency installation, the run command, a suites table marking which suites CI runs on every PR, and a short note on what CI does that you do not need locally.

One set of instructions for both humans and agents, as requested — copy-pasteable, no "see the wiki".

**Verification:** every command was transcribed from the workflow files, not invented. I did not execute the suites — the commands are read from CI, so treat them as accurate to what CI does rather than as a passing local run.
